### PR TITLE
Add functionality for volume-delay functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ included in the (note yet determined) next version number.
 
 **Development version**
 
+- Add volume-delay function module
 - Add routing utilities based on scenarios
 - Fix bug in plan to CSV conversion when arrival activity start time is not set
 - Make use of new convergence markers in MATSim

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -13,6 +13,12 @@
 
 	<dependencies>
 		<dependency>
+			<groupId>org.eqasim</groupId>
+			<artifactId>vdf</artifactId>
+			<version>1.3.1</version>
+		</dependency>
+
+		<dependency>
 			<groupId>org.matsim.contrib</groupId>
 			<artifactId>drt</artifactId>
 			<version>${matsim.version}</version>

--- a/examples/src/main/java/org/eqasim/examples/corsica_vdf/RunCorsicaVDFSimulation.java
+++ b/examples/src/main/java/org/eqasim/examples/corsica_vdf/RunCorsicaVDFSimulation.java
@@ -1,0 +1,51 @@
+package org.eqasim.examples.corsica_vdf;
+
+import java.net.URL;
+
+import org.eqasim.core.simulation.analysis.EqasimAnalysisModule;
+import org.eqasim.core.simulation.mode_choice.EqasimModeChoiceModule;
+import org.eqasim.ile_de_france.IDFConfigurator;
+import org.eqasim.ile_de_france.mode_choice.IDFModeChoiceModule;
+import org.eqasim.vdf.VDFConfigGroup;
+import org.eqasim.vdf.VDFModule;
+import org.matsim.api.core.v01.Scenario;
+import org.matsim.core.config.CommandLine;
+import org.matsim.core.config.CommandLine.ConfigurationException;
+import org.matsim.core.config.Config;
+import org.matsim.core.config.ConfigUtils;
+import org.matsim.core.controler.Controler;
+import org.matsim.core.scenario.ScenarioUtils;
+
+import com.google.common.io.Resources;
+
+/**
+ * This is an example run script that runs the Corsica test scenario with a
+ * volume-delay function to simulate travel times.
+ */
+public class RunCorsicaVDFSimulation {
+	static public void main(String[] args) throws ConfigurationException {
+		CommandLine cmd = new CommandLine.Builder(args) //
+				.allowPrefixes("mode-parameter", "cost-parameter") //
+				.build();
+
+		URL configUrl = Resources.getResource("corsica/corsica_config.xml");
+		Config config = ConfigUtils.loadConfig(configUrl, IDFConfigurator.getConfigGroups());
+
+		config.controler().setLastIteration(2);
+		config.addModule(new VDFConfigGroup());
+
+		Scenario scenario = ScenarioUtils.createScenario(config);
+		IDFConfigurator.configureScenario(scenario);
+		ScenarioUtils.loadScenario(scenario);
+
+		Controler controller = new Controler(scenario);
+		IDFConfigurator.configureController(controller);
+		controller.addOverridingModule(new EqasimAnalysisModule());
+		controller.addOverridingModule(new EqasimModeChoiceModule());
+		controller.addOverridingModule(new IDFModeChoiceModule(cmd));
+
+		controller.addOverridingModule(new VDFModule());
+
+		controller.run();
+	}
+}

--- a/examples/src/test/java/org/eqasim/examples/corsica_vdf/CorsicaVDFSimulationTest.java
+++ b/examples/src/test/java/org/eqasim/examples/corsica_vdf/CorsicaVDFSimulationTest.java
@@ -1,0 +1,13 @@
+package org.eqasim.examples.corsica_vdf;
+
+import java.io.IOException;
+
+import org.junit.Test;
+import org.matsim.core.config.CommandLine.ConfigurationException;
+
+public class CorsicaVDFSimulationTest {
+	@Test
+	public void testCorsicaDrtSimulationTest() throws ConfigurationException, IOException {
+		RunCorsicaVDFSimulation.main(new String[] {});
+	}
+}

--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,7 @@
 		<module>examples</module>
 		<module>san_francisco</module>
 		<module>los_angeles</module>
+		<module>vdf</module>
 	</modules>
 
 	<properties>

--- a/vdf/pom.xml
+++ b/vdf/pom.xml
@@ -1,0 +1,19 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.eqasim</groupId>
+		<artifactId>eqasim</artifactId>
+		<version>1.3.1</version>
+	</parent>
+	<artifactId>vdf</artifactId>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.eqasim</groupId>
+			<artifactId>core</artifactId>
+			<version>1.3.1</version>
+		</dependency>
+	</dependencies>
+</project>

--- a/vdf/src/main/java/org/eqasim/vdf/VDFConfigGroup.java
+++ b/vdf/src/main/java/org/eqasim/vdf/VDFConfigGroup.java
@@ -1,0 +1,124 @@
+package org.eqasim.vdf;
+
+import org.matsim.core.config.ReflectiveConfigGroup;
+import org.matsim.core.utils.misc.Time;
+
+public class VDFConfigGroup extends ReflectiveConfigGroup {
+	static public final String GROUP_NAME = "eqasim:vdf";
+
+	static private final String START_TIME = "startTime";
+	static private final String END_TIME = "endTime";
+	static private final String INTERVAL = "interval";
+	static private final String MINIMUM_SPEED = "minimumSpeed";
+	static private final String HORIZON = "horizon";
+
+	static private final String BPR_FACTOR = "bpr:factor";
+	static private final String BPR_EXPONENT = "bpr:exponent";
+
+	private double startTime = 0.0 * 3600.0;
+	private double endTime = 24.0 * 3600.0;
+	private double interval = 3600.0;
+	private double minimumSpeed = 5.0 / 3.6;
+	private int horizon = 10;
+
+	private double bprFactor = 0.15;
+	private double bprExponent = 4.0;
+
+	public VDFConfigGroup() {
+		super(GROUP_NAME);
+	}
+
+	@StringGetter(START_TIME)
+	public String getStartTimeAsString() {
+		return Time.writeTime(startTime);
+	}
+
+	public double getStartTime() {
+		return startTime;
+	}
+
+	@StringSetter(START_TIME)
+	public void setStartTimeAsString(String startTime) {
+		this.startTime = Time.parseTime(startTime);
+	}
+
+	public void setStartTime(double startTime) {
+		this.startTime = startTime;
+	}
+
+	@StringGetter(END_TIME)
+	public String getEndTimeAsString() {
+		return Time.writeTime(endTime);
+	}
+
+	public double getEndTime() {
+		return endTime;
+	}
+
+	@StringSetter(END_TIME)
+	public void setEndTimeAsString(String endTime) {
+		this.endTime = Time.parseTime(endTime);
+	}
+
+	public void setEndTime(double endTime) {
+		this.endTime = endTime;
+	}
+
+	@StringGetter(INTERVAL)
+	public String getIntervalAsString() {
+		return Time.writeTime(interval);
+	}
+
+	public double getInterval() {
+		return interval;
+	}
+
+	@StringSetter(INTERVAL)
+	public void setIntervalAsString(String interval) {
+		this.interval = Time.parseTime(interval);
+	}
+
+	public void setInterval(double interval) {
+		this.interval = interval;
+	}
+
+	@StringGetter(MINIMUM_SPEED)
+	public double getMinimumSpeed() {
+		return minimumSpeed;
+	}
+
+	@StringSetter(MINIMUM_SPEED)
+	public void setMinimumSpeed(double minimumSpeed) {
+		this.minimumSpeed = minimumSpeed;
+	}
+
+	@StringGetter(HORIZON)
+	public int getHorizon() {
+		return horizon;
+	}
+
+	@StringSetter(HORIZON)
+	public void setHorizon(int horizon) {
+		this.horizon = horizon;
+	}
+
+	@StringGetter(BPR_FACTOR)
+	public double getBprFactor() {
+		return bprFactor;
+	}
+
+	@StringSetter(BPR_FACTOR)
+	public void setBprFactor(double bprFactor) {
+		this.bprFactor = bprFactor;
+	}
+
+	@StringGetter(BPR_EXPONENT)
+	public double getBprExponent() {
+		return bprExponent;
+	}
+
+	@StringSetter(BPR_EXPONENT)
+	public void setBprExponent(double bprExponent) {
+		this.bprExponent = bprExponent;
+	}
+}

--- a/vdf/src/main/java/org/eqasim/vdf/VDFLinkSpeedCalculator.java
+++ b/vdf/src/main/java/org/eqasim/vdf/VDFLinkSpeedCalculator.java
@@ -1,0 +1,24 @@
+package org.eqasim.vdf;
+
+import org.matsim.api.core.v01.network.Link;
+import org.matsim.api.core.v01.population.Person;
+import org.matsim.api.core.v01.population.Population;
+import org.matsim.core.mobsim.qsim.qnetsimengine.QVehicle;
+import org.matsim.core.mobsim.qsim.qnetsimengine.linkspeedcalculator.LinkSpeedCalculator;
+
+public class VDFLinkSpeedCalculator implements LinkSpeedCalculator {
+	private final VDFTravelTime travelTime;
+	private final Population population;
+
+	public VDFLinkSpeedCalculator(Population population, VDFTravelTime travelTime) {
+		this.travelTime = travelTime;
+		this.population = population;
+	}
+
+	@Override
+	public double getMaximumVelocity(QVehicle vehicle, Link link, double time) {
+		Person person = population.getPersons().get(vehicle.getDriver().getId());
+		double calculatedTravelTime = travelTime.getLinkTravelTime(link, time, person, vehicle.getVehicle());
+		return Math.min(link.getLength() / calculatedTravelTime, vehicle.getMaximumVelocity());
+	}
+}

--- a/vdf/src/main/java/org/eqasim/vdf/VDFModule.java
+++ b/vdf/src/main/java/org/eqasim/vdf/VDFModule.java
@@ -1,0 +1,45 @@
+package org.eqasim.vdf;
+
+import org.eqasim.core.components.config.EqasimConfigGroup;
+import org.eqasim.vdf.function.BPRFunction;
+import org.eqasim.vdf.function.VolumeDelayFunction;
+import org.matsim.api.core.v01.TransportMode;
+import org.matsim.api.core.v01.network.Network;
+import org.matsim.core.config.groups.QSimConfigGroup;
+import org.matsim.core.controler.AbstractModule;
+
+import com.google.inject.Provides;
+import com.google.inject.Singleton;
+
+public class VDFModule extends AbstractModule {
+	@Override
+	public void install() {
+		addTravelTimeBinding(TransportMode.car).to(VDFTravelTime.class);
+		addEventHandlerBinding().to(VDFTrafficHandler.class);
+
+		bind(VolumeDelayFunction.class).to(BPRFunction.class);
+	}
+
+	@Provides
+	@Singleton
+	public VDFTravelTime provideVDFTravelTime(VDFConfigGroup config, Network network, VolumeDelayFunction vdf,
+			QSimConfigGroup qsimConfig, EqasimConfigGroup eqasimConfig) {
+		int numberOfIntervals = (int) Math.floor((config.getEndTime() - config.getStartTime()) / config.getInterval())
+				+ 1;
+		return new VDFTravelTime(config.getEndTime(), config.getInterval(), numberOfIntervals, config.getMinimumSpeed(),
+				qsimConfig.getFlowCapFactor(), network, vdf, eqasimConfig.getCrossingPenalty());
+	}
+
+	@Provides
+	@Singleton
+	public VDFTrafficHandler provideVDFTrafficHandler(VDFConfigGroup config, Network network,
+			VDFTravelTime travelTime) {
+		return new VDFTrafficHandler(network, travelTime, config.getHorizon());
+	}
+
+	@Provides
+	@Singleton
+	public BPRFunction provideBPRFunction(VDFConfigGroup config) {
+		return new BPRFunction(config.getBprFactor(), config.getBprExponent());
+	}
+}

--- a/vdf/src/main/java/org/eqasim/vdf/VDFQSimModule.java
+++ b/vdf/src/main/java/org/eqasim/vdf/VDFQSimModule.java
@@ -1,0 +1,32 @@
+package org.eqasim.vdf;
+
+import org.matsim.api.core.v01.Scenario;
+import org.matsim.api.core.v01.population.Population;
+import org.matsim.core.api.experimental.events.EventsManager;
+import org.matsim.core.mobsim.qsim.AbstractQSimModule;
+import org.matsim.core.mobsim.qsim.qnetsimengine.ConfigurableQNetworkFactory;
+import org.matsim.core.mobsim.qsim.qnetsimengine.QNetworkFactory;
+
+import com.google.inject.Provides;
+import com.google.inject.Singleton;
+
+public class VDFQSimModule extends AbstractQSimModule {
+	@Override
+	protected void configureQSim() {
+	}
+
+	@Provides
+	@Singleton
+	public QNetworkFactory provideQNetworkFactory(EventsManager events, Scenario scenario,
+			VDFLinkSpeedCalculator linkSpeedCalculator) {
+		ConfigurableQNetworkFactory networkFactory = new ConfigurableQNetworkFactory(events, scenario);
+		networkFactory.setLinkSpeedCalculator(linkSpeedCalculator);
+		return networkFactory;
+	}
+
+	@Provides
+	@Singleton
+	public VDFLinkSpeedCalculator provideVDFLinkSpeedCalculator(Population population, VDFTravelTime travelTime) {
+		return new VDFLinkSpeedCalculator(population, travelTime);
+	}
+}

--- a/vdf/src/main/java/org/eqasim/vdf/VDFTrafficHandler.java
+++ b/vdf/src/main/java/org/eqasim/vdf/VDFTrafficHandler.java
@@ -1,0 +1,79 @@
+package org.eqasim.vdf;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.IdMap;
+import org.matsim.api.core.v01.events.LinkEnterEvent;
+import org.matsim.api.core.v01.events.handler.LinkEnterEventHandler;
+import org.matsim.api.core.v01.network.Link;
+import org.matsim.api.core.v01.network.Network;
+
+public class VDFTrafficHandler implements LinkEnterEventHandler {
+	private final VDFTravelTime travelTime;
+	private final Network network;
+	private final int horizon;
+
+	private final IdMap<Link, List<Integer>> counts = new IdMap<>(Link.class);
+	private final List<IdMap<Link, List<Integer>>> history = new LinkedList<>();
+
+	public VDFTrafficHandler(Network network, VDFTravelTime travelTime, int horizon) {
+		this.travelTime = travelTime;
+		this.network = network;
+		this.horizon = horizon;
+
+		reset(0);
+	}
+
+	@Override
+	public synchronized void handleEvent(LinkEnterEvent event) {
+		int i = travelTime.getInterval(event.getTime());
+		int currentValue = counts.get(event.getLinkId()).get(i);
+		counts.get(event.getLinkId()).set(i, currentValue + 1);
+	}
+
+	@Override
+	public void reset(int iteration) {
+		if (history.size() == horizon) {
+			history.remove(0);
+		}
+		
+		// Make a copy to add to the history
+		
+		IdMap<Link, List<Integer>> copy = new IdMap<>(Link.class);
+		
+		for (Map.Entry<Id<Link>, List<Integer>> entry : counts.entrySet()) {
+			copy.put(entry.getKey(), new ArrayList<>(entry.getValue()));
+		}
+		
+		history.add(copy);
+		
+		IdMap<Link, List<Double>> aggregated = new IdMap<>(Link.class);
+		
+		for (Id<Link> linkId : network.getLinks().keySet()) {
+			// Reset current counts
+			counts.put(linkId, new ArrayList<>(Collections.nCopies(travelTime.getNumberOfIntervals(), 0)));
+		
+			// Initialize aggregated counts
+			aggregated.put(linkId, new ArrayList<>(Collections.nCopies(travelTime.getNumberOfIntervals(), 0.0)));
+		}
+		
+		// Aggregate
+		
+		for (IdMap<Link, List<Integer>> item : history) {
+			for (Map.Entry<Id<Link>, List<Integer>> entry : item.entrySet()) {
+				List<Double> aggregatedList = aggregated.get(entry.getKey());
+				
+				for (int i = 0; i < aggregatedList.size(); i++) {
+					aggregatedList.set(i, aggregatedList.get(i) + (double) entry.getValue().get(i) / (double) history.size());
+				}
+			}
+		}
+		
+		travelTime.update(aggregated);
+	}
+}

--- a/vdf/src/main/java/org/eqasim/vdf/VDFTravelTime.java
+++ b/vdf/src/main/java/org/eqasim/vdf/VDFTravelTime.java
@@ -1,0 +1,98 @@
+package org.eqasim.vdf;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.eqasim.vdf.function.VolumeDelayFunction;
+import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.IdMap;
+import org.matsim.api.core.v01.network.Link;
+import org.matsim.api.core.v01.network.Network;
+import org.matsim.api.core.v01.population.Person;
+import org.matsim.core.router.util.TravelTime;
+import org.matsim.vehicles.Vehicle;
+
+public class VDFTravelTime implements TravelTime {
+	private final double startTime;
+	private final double interval;
+	private final int numberOfIntervals;
+	private final double minimumSpeed;
+	private final double flowCapacityFactor;
+	private final double crossingPenalty;
+
+	private final Network network;
+	private final VolumeDelayFunction vdf;
+
+	private final IdMap<Link, List<Double>> travelTimes = new IdMap<>(Link.class);
+
+	public VDFTravelTime(double startTime, double interval, int numberOfIntervals, double minimumSpeed,
+			double flowCapacityFacotor, Network network, VolumeDelayFunction vdf, double crossingPenalty) {
+		this.startTime = startTime;
+		this.interval = interval;
+		this.numberOfIntervals = numberOfIntervals;
+		this.network = network;
+		this.vdf = vdf;
+		this.minimumSpeed = minimumSpeed;
+		this.flowCapacityFactor = flowCapacityFacotor;
+		this.crossingPenalty = crossingPenalty;
+
+		for (Link link : network.getLinks().values()) {
+			double travelTime = Math.max(1.0,
+					Math.max(link.getLength() / minimumSpeed, link.getLength() / link.getFreespeed()));
+			travelTimes.put(link.getId(), new ArrayList<>(Collections.nCopies(numberOfIntervals, travelTime)));
+		}
+	}
+
+	@Override
+	public double getLinkTravelTime(Link link, double time, Person person, Vehicle vehicle) {
+		int i = getInterval(time);
+		return travelTimes.get(link.getId()).get(i);
+	}
+
+	public void update(IdMap<Link, List<Double>> counts) {
+		for (Map.Entry<Id<Link>, List<Double>> entry : counts.entrySet()) {
+			Link link = network.getLinks().get(entry.getKey());
+
+			List<Double> linkCounts = entry.getValue();
+			List<Double> linkTravelTimes = travelTimes.get(entry.getKey());
+
+			for (int i = 0; i < numberOfIntervals; i++) {
+				double time = startTime + i * interval;
+
+				// Pass per interval
+				double flow = linkCounts.get(i) / flowCapacityFactor;
+				double capacity = interval * link.getCapacity(time) / network.getCapacityPeriod();
+
+				double travelTime = Math.max(1.0,
+						Math.max(link.getLength() / minimumSpeed, vdf.getTravelTime(time, flow, capacity, link)));
+				linkTravelTimes.set(i, considerCrossingPenalty(link, travelTime));
+			}
+		}
+	}
+
+	private double considerCrossingPenalty(Link link, double baseTravelTime) {
+		boolean isMajor = true;
+
+		for (Link other : link.getToNode().getInLinks().values()) {
+			if (other.getCapacity() >= link.getCapacity()) {
+				isMajor = false;
+			}
+		}
+
+		if (isMajor || link.getToNode().getInLinks().size() == 1) {
+			return baseTravelTime;
+		} else {
+			return baseTravelTime + crossingPenalty;
+		}
+	}
+
+	public int getNumberOfIntervals() {
+		return numberOfIntervals;
+	}
+
+	public int getInterval(double time) {
+		return Math.min(Math.max(0, (int) Math.floor((time - startTime) / interval)), numberOfIntervals - 1);
+	}
+}

--- a/vdf/src/main/java/org/eqasim/vdf/function/BPRFunction.java
+++ b/vdf/src/main/java/org/eqasim/vdf/function/BPRFunction.java
@@ -1,0 +1,19 @@
+package org.eqasim.vdf.function;
+
+import org.matsim.api.core.v01.network.Link;
+
+public class BPRFunction implements VolumeDelayFunction {
+	private final double factor;
+	private final double exponent;
+
+	public BPRFunction(double factor, double exponent) {
+		this.factor = factor;
+		this.exponent = exponent;
+	}
+
+	@Override
+	public double getTravelTime(double time, double flow, double capacity, Link link) {
+		double freeflowTravelTime = link.getLength() / link.getFreespeed(time);
+		return freeflowTravelTime * (1.0 + factor * Math.pow(flow / capacity, exponent));
+	}
+}

--- a/vdf/src/main/java/org/eqasim/vdf/function/VolumeDelayFunction.java
+++ b/vdf/src/main/java/org/eqasim/vdf/function/VolumeDelayFunction.java
@@ -1,0 +1,7 @@
+package org.eqasim.vdf.function;
+
+import org.matsim.api.core.v01.network.Link;
+
+public interface VolumeDelayFunction {
+	double getTravelTime(double time, double flow, double capacity, Link link);
+}


### PR DESCRIPTION
To enable traffic simulation based on volume-delay functions:
- Add `VDFConfigGroup` for configuration options, including the definition of time slices in which flows are estimated, and the parameters of the a standard BPR function.
- Add `VDFModule` to enable VDF-based network simulation (travel times will be used in routing via `TravelTime` and in QSim via `LinkSpeedCalculator` based on the average flow over the `horizon` last iterations)