### PR TITLE
Simulated public transport vehicles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ included in the (note yet determined) next version number.
 
 **Development version**
 
-- No changes yet
+- Enable support for network-based public transport simulation by setting `eqasim.useScheduleBasedTransport` to `false` (it is activated by default)
 
 **1.1.0**
 

--- a/core/src/main/java/org/eqasim/core/analysis/DefaultPersonAnalysisFilter.java
+++ b/core/src/main/java/org/eqasim/core/analysis/DefaultPersonAnalysisFilter.java
@@ -6,6 +6,6 @@ import org.matsim.api.core.v01.population.Person;
 public class DefaultPersonAnalysisFilter implements PersonAnalysisFilter {
 	@Override
 	public boolean analyzePerson(Id<Person> personId) {
-		return true;
+		return !personId.toString().startsWith("pt_");
 	}
 }

--- a/core/src/main/java/org/eqasim/core/analysis/pt/PublicTransportTripListener.java
+++ b/core/src/main/java/org/eqasim/core/analysis/pt/PublicTransportTripListener.java
@@ -14,9 +14,11 @@ import org.matsim.api.core.v01.events.handler.ActivityStartEventHandler;
 import org.matsim.api.core.v01.events.handler.GenericEventHandler;
 import org.matsim.api.core.v01.events.handler.PersonDepartureEventHandler;
 import org.matsim.api.core.v01.population.Person;
+import org.matsim.core.api.experimental.events.AgentWaitingForPtEvent;
+import org.matsim.core.api.experimental.events.handler.AgentWaitingForPtEventHandler;
 
-public class PublicTransportTripListener
-		implements PersonDepartureEventHandler, ActivityStartEventHandler, GenericEventHandler {
+public class PublicTransportTripListener implements PersonDepartureEventHandler, ActivityStartEventHandler,
+		GenericEventHandler, AgentWaitingForPtEventHandler {
 	final private Collection<PublicTransportTripItem> trips = new LinkedList<>();
 	final private Map<Id<Person>, Integer> tripIndices = new HashMap<>();
 
@@ -60,5 +62,11 @@ public class PublicTransportTripListener
 		} else {
 			tripIndices.compute(event.getPersonId(), (k, v) -> v + 1);
 		}
+	}
+
+	@Override
+	public void handleEvent(AgentWaitingForPtEvent event) {
+		throw new RuntimeException(
+				"So far, this analysis tool only works with schedule-based simulation. Your simulation input simulated public transport in the QSim.");
 	}
 }

--- a/core/src/main/java/org/eqasim/core/components/config/EqasimConfigGroup.java
+++ b/core/src/main/java/org/eqasim/core/components/config/EqasimConfigGroup.java
@@ -23,6 +23,8 @@ public class EqasimConfigGroup extends ReflectiveConfigGroup {
 	private final static String TRIP_ANALYSIS_INTERVAL = "tripAnalysisInterval";
 	private final static String TRIP_ANALYSIS_DISTANCE_UNIT = "tripAnalysisDistanceUnit";
 
+	private final static String USE_SCHEDULE_BASED_TRANSPORT = "useScheduleBasedTransport";
+
 	private double sampleSize = 1.0;
 	private DistanceUnit distanceUnit = DistanceUnit.meter;
 
@@ -33,6 +35,8 @@ public class EqasimConfigGroup extends ReflectiveConfigGroup {
 
 	private int tripAnalysisInterval = 0;
 	private DistanceUnit tripAnalysisDistanceUnit = DistanceUnit.meter;
+
+	private boolean useScheduleBasedTransport = true;
 
 	public EqasimConfigGroup() {
 		super(GROUP_NAME);
@@ -222,5 +226,15 @@ public class EqasimConfigGroup extends ReflectiveConfigGroup {
 	@StringSetter(TRIP_ANALYSIS_DISTANCE_UNIT)
 	public void setTripAnalysisDistanceUnit(DistanceUnit tripAnalysisDistanceUnit) {
 		this.tripAnalysisDistanceUnit = tripAnalysisDistanceUnit;
+	}
+
+	@StringGetter(USE_SCHEDULE_BASED_TRANSPORT)
+	public boolean getUseScheduleBasedTransport() {
+		return useScheduleBasedTransport;
+	}
+
+	@StringSetter(USE_SCHEDULE_BASED_TRANSPORT)
+	public void setUseScheduleBasedTransport(boolean useScheduleBasedTransport) {
+		this.useScheduleBasedTransport = useScheduleBasedTransport;
 	}
 }

--- a/core/src/main/java/org/eqasim/core/components/transit/EqasimTransitEngine.java
+++ b/core/src/main/java/org/eqasim/core/components/transit/EqasimTransitEngine.java
@@ -89,8 +89,8 @@ public class EqasimTransitEngine implements DepartureHandler, MobsimEngine {
 			Leg leg = (Leg) ((PlanAgent) agent).getCurrentPlanElement();
 			EnrichedTransitRoute route = (EnrichedTransitRoute) leg.getRoute();
 
-			TransitLine transitLine = transitSchedule.getTransitLines().get(route.getTransitLineId());
-			TransitRoute transitRoute = transitLine.getRoutes().get(route.getTransitRouteId());
+			TransitLine transitLine = transitSchedule.getTransitLines().get(route.getLineId());
+			TransitRoute transitRoute = transitLine.getRoutes().get(route.getRouteId());
 
 			TransitRouteStop accessStop = transitRoute.getStops().get(route.getAccessStopIndex());
 			TransitRouteStop egressStop = transitRoute.getStops().get(route.getEgressStopIndex());

--- a/core/src/main/java/org/eqasim/core/components/transit/EqasimTransitQSimModule.java
+++ b/core/src/main/java/org/eqasim/core/components/transit/EqasimTransitQSimModule.java
@@ -1,7 +1,9 @@
 package org.eqasim.core.components.transit;
 
+import org.eqasim.core.components.config.EqasimConfigGroup;
 import org.eqasim.core.components.transit.departure.DepartureFinder;
 import org.matsim.core.api.experimental.events.EventsManager;
+import org.matsim.core.config.Config;
 import org.matsim.core.mobsim.qsim.AbstractQSimModule;
 import org.matsim.core.mobsim.qsim.QSim;
 import org.matsim.core.mobsim.qsim.components.QSimComponentsConfig;
@@ -16,7 +18,9 @@ public class EqasimTransitQSimModule extends AbstractQSimModule {
 
 	@Override
 	protected void configureQSim() {
-		addQSimComponentBinding(COMPONENT_NAME).to(EqasimTransitEngine.class);
+		if (EqasimConfigGroup.get(getConfig()).getUseScheduleBasedTransport()) {
+			addQSimComponentBinding(COMPONENT_NAME).to(EqasimTransitEngine.class);
+		}
 	}
 
 	@Provides
@@ -26,8 +30,10 @@ public class EqasimTransitQSimModule extends AbstractQSimModule {
 		return new EqasimTransitEngine(eventsManager, transitSchedule, departureFinder, qsim.getAgentCounter());
 	}
 
-	static public void configure(QSimComponentsConfig components) {
-		components.removeNamedComponent(TransitEngineModule.TRANSIT_ENGINE_NAME);
-		components.addNamedComponent(COMPONENT_NAME);
+	static public void configure(QSimComponentsConfig components, Config config) {
+		if (EqasimConfigGroup.get(config).getUseScheduleBasedTransport()) {
+			components.removeNamedComponent(TransitEngineModule.TRANSIT_ENGINE_NAME);
+			components.addNamedComponent(COMPONENT_NAME);
+		}
 	}
 }

--- a/core/src/main/java/org/eqasim/core/components/transit/routing/DefaultEnrichedTransitRoute.java
+++ b/core/src/main/java/org/eqasim/core/components/transit/routing/DefaultEnrichedTransitRoute.java
@@ -5,9 +5,12 @@ import java.io.IOException;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.core.population.routes.AbstractRoute;
+import org.matsim.core.utils.misc.OptionalTime;
+import org.matsim.pt.routes.DefaultTransitPassengerRoute.RouteDescription;
 import org.matsim.pt.transitSchedule.api.Departure;
 import org.matsim.pt.transitSchedule.api.TransitLine;
 import org.matsim.pt.transitSchedule.api.TransitRoute;
+import org.matsim.pt.transitSchedule.api.TransitStopFacility;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -16,7 +19,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 public class DefaultEnrichedTransitRoute extends AbstractRoute implements EnrichedTransitRoute {
 	final public static String ROUTE_TYPE = "enriched_pt";
 
-	private RouteDescription routeDescription = null;
+	private EnrichedRouteDescription routeDescription = null;
 
 	public DefaultEnrichedTransitRoute(final Id<Link> startLinkId, final Id<Link> endLinkId) {
 		super(startLinkId, endLinkId);
@@ -24,13 +27,15 @@ public class DefaultEnrichedTransitRoute extends AbstractRoute implements Enrich
 
 	public DefaultEnrichedTransitRoute(final Id<Link> startLinkId, final Id<Link> endLinkId, double distance,
 			double inVehicleTime, double transferTime, int accessStopIndex, int egressStopIndex,
-			Id<TransitLine> transitLineId, Id<TransitRoute> transitRouteId, Id<Departure> departureId) {
+			Id<TransitLine> transitLineId, Id<TransitRoute> transitRouteId, Id<Departure> departureId,
+			Id<TransitStopFacility> accessFacilityId, Id<TransitStopFacility> egressFacilityId,
+			OptionalTime boardingTime) {
 		super(startLinkId, endLinkId);
 
 		setDistance(distance);
 		setTravelTime(inVehicleTime + transferTime);
 
-		this.routeDescription = new RouteDescription();
+		this.routeDescription = new EnrichedRouteDescription();
 		routeDescription.inVehicleTime = inVehicleTime;
 		routeDescription.transferTime = transferTime;
 		routeDescription.accessStopIndex = accessStopIndex;
@@ -38,6 +43,9 @@ public class DefaultEnrichedTransitRoute extends AbstractRoute implements Enrich
 		routeDescription.transitLineId = transitLineId;
 		routeDescription.transitRouteId = transitRouteId;
 		routeDescription.departureId = departureId;
+		routeDescription.accessFacilityId = accessFacilityId;
+		routeDescription.egressFacilityId = egressFacilityId;
+		routeDescription.boardingTime = boardingTime;
 	}
 
 	@Override
@@ -57,7 +65,7 @@ public class DefaultEnrichedTransitRoute extends AbstractRoute implements Enrich
 	@Override
 	public void setRouteDescription(String routeDescription) {
 		try {
-			this.routeDescription = new ObjectMapper().readValue(routeDescription, RouteDescription.class);
+			this.routeDescription = new ObjectMapper().readValue(routeDescription, EnrichedRouteDescription.class);
 		} catch (IOException e) {
 			throw new RuntimeException(e);
 		}
@@ -74,12 +82,12 @@ public class DefaultEnrichedTransitRoute extends AbstractRoute implements Enrich
 	}
 
 	@Override
-	public Id<TransitLine> getTransitLineId() {
+	public Id<TransitLine> getLineId() {
 		return routeDescription.transitLineId;
 	}
 
 	@Override
-	public Id<TransitRoute> getTransitRouteId() {
+	public Id<TransitRoute> getRouteId() {
 		return routeDescription.transitRouteId;
 	}
 
@@ -101,49 +109,42 @@ public class DefaultEnrichedTransitRoute extends AbstractRoute implements Enrich
 	@Override
 	public DefaultEnrichedTransitRoute clone() {
 		return new DefaultEnrichedTransitRoute(getStartLinkId(), getEndLinkId(), getDistance(), getInVehicleTime(),
-				getWaitingTime(), getAccessStopIndex(), getEgressStopIndex(), getTransitLineId(), getTransitRouteId(),
-				getDepartureId());
+				getWaitingTime(), getAccessStopIndex(), getEgressStopIndex(), getLineId(), getRouteId(),
+				getDepartureId(), getAccessStopId(), getEgressStopId(), getBoardingTime());
 	}
 
-	public static class RouteDescription {
+	public static class EnrichedRouteDescription extends RouteDescription {
 		public double inVehicleTime;
 		public double transferTime;
 
 		public int accessStopIndex;
 		public int egressStopindex;
 
-		public Id<TransitLine> transitLineId;
-		public Id<TransitRoute> transitRouteId;
 		public Id<Departure> departureId;
-
-		@JsonProperty("transitLineId")
-		public String getTransitLineId() {
-			return transitLineId.toString();
-		}
-
-		@JsonProperty("transitRouteId")
-		public String getRouteLineId() {
-			return transitRouteId.toString();
-		}
 
 		@JsonProperty("departureId")
 		public String getDepartureId() {
 			return departureId.toString();
 		}
 
-		@JsonProperty("transitLineId")
-		public void setTransitLineId(String transitLineId) {
-			this.transitLineId = Id.create(transitLineId, TransitLine.class);
-		}
-
-		@JsonProperty("transitRouteId")
-		public void setRouteLineId(String transitRouteId) {
-			this.transitRouteId = Id.create(transitRouteId, TransitRoute.class);
-		}
-
 		@JsonProperty("departureId")
 		public void setDepartureId(String departureId) {
 			this.departureId = Id.create(departureId, Departure.class);
 		}
+	}
+
+	@Override
+	public Id<TransitStopFacility> getAccessStopId() {
+		return routeDescription.accessFacilityId;
+	}
+
+	@Override
+	public Id<TransitStopFacility> getEgressStopId() {
+		return routeDescription.egressFacilityId;
+	}
+
+	@Override
+	public OptionalTime getBoardingTime() {
+		return routeDescription.boardingTime;
 	}
 }

--- a/core/src/main/java/org/eqasim/core/components/transit/routing/DefaultEnrichedTransitRouter.java
+++ b/core/src/main/java/org/eqasim/core/components/transit/routing/DefaultEnrichedTransitRouter.java
@@ -85,7 +85,9 @@ public class DefaultEnrichedTransitRouter implements EnrichedTransitRouter {
 					EnrichedTransitRoute enrichedRoute = new DefaultEnrichedTransitRoute(originalRoute.getStartLinkId(),
 							originalRoute.getEndLinkId(), distance, connection.getInVehicleTime(),
 							connection.getWaitingTime() + additionalTransferTime, accessStopIndex, egressStopIndex,
-							originalRoute.getLineId(), originalRoute.getRouteId(), connection.getDeparture().getId());
+							originalRoute.getLineId(), originalRoute.getRouteId(), connection.getDeparture().getId(),
+							originalRoute.getAccessStopId(), originalRoute.getEgressStopId(),
+							originalRoute.getBoardingTime());
 
 					currentLeg.setRoute(enrichedRoute);
 					currentLeg.setDepartureTime(currentTime);
@@ -114,17 +116,17 @@ public class DefaultEnrichedTransitRouter implements EnrichedTransitRouter {
 				if (i > 0) {
 					EnrichedTransitRoute preceedingRoute = (EnrichedTransitRoute) legs.get(i - 1).getRoute();
 
-					originCoord = transitSchedule.getTransitLines().get(preceedingRoute.getTransitLineId()).getRoutes()
-							.get(preceedingRoute.getTransitRouteId()).getStops()
-							.get(preceedingRoute.getEgressStopIndex()).getStopFacility().getCoord();
+					originCoord = transitSchedule.getTransitLines().get(preceedingRoute.getLineId()).getRoutes()
+							.get(preceedingRoute.getRouteId()).getStops().get(preceedingRoute.getEgressStopIndex())
+							.getStopFacility().getCoord();
 				}
 
 				if (i < legs.size() - 2) {
 					EnrichedTransitRoute followingRoute = (EnrichedTransitRoute) legs.get(i + 1).getRoute();
 
-					destinationCoord = transitSchedule.getTransitLines().get(followingRoute.getTransitLineId())
-							.getRoutes().get(followingRoute.getTransitRouteId()).getStops()
-							.get(followingRoute.getAccessStopIndex()).getStopFacility().getCoord();
+					destinationCoord = transitSchedule.getTransitLines().get(followingRoute.getLineId()).getRoutes()
+							.get(followingRoute.getRouteId()).getStops().get(followingRoute.getAccessStopIndex())
+							.getStopFacility().getCoord();
 				}
 
 				double beelineDistance = CoordUtils.calcEuclideanDistance(originCoord, destinationCoord);

--- a/core/src/main/java/org/eqasim/core/components/transit/routing/EnrichedTransitRoute.java
+++ b/core/src/main/java/org/eqasim/core/components/transit/routing/EnrichedTransitRoute.java
@@ -1,19 +1,13 @@
 package org.eqasim.core.components.transit.routing;
 
 import org.matsim.api.core.v01.Id;
-import org.matsim.api.core.v01.population.Route;
+import org.matsim.pt.routes.TransitPassengerRoute;
 import org.matsim.pt.transitSchedule.api.Departure;
-import org.matsim.pt.transitSchedule.api.TransitLine;
-import org.matsim.pt.transitSchedule.api.TransitRoute;
 
-public interface EnrichedTransitRoute extends Route {
+public interface EnrichedTransitRoute extends TransitPassengerRoute {
 	double getInVehicleTime();
 
 	double getWaitingTime();
-
-	Id<TransitLine> getTransitLineId();
-
-	Id<TransitRoute> getTransitRouteId();
 
 	Id<Departure> getDepartureId();
 

--- a/core/src/main/java/org/eqasim/core/components/transit/routing/EnrichedTransitRoutingModule.java
+++ b/core/src/main/java/org/eqasim/core/components/transit/routing/EnrichedTransitRoutingModule.java
@@ -52,13 +52,13 @@ public class EnrichedTransitRoutingModule implements RoutingModule {
 			if (legs.get(i).getMode().equals(TransportMode.pt)) {
 				EnrichedTransitRoute route = (EnrichedTransitRoute) legs.get(i).getRoute();
 
-				currentFacility = transitSchedule.getTransitLines().get(route.getTransitLineId()).getRoutes()
-						.get(route.getTransitRouteId()).getStops().get(route.getEgressStopIndex()).getStopFacility();
+				currentFacility = transitSchedule.getTransitLines().get(route.getLineId()).getRoutes()
+						.get(route.getRouteId()).getStops().get(route.getEgressStopIndex()).getStopFacility();
 			} else {
 				EnrichedTransitRoute route = (EnrichedTransitRoute) legs.get(i + 1).getRoute();
 
-				currentFacility = transitSchedule.getTransitLines().get(route.getTransitLineId()).getRoutes()
-						.get(route.getTransitRouteId()).getStops().get(route.getAccessStopIndex()).getStopFacility();
+				currentFacility = transitSchedule.getTransitLines().get(route.getLineId()).getRoutes()
+						.get(route.getRouteId()).getStops().get(route.getAccessStopIndex()).getStopFacility();
 			}
 
 			Activity activity = PopulationUtils.createActivityFromCoordAndLinkId(PtConstants.TRANSIT_ACTIVITY_TYPE,

--- a/core/src/main/java/org/eqasim/core/scenario/cutter/population/trips/crossing/transit/DefaultTransitRouteCrossingPointFinder.java
+++ b/core/src/main/java/org/eqasim/core/scenario/cutter/population/trips/crossing/transit/DefaultTransitRouteCrossingPointFinder.java
@@ -30,8 +30,8 @@ public class DefaultTransitRouteCrossingPointFinder implements TransitRouteCross
 	public List<TransitRouteCrossingPoint> findCrossingPoints(EnrichedTransitRoute route, double departureTime) {
 		List<TransitRouteCrossingPoint> crossingPoints = new LinkedList<>();
 
-		TransitLine transitLine = schedule.getTransitLines().get(route.getTransitLineId());
-		TransitRoute transitRoute = transitLine.getRoutes().get(route.getTransitRouteId());
+		TransitLine transitLine = schedule.getTransitLines().get(route.getLineId());
+		TransitRoute transitRoute = transitLine.getRoutes().get(route.getRouteId());
 
 		Departure departure = transitRoute.getDepartures().get(route.getDepartureId());
 		double routeDepartureTime = departure.getDepartureTime();

--- a/core/src/main/java/org/eqasim/core/simulation/EqasimConfigurator.java
+++ b/core/src/main/java/org/eqasim/core/simulation/EqasimConfigurator.java
@@ -60,7 +60,7 @@ public class EqasimConfigurator {
 		}
 
 		controller.configureQSimComponents(configurator -> {
-			EqasimTransitQSimModule.configure(configurator);
+			EqasimTransitQSimModule.configure(configurator, controller.getConfig());
 		});
 	}
 

--- a/core/src/test/java/org/eqasim/scenario/cutter/population/trips/crossing/TestDefaultTransitRouteCrossingPointFinder.java
+++ b/core/src/test/java/org/eqasim/scenario/cutter/population/trips/crossing/TestDefaultTransitRouteCrossingPointFinder.java
@@ -13,6 +13,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.matsim.api.core.v01.Coord;
 import org.matsim.api.core.v01.Id;
+import org.matsim.core.utils.misc.OptionalTime;
 import org.matsim.pt.transitSchedule.TransitScheduleFactoryImpl;
 import org.matsim.pt.transitSchedule.api.Departure;
 import org.matsim.pt.transitSchedule.api.TransitLine;
@@ -57,7 +58,7 @@ public class TestDefaultTransitRouteCrossingPointFinder {
 	}
 
 	final private static EnrichedTransitRoute routeMock = new DefaultEnrichedTransitRoute(null, null, 0.0, 0.0, 0.0, 3,
-			6, transitLine.getId(), transitRoute.getId(), departure.getId());
+			6, transitLine.getId(), transitRoute.getId(), departure.getId(), null, null, OptionalTime.undefined());
 
 	static ScenarioExtent createExtentMock(double... inside) {
 		List<Double> _inside = new LinkedList<>();

--- a/core/src/test/java/org/eqasim/simulation/transit/routing/TestDefaultEnrichedTransitRoute.java
+++ b/core/src/test/java/org/eqasim/simulation/transit/routing/TestDefaultEnrichedTransitRoute.java
@@ -15,7 +15,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 public class TestDefaultEnrichedTransitRoute {
 	@Test
 	public void testRouteInformatonSerialization() throws IOException {
-		DefaultEnrichedTransitRoute.RouteDescription description = new DefaultEnrichedTransitRoute.RouteDescription();
+		DefaultEnrichedTransitRoute.EnrichedRouteDescription description = new DefaultEnrichedTransitRoute.EnrichedRouteDescription();
 
 		description.transitLineId = Id.create("abc", TransitLine.class);
 		description.transitRouteId = Id.create("def", TransitRoute.class);
@@ -33,8 +33,8 @@ public class TestDefaultEnrichedTransitRoute {
 				"{\"inVehicleTime\":30.0,\"transferTime\":55.0,\"accessStopIndex\":20,\"egressStopindex\":40,\"transitRouteId\":\"def\",\"transitLineId\":\"abc\",\"departureId\":\"dep\"}",
 				serialized);
 
-		DefaultEnrichedTransitRoute.RouteDescription deserialized = new ObjectMapper().readValue(serialized,
-				DefaultEnrichedTransitRoute.RouteDescription.class);
+		DefaultEnrichedTransitRoute.EnrichedRouteDescription deserialized = new ObjectMapper().readValue(serialized,
+				DefaultEnrichedTransitRoute.EnrichedRouteDescription.class);
 
 		Assert.assertEquals(20, deserialized.accessStopIndex);
 		Assert.assertEquals(40, deserialized.egressStopindex);

--- a/core/src/test/java/org/eqasim/simulation/transit/routing/TestDefaultEnrichedTransitRoute.java
+++ b/core/src/test/java/org/eqasim/simulation/transit/routing/TestDefaultEnrichedTransitRoute.java
@@ -9,6 +9,7 @@ import org.matsim.api.core.v01.Id;
 import org.matsim.pt.transitSchedule.api.Departure;
 import org.matsim.pt.transitSchedule.api.TransitLine;
 import org.matsim.pt.transitSchedule.api.TransitRoute;
+import org.matsim.pt.transitSchedule.api.TransitStopFacility;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -27,10 +28,13 @@ public class TestDefaultEnrichedTransitRoute {
 		description.inVehicleTime = 30.0;
 		description.transferTime = 55.0;
 
+		description.accessFacilityId = Id.create("af", TransitStopFacility.class);
+		description.egressFacilityId = Id.create("ef", TransitStopFacility.class);
+
 		String serialized = new ObjectMapper().writeValueAsString(description);
 
 		Assert.assertEquals(
-				"{\"inVehicleTime\":30.0,\"transferTime\":55.0,\"accessStopIndex\":20,\"egressStopindex\":40,\"transitRouteId\":\"def\",\"transitLineId\":\"abc\",\"departureId\":\"dep\"}",
+				"{\"transitRouteId\":\"def\",\"inVehicleTime\":30.0,\"transferTime\":55.0,\"accessStopIndex\":20,\"egressStopindex\":40,\"boardingTime\":\"undefined\",\"transitLineId\":\"abc\",\"accessFacilityId\":\"af\",\"egressFacilityId\":\"ef\",\"departureId\":\"dep\"}",
 				serialized);
 
 		DefaultEnrichedTransitRoute.EnrichedRouteDescription deserialized = new ObjectMapper().readValue(serialized,

--- a/examples/src/main/java/org/eqasim/examples/zurich_av/RunSimulation.java
+++ b/examples/src/main/java/org/eqasim/examples/zurich_av/RunSimulation.java
@@ -78,7 +78,7 @@ public class RunSimulation {
 		// This is not totally obvious, but we need to adjust the QSim components if we
 		// have AVs
 		controller.configureQSimComponents(configurator -> {
-			EqasimTransitQSimModule.configure(configurator);
+			EqasimTransitQSimModule.configure(configurator, config);
 			AVQSimModule.configureComponents(configurator);
 		});
 

--- a/ile_de_france/src/main/java/org/eqasim/ile_de_france/mode_choice/costs/IDFPtCostModel.java
+++ b/ile_de_france/src/main/java/org/eqasim/ile_de_france/mode_choice/costs/IDFPtCostModel.java
@@ -42,8 +42,8 @@ public class IDFPtCostModel implements CostModel {
 				if (leg.getMode().equals(TransportMode.pt)) {
 					EnrichedTransitRoute route = (EnrichedTransitRoute) leg.getRoute();
 
-					String transportMode = transitSchedule.getTransitLines().get(route.getTransitLineId()).getRoutes()
-							.get(route.getTransitRouteId()).getTransportMode();
+					String transportMode = transitSchedule.getTransitLines().get(route.getLineId()).getRoutes()
+							.get(route.getRouteId()).getTransportMode();
 
 					if (!transportMode.equals("bus") && !transportMode.equals("subway")) {
 						return false;

--- a/sao_paulo/src/main/java/org/eqasim/sao_paulo/RunSimulation.java
+++ b/sao_paulo/src/main/java/org/eqasim/sao_paulo/RunSimulation.java
@@ -24,6 +24,10 @@ public class RunSimulation {
 				EqasimConfigurator.getConfigGroups());
 		EqasimConfigGroup.get(config).setTripAnalysisInterval(1);
 		cmd.applyConfiguration(config);
+		
+		config.controler().setLastIteration(0);
+		config.transit().setUseTransit(true);
+		config.transit().setUsingTransitInMobsim(true);
 
 		Scenario scenario = ScenarioUtils.createScenario(config);
 		EqasimConfigurator.configureScenario(scenario);

--- a/sao_paulo/src/main/java/org/eqasim/sao_paulo/mode_choice/costs/SaoPauloPtCostModel.java
+++ b/sao_paulo/src/main/java/org/eqasim/sao_paulo/mode_choice/costs/SaoPauloPtCostModel.java
@@ -41,8 +41,8 @@ public class SaoPauloPtCostModel implements CostModel {
 				if (leg.getMode().contentEquals(mode)) {
 
 					TransitLine tl = scenario.getTransitSchedule().getTransitLines()
-							.get(((EnrichedTransitRoute) leg.getRoute()).getTransitLineId());
-					TransitRoute tr = tl.getRoutes().get(((EnrichedTransitRoute) leg.getRoute()).getTransitRouteId());
+							.get(((EnrichedTransitRoute) leg.getRoute()).getLineId());
+					TransitRoute tr = tl.getRoutes().get(((EnrichedTransitRoute) leg.getRoute()).getRouteId());
 					if (tr.getTransportMode().equals("subway") || tr.getTransportMode().equals("rail"))
 						n_Vehicles += 1;
 				}
@@ -62,8 +62,8 @@ public class SaoPauloPtCostModel implements CostModel {
 				if (leg.getMode().contentEquals(mode)) {
 
 					TransitLine tl = scenario.getTransitSchedule().getTransitLines()
-							.get(((EnrichedTransitRoute) leg.getRoute()).getTransitLineId());
-					TransitRoute tr = tl.getRoutes().get(((EnrichedTransitRoute) leg.getRoute()).getTransitRouteId());
+							.get(((EnrichedTransitRoute) leg.getRoute()).getLineId());
+					TransitRoute tr = tl.getRoutes().get(((EnrichedTransitRoute) leg.getRoute()).getRouteId());
 					if (tr.getTransportMode().equals("bus"))
 						n_Vehicles += 1;
 				}


### PR DESCRIPTION
- Enables use of simulated public transport in MATSim (detailed vehicle <-> passenger interactions)
- Can be activated by setting `eqasim.useScheduleBasedTransport` to `false` in the configuration
- Fixes #45 