### PR TITLE
Test fix congestion

### DIFF
--- a/sao_paulo/src/main/java/org/eqasim/sao_paulo/RunSimulation.java
+++ b/sao_paulo/src/main/java/org/eqasim/sao_paulo/RunSimulation.java
@@ -30,6 +30,24 @@ public class RunSimulation {
 		ScenarioUtils.loadScenario(scenario);
 		EqasimConfigurator.adjustScenario(scenario);
 		
+		Random random = new Random(0);
+		  
+		for (Person person : scenario.getPopulation().getPersons().values()) { 
+			for (Plan plan : person.getPlans()) {
+				for (Trip trip : TripStructureUtils.getTrips(plan)) { 
+					if (trip.getTripElements().size() == 1)	{
+						Leg leg = (Leg) trip.getTripElements().get(0);  
+						if (leg.getMode().equals("car")) { 
+							if (random.nextDouble() < 0.5) {
+		 						leg.setMode("walk"); 
+								leg.setRoute(null); 
+							} 
+						}
+					}
+				}
+			}
+		}
+		 
 		EqasimConfigGroup eqasimConfig = (EqasimConfigGroup) config.getModules().get(EqasimConfigGroup.GROUP_NAME);
 		eqasimConfig.setEstimator("walk", "spWalkEstimator");
 		eqasimConfig.setEstimator("pt", "spPTEstimator");

--- a/sao_paulo/src/main/java/org/eqasim/sao_paulo/RunSimulation.java
+++ b/sao_paulo/src/main/java/org/eqasim/sao_paulo/RunSimulation.java
@@ -1,16 +1,23 @@
 package org.eqasim.sao_paulo;
 
+import java.util.Random;
+
 import org.eqasim.core.components.config.EqasimConfigGroup;
 import org.eqasim.core.simulation.EqasimConfigurator;
 import org.eqasim.core.simulation.analysis.EqasimAnalysisModule;
 import org.eqasim.core.simulation.mode_choice.EqasimModeChoiceModule;
 import org.eqasim.sao_paulo.mode_choice.SaoPauloModeChoiceModule;
 import org.matsim.api.core.v01.Scenario;
+import org.matsim.api.core.v01.population.Leg;
+import org.matsim.api.core.v01.population.Person;
+import org.matsim.api.core.v01.population.Plan;
 import org.matsim.core.config.CommandLine;
 import org.matsim.core.config.CommandLine.ConfigurationException;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.controler.Controler;
+import org.matsim.core.router.TripStructureUtils;
+import org.matsim.core.router.TripStructureUtils.Trip;
 import org.matsim.core.scenario.ScenarioUtils;
 
 public class RunSimulation {

--- a/sao_paulo/src/main/java/org/eqasim/sao_paulo/mode_choice/utilities/estimators/SaoPauloCarUtilityEstimator.java
+++ b/sao_paulo/src/main/java/org/eqasim/sao_paulo/mode_choice/utilities/estimators/SaoPauloCarUtilityEstimator.java
@@ -45,10 +45,10 @@ public class SaoPauloCarUtilityEstimator extends CarUtilityEstimator {
 		utility += estimateRegionalUtility(variables);
 		utility += estimateAccessEgressTimeUtility(variables_car);
 		if (variables.hhlIncome == 0.0)
-			utility += estimateMonetaryCostUtility(variables_car) * (parameters.spAvgHHLIncome.avg_hhl_income / 1.0);
+			utility += estimateMonetaryCostUtility(variables_car) * (parameters.spAvgHHLIncome.avg_hhl_income / parameters.spAvgHHLIncome.avg_hhl_income);
 		else
 			utility += estimateMonetaryCostUtility(variables_car)
-					* (parameters.spAvgHHLIncome.avg_hhl_income / variables.hhlIncome);
+					* (parameters.spAvgHHLIncome.avg_hhl_income / parameters.spAvgHHLIncome.avg_hhl_income);
 
 		return utility;
 	}

--- a/sao_paulo/src/main/java/org/eqasim/sao_paulo/mode_choice/utilities/estimators/SaoPauloPTUtilityEstimator.java
+++ b/sao_paulo/src/main/java/org/eqasim/sao_paulo/mode_choice/utilities/estimators/SaoPauloPTUtilityEstimator.java
@@ -53,10 +53,10 @@ public class SaoPauloPTUtilityEstimator  extends PtUtilityEstimator{
 		utility += estimateAgeUtility(person);
 		if (variables.hhlIncome == 0.0)
 			utility += estimateMonetaryCostUtility(variables_pt)
-			* (parameters.spAvgHHLIncome.avg_hhl_income / 1.0);
+			* (parameters.spAvgHHLIncome.avg_hhl_income / parameters.spAvgHHLIncome.avg_hhl_income);
 		else
 			utility += estimateMonetaryCostUtility(variables_pt)
-				* (parameters.spAvgHHLIncome.avg_hhl_income / variables.hhlIncome);
+				* (parameters.spAvgHHLIncome.avg_hhl_income / parameters.spAvgHHLIncome.avg_hhl_income);
 
 		return utility;
 	}

--- a/sao_paulo/src/main/java/org/eqasim/sao_paulo/mode_choice/utilities/estimators/SaoPauloTaxiUtilityEstimator.java
+++ b/sao_paulo/src/main/java/org/eqasim/sao_paulo/mode_choice/utilities/estimators/SaoPauloTaxiUtilityEstimator.java
@@ -42,10 +42,10 @@ public class SaoPauloTaxiUtilityEstimator implements UtilityEstimator {
 		utility += estimateAccessEgressTimeUtility(variables_taxi);
 		if (variables.hhlIncome == 0.0)
 			utility += estimateMonetaryCostUtility(variables_taxi)
-			* (parameters.spAvgHHLIncome.avg_hhl_income / 1.0);
+			* (parameters.spAvgHHLIncome.avg_hhl_income / parameters.spAvgHHLIncome.avg_hhl_income);
 		else
 			utility += estimateMonetaryCostUtility(variables_taxi)
-				* (parameters.spAvgHHLIncome.avg_hhl_income / variables.hhlIncome);
+				* (parameters.spAvgHHLIncome.avg_hhl_income / parameters.spAvgHHLIncome.avg_hhl_income);
 
 		return utility;
 	}


### PR DESCRIPTION
in RunSimulation we now change half of car trips to walk to have a slow approach to equilibrium as previously it was causing a lot of congestion that was not going away

Income elasticity was also removed