### PR TITLE
Use event information in cutting process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ included in the (note yet determined) next version number.
 
 **Development version**
 
+- Allow cutter to process events to (1) perform routing based on recorded travel time, and (2) find crossing points based on the actual link enter/leave times of a previous simulation
 - Simplify cutting by introducing `--plans-path` option which is interpreted as relative to CWD
 - Location assignment functionality for scenario preparation functionality has been removed. A more advanced is used in the upstream Python pipelines for scenario generation.
 - Add volume-delay function module

--- a/core/src/main/java/org/eqasim/core/components/travel_time/RecordedTravelTime.java
+++ b/core/src/main/java/org/eqasim/core/components/travel_time/RecordedTravelTime.java
@@ -17,6 +17,7 @@ import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.population.Person;
 import org.matsim.core.api.experimental.events.EventsManager;
+import org.matsim.core.config.Config;
 import org.matsim.core.events.EventsUtils;
 import org.matsim.core.events.MatsimEventsReader;
 import org.matsim.core.router.util.TravelTime;
@@ -148,6 +149,14 @@ public class RecordedTravelTime implements TravelTime {
 	static public RecordedTravelTime readFromEvents(File eventsPath, RoadNetwork network, double startTime,
 			double endTime, double interval) {
 		return readFromEvents(eventsPath, network, new FreeSpeedTravelTime(), startTime, endTime, interval);
+	}
+
+	static public RecordedTravelTime readFromEvents(File eventsPath, RoadNetwork network, Config config) {
+		double startTime = 0.0;
+		double endTime = config.travelTimeCalculator().getMaxTime();
+		double interval = config.travelTimeCalculator().getTraveltimeBinSize();
+
+		return RecordedTravelTime.readFromEvents(eventsPath, network, startTime, endTime, interval);
 	}
 
 	static public RecordedTravelTime readFromEvents(File eventsPath, RoadNetwork network, TravelTime fallback,

--- a/core/src/main/java/org/eqasim/core/scenario/cutter/CutterTravelTimeModule.java
+++ b/core/src/main/java/org/eqasim/core/scenario/cutter/CutterTravelTimeModule.java
@@ -1,0 +1,22 @@
+package org.eqasim.core.scenario.cutter;
+
+import java.util.Optional;
+
+import org.eqasim.core.components.travel_time.RecordedTravelTime;
+import org.matsim.core.controler.AbstractModule;
+import org.matsim.core.router.util.TravelTime;
+
+public class CutterTravelTimeModule extends AbstractModule {
+	private final Optional<RecordedTravelTime> travelTime;
+
+	public CutterTravelTimeModule(Optional<RecordedTravelTime> travelTime) {
+		this.travelTime = travelTime;
+	}
+
+	@Override
+	public void install() {
+		if (travelTime.isPresent()) {
+			bind(TravelTime.class).toInstance(travelTime.get());
+		}
+	}
+}

--- a/core/src/main/java/org/eqasim/core/scenario/cutter/RunScenarioCutter.java
+++ b/core/src/main/java/org/eqasim/core/scenario/cutter/RunScenarioCutter.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.util.Optional;
 
+import org.eqasim.core.components.travel_time.RecordedTravelTime;
 import org.eqasim.core.misc.InjectorBuilder;
 import org.eqasim.core.scenario.cutter.extent.ScenarioExtent;
 import org.eqasim.core.scenario.cutter.extent.ShapeScenarioExtent;
@@ -40,7 +41,7 @@ public class RunScenarioCutter {
 			throws ConfigurationException, MalformedURLException, IOException, InterruptedException {
 		CommandLine cmd = new CommandLine.Builder(args) //
 				.requireOptions("config-path", "output-path", "extent-path") //
-				.allowOptions("threads", "prefix", "extent-attribute", "extent-value") //
+				.allowOptions("threads", "prefix", "extent-attribute", "extent-value", "events-path") //
 				.build();
 
 		// Load some configuration
@@ -73,10 +74,20 @@ public class RunScenarioCutter {
 		// Prepare road network
 		RoadNetwork roadNetwork = new RoadNetwork(scenario.getNetwork());
 
+		// Optionally, load travel time
+		Optional<RecordedTravelTime> travelTime = Optional.empty();
+
+		if (cmd.hasOption("events-path")) {
+			travelTime = Optional.of(RecordedTravelTime.readFromEvents( //
+					new File(cmd.getOptionStrict("events-path")), roadNetwork, config));
+		}
+
 		// Cut population
 		Injector populationCutterInjector = new InjectorBuilder(scenario) //
 				.addOverridingModules(EqasimConfigurator.getModules()) //
-				.addOverridingModule(new PopulationCutterModule(extent, numberOfThreads, 40)) //
+				.addOverridingModule(
+						new PopulationCutterModule(extent, numberOfThreads, 40, cmd.getOption("events-path"))) //
+				.addOverridingModule(new CutterTravelTimeModule(travelTime)) //
 				.build();
 
 		PopulationCutter populationCutter = populationCutterInjector.getInstance(PopulationCutter.class);
@@ -127,6 +138,7 @@ public class RunScenarioCutter {
 		Injector routingInjector = new InjectorBuilder(scenario) //
 				.addOverridingModules(EqasimConfigurator.getModules()) //
 				.addOverridingModule(new PopulationRouterModule(numberOfThreads, 100, false)) //
+				.addOverridingModule(new CutterTravelTimeModule(travelTime)) //
 				.build();
 
 		PopulationRouter router = routingInjector.getInstance(PopulationRouter.class);

--- a/core/src/main/java/org/eqasim/core/scenario/cutter/population/PlanCutter.java
+++ b/core/src/main/java/org/eqasim/core/scenario/cutter/population/PlanCutter.java
@@ -6,7 +6,9 @@ import java.util.List;
 import org.eqasim.core.misc.Constants;
 import org.eqasim.core.scenario.cutter.extent.ScenarioExtent;
 import org.eqasim.core.scenario.cutter.population.trips.TripProcessor;
+import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.population.Activity;
+import org.matsim.api.core.v01.population.Person;
 import org.matsim.api.core.v01.population.PlanElement;
 import org.matsim.core.population.PopulationUtils;
 import org.matsim.core.router.TripStructureUtils;
@@ -32,29 +34,32 @@ public class PlanCutter {
 		} else {
 			Activity virtualActivity = PopulationUtils.createActivityFromCoord(Constants.OUTSIDE_ACTIVITY_TYPE,
 					activity.getCoord());
-			
+
 			if (activity.getEndTime().isDefined()) {
 				virtualActivity.setEndTime(activity.getEndTime().seconds());
 			} else {
 				virtualActivity.setEndTimeUndefined();
 			}
-			
+
 			virtualActivity.getAttributes().putAttribute(Constants.TYPE_BEFORE_CUTTING_ATTRIBUTE, activity.getType());
 
 			plan.add(virtualActivity);
 		}
 	}
 
-	public List<PlanElement> processPlan(List<PlanElement> elements) {
+	public List<PlanElement> processPlan(Id<Person> personId, List<PlanElement> elements) {
 		List<PlanElement> result = new LinkedList<>();
 
 		if (elements.size() > 0) {
 			addActivity(result, (Activity) elements.get(0));
+			int legIndex = 0;
 
 			for (TripStructureUtils.Trip trip : TripStructureUtils.getTrips(elements)) {
-				result.addAll(tripProcessor.process(trip.getOriginActivity(), trip.getTripElements(),
-						trip.getDestinationActivity()));
+				result.addAll(tripProcessor.process(personId, legIndex, trip.getOriginActivity(),
+						trip.getTripElements(), trip.getDestinationActivity()));
+
 				addActivity(result, trip.getDestinationActivity());
+				legIndex += trip.getLegsOnly().size();
 			}
 		}
 

--- a/core/src/main/java/org/eqasim/core/scenario/cutter/population/PopulationCutter.java
+++ b/core/src/main/java/org/eqasim/core/scenario/cutter/population/PopulationCutter.java
@@ -96,7 +96,8 @@ public class PopulationCutter {
 					List<Plan> oldPlans = new LinkedList<>();
 
 					for (Plan oldPlan : person.getPlans()) {
-						List<PlanElement> newPlanElements = planCutter.processPlan(oldPlan.getPlanElements());
+						List<PlanElement> newPlanElements = planCutter.processPlan(person.getId(),
+								oldPlan.getPlanElements());
 
 						Plan newPlan = populationFactory.createPlan();
 

--- a/core/src/main/java/org/eqasim/core/scenario/cutter/population/trips/ModeAwareTripProcessor.java
+++ b/core/src/main/java/org/eqasim/core/scenario/cutter/population/trips/ModeAwareTripProcessor.java
@@ -4,7 +4,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.population.Activity;
+import org.matsim.api.core.v01.population.Person;
 import org.matsim.api.core.v01.population.PlanElement;
 import org.matsim.core.router.MainModeIdentifier;
 
@@ -21,8 +23,9 @@ public class ModeAwareTripProcessor implements TripProcessor {
 	}
 
 	@Override
-	public List<PlanElement> process(Activity firstActivity, List<PlanElement> trip, Activity secondActivity) {
+	public List<PlanElement> process(Id<Person> personId, int firstLegIndex, Activity firstActivity,
+			List<PlanElement> trip, Activity secondActivity) {
 		String mainMode = mainModeIdentifier.identifyMainMode(trip);
-		return processors.get(mainMode).process(firstActivity, trip, secondActivity);
+		return processors.get(mainMode).process(personId, firstLegIndex, firstActivity, trip, secondActivity);
 	}
 }

--- a/core/src/main/java/org/eqasim/core/scenario/cutter/population/trips/NetworkTripProcessor.java
+++ b/core/src/main/java/org/eqasim/core/scenario/cutter/population/trips/NetworkTripProcessor.java
@@ -7,8 +7,10 @@ import java.util.List;
 import org.eqasim.core.scenario.cutter.extent.ScenarioExtent;
 import org.eqasim.core.scenario.cutter.population.trips.crossing.network.NetworkCrossingPoint;
 import org.eqasim.core.scenario.cutter.population.trips.crossing.network.NetworkCrossingPointFinder;
+import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.population.Activity;
 import org.matsim.api.core.v01.population.Leg;
+import org.matsim.api.core.v01.population.Person;
 import org.matsim.api.core.v01.population.PlanElement;
 import org.matsim.core.population.PopulationUtils;
 import org.matsim.core.population.routes.NetworkRoute;
@@ -26,12 +28,13 @@ public class NetworkTripProcessor implements TripProcessor {
 	}
 
 	@Override
-	public List<PlanElement> process(Activity firstActivity, List<PlanElement> trip, Activity secondActivity) {
+	public List<PlanElement> process(Id<Person> personId, int firstLegIndex, Activity firstActivity,
+			List<PlanElement> trip, Activity secondActivity) {
 		Leg leg = (Leg) trip.get(0);
 
 		NetworkRoute route = (NetworkRoute) leg.getRoute();
-		List<NetworkCrossingPoint> crossingPoints = crossingPointFinder.findCrossingPoints(leg.getMode(), route,
-				leg.getDepartureTime().seconds());
+		List<NetworkCrossingPoint> crossingPoints = crossingPointFinder.findCrossingPoints(personId, firstLegIndex,
+				leg.getMode(), route, leg.getDepartureTime().seconds());
 
 		if (crossingPoints.size() > 0) {
 			List<PlanElement> result = new LinkedList<>();
@@ -49,7 +52,7 @@ public class NetworkTripProcessor implements TripProcessor {
 		} else if (crossingPointFinder.isInside(route)) {
 			return Arrays.asList(PopulationUtils.createLeg(leg.getMode()));
 		} else {
-			// The route is outside. This does not means that both (or any) activity is
+			// The route is outside. This does not mean that both (or any) activity is
 			// actually outside. These are mainly special cases in which the route is
 			// outside, but some activity is inside, across the border, because the link is
 			// parallel to the border. We put an outside activity right next to the inside
@@ -79,8 +82,10 @@ public class NetworkTripProcessor implements TripProcessor {
 		}
 	}
 
-	public List<PlanElement> process(String mode, NetworkRoute route, double departureTime, boolean allOutside) {
-		List<NetworkCrossingPoint> crossingPoints = crossingPointFinder.findCrossingPoints(mode, route, departureTime);
+	public List<PlanElement> process(Id<Person> personId, int firstLegIndex, String mode, NetworkRoute route,
+			double departureTime, boolean allOutside) {
+		List<NetworkCrossingPoint> crossingPoints = crossingPointFinder.findCrossingPoints(personId, firstLegIndex,
+				mode, route, departureTime);
 
 		if (crossingPoints.size() == 0) {
 			return Arrays.asList(PopulationUtils.createLeg(allOutside ? "outside" : mode));

--- a/core/src/main/java/org/eqasim/core/scenario/cutter/population/trips/NetworkTripProcessor.java
+++ b/core/src/main/java/org/eqasim/core/scenario/cutter/population/trips/NetworkTripProcessor.java
@@ -81,27 +81,4 @@ public class NetworkTripProcessor implements TripProcessor {
 			return result;
 		}
 	}
-
-	public List<PlanElement> process(Id<Person> personId, int firstLegIndex, String mode, NetworkRoute route,
-			double departureTime, boolean allOutside) {
-		List<NetworkCrossingPoint> crossingPoints = crossingPointFinder.findCrossingPoints(personId, firstLegIndex,
-				mode, route, departureTime);
-
-		if (crossingPoints.size() == 0) {
-			return Arrays.asList(PopulationUtils.createLeg(allOutside ? "outside" : mode));
-		} else {
-			List<PlanElement> result = new LinkedList<>();
-
-			result.add(PopulationUtils.createLeg(crossingPoints.get(0).isOutgoing ? mode : "outside"));
-
-			for (NetworkCrossingPoint point : crossingPoints) {
-				Activity activity = PopulationUtils.createActivityFromLinkId("outside", point.link.getId());
-				activity.setEndTime(point.leaveTime);
-				result.add(activity);
-				result.add(PopulationUtils.createLeg(point.isOutgoing ? "outside" : mode));
-			}
-
-			return result;
-		}
-	}
 }

--- a/core/src/main/java/org/eqasim/core/scenario/cutter/population/trips/TeleportationTripProcessor.java
+++ b/core/src/main/java/org/eqasim/core/scenario/cutter/population/trips/TeleportationTripProcessor.java
@@ -8,8 +8,10 @@ import org.eqasim.core.scenario.cutter.extent.ScenarioExtent;
 import org.eqasim.core.scenario.cutter.population.trips.crossing.teleportation.TeleportationCrossingPoint;
 import org.eqasim.core.scenario.cutter.population.trips.crossing.teleportation.TeleportationCrossingPointFinder;
 import org.matsim.api.core.v01.Coord;
+import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.population.Activity;
 import org.matsim.api.core.v01.population.Leg;
+import org.matsim.api.core.v01.population.Person;
 import org.matsim.api.core.v01.population.PlanElement;
 import org.matsim.core.population.PopulationUtils;
 
@@ -26,7 +28,8 @@ public class TeleportationTripProcessor implements TripProcessor {
 	}
 
 	@Override
-	public List<PlanElement> process(Activity firstActivity, List<PlanElement> trip, Activity secondActivity) {
+	public List<PlanElement> process(Id<Person> personId, int firstLegIndex, Activity firstActivity,
+			List<PlanElement> trip, Activity secondActivity) {
 		Leg leg = (Leg) trip.get(0);
 
 		return process(firstActivity.getCoord(), secondActivity.getCoord(), leg.getTravelTime().seconds(),

--- a/core/src/main/java/org/eqasim/core/scenario/cutter/population/trips/TransitTripProcessor.java
+++ b/core/src/main/java/org/eqasim/core/scenario/cutter/population/trips/TransitTripProcessor.java
@@ -8,7 +8,9 @@ import org.eqasim.core.scenario.cutter.extent.ScenarioExtent;
 import org.eqasim.core.scenario.cutter.population.trips.crossing.transit.TransitTripCrossingPoint;
 import org.eqasim.core.scenario.cutter.population.trips.crossing.transit.TransitTripCrossingPointFinder;
 import org.matsim.api.core.v01.Coord;
+import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.population.Activity;
+import org.matsim.api.core.v01.population.Person;
 import org.matsim.api.core.v01.population.PlanElement;
 import org.matsim.core.population.PopulationUtils;
 
@@ -25,7 +27,8 @@ public class TransitTripProcessor implements TripProcessor {
 	}
 
 	@Override
-	public List<PlanElement> process(Activity firstActivity, List<PlanElement> trip, Activity secondActivity) {
+	public List<PlanElement> process(Id<Person> personId, int firstLegIndex, Activity firstActivity,
+			List<PlanElement> trip, Activity secondActivity) {
 		return process(firstActivity.getCoord(), trip, secondActivity.getCoord(),
 				!extent.isInside(firstActivity.getCoord()) && !extent.isInside(secondActivity.getCoord()));
 	}

--- a/core/src/main/java/org/eqasim/core/scenario/cutter/population/trips/TripProcessor.java
+++ b/core/src/main/java/org/eqasim/core/scenario/cutter/population/trips/TripProcessor.java
@@ -2,9 +2,12 @@ package org.eqasim.core.scenario.cutter.population.trips;
 
 import java.util.List;
 
+import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.population.Activity;
+import org.matsim.api.core.v01.population.Person;
 import org.matsim.api.core.v01.population.PlanElement;
 
 public interface TripProcessor {
-	List<PlanElement> process(Activity firstActivity, List<PlanElement> trip, Activity secondActivity);
+	List<PlanElement> process(Id<Person> personId, int firstLegIndex, Activity firstActivity, List<PlanElement> trip,
+			Activity secondActivity);
 }

--- a/core/src/main/java/org/eqasim/core/scenario/cutter/population/trips/crossing/network/DefaultNetworkCrossingPointFinder.java
+++ b/core/src/main/java/org/eqasim/core/scenario/cutter/population/trips/crossing/network/DefaultNetworkCrossingPointFinder.java
@@ -3,11 +3,15 @@ package org.eqasim.core.scenario.cutter.population.trips.crossing.network;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import org.eqasim.core.scenario.cutter.extent.ScenarioExtent;
+import org.eqasim.core.scenario.cutter.population.trips.crossing.network.timing.LinkTimingData;
+import org.eqasim.core.scenario.cutter.population.trips.crossing.network.timing.LinkTimingRegistry;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
+import org.matsim.api.core.v01.population.Person;
 import org.matsim.core.population.routes.NetworkRoute;
 import org.matsim.core.router.util.TravelTime;
 
@@ -16,18 +20,22 @@ import com.google.inject.Inject;
 public class DefaultNetworkCrossingPointFinder implements NetworkCrossingPointFinder {
 	final private ScenarioExtent extent;
 	final private Network network;
+	
 	final private Map<String, TravelTime> travelTimes;
+	final private LinkTimingRegistry timingRegistry;
+	
 
 	@Inject
 	public DefaultNetworkCrossingPointFinder(ScenarioExtent extent, Network network,
-			Map<String, TravelTime> travelTimes) {
+			Map<String, TravelTime> travelTimes, LinkTimingRegistry timingRegistry) {
 		this.extent = extent;
 		this.network = network;
 		this.travelTimes = travelTimes;
+		this.timingRegistry = timingRegistry;
 	}
 
 	@Override
-	public List<NetworkCrossingPoint> findCrossingPoints(String mode, NetworkRoute route, double departureTime) {
+	public List<NetworkCrossingPoint> findCrossingPoints(Id<Person> personId, int legIndex, String mode, NetworkRoute route, double departureTime) {
 		List<NetworkCrossingPoint> crossingPoints = new LinkedList<>();
 
 		List<Id<Link>> fullRoute = new LinkedList<>();
@@ -52,6 +60,13 @@ public class DefaultNetworkCrossingPointFinder implements NetworkCrossingPointFi
 			boolean toIsInside = extent.isInside(link.getToNode().getCoord());
 
 			if (fromIsInside != toIsInside) {
+				Optional<LinkTimingData> timingData = timingRegistry.getTimingData(personId, legIndex, linkId);
+				
+				if (timingData.isPresent()) {
+					enterTime = timingData.get().enterTime;
+					leaveTime = timingData.get().leaveTime;
+				}
+				
 				crossingPoints.add(new NetworkCrossingPoint(index, link, enterTime, leaveTime, fromIsInside));
 			}
 

--- a/core/src/main/java/org/eqasim/core/scenario/cutter/population/trips/crossing/network/DefaultNetworkCrossingPointFinder.java
+++ b/core/src/main/java/org/eqasim/core/scenario/cutter/population/trips/crossing/network/DefaultNetworkCrossingPointFinder.java
@@ -20,10 +20,9 @@ import com.google.inject.Inject;
 public class DefaultNetworkCrossingPointFinder implements NetworkCrossingPointFinder {
 	final private ScenarioExtent extent;
 	final private Network network;
-	
+
 	final private Map<String, TravelTime> travelTimes;
 	final private LinkTimingRegistry timingRegistry;
-	
 
 	@Inject
 	public DefaultNetworkCrossingPointFinder(ScenarioExtent extent, Network network,
@@ -35,7 +34,8 @@ public class DefaultNetworkCrossingPointFinder implements NetworkCrossingPointFi
 	}
 
 	@Override
-	public List<NetworkCrossingPoint> findCrossingPoints(Id<Person> personId, int legIndex, String mode, NetworkRoute route, double departureTime) {
+	public List<NetworkCrossingPoint> findCrossingPoints(Id<Person> personId, int legIndex, String mode,
+			NetworkRoute route, double departureTime) {
 		List<NetworkCrossingPoint> crossingPoints = new LinkedList<>();
 
 		List<Id<Link>> fullRoute = new LinkedList<>();
@@ -61,12 +61,12 @@ public class DefaultNetworkCrossingPointFinder implements NetworkCrossingPointFi
 
 			if (fromIsInside != toIsInside) {
 				Optional<LinkTimingData> timingData = timingRegistry.getTimingData(personId, legIndex, linkId);
-				
+
 				if (timingData.isPresent()) {
 					enterTime = timingData.get().enterTime;
 					leaveTime = timingData.get().leaveTime;
 				}
-				
+
 				crossingPoints.add(new NetworkCrossingPoint(index, link, enterTime, leaveTime, fromIsInside));
 			}
 

--- a/core/src/main/java/org/eqasim/core/scenario/cutter/population/trips/crossing/network/NetworkCrossingPointFinder.java
+++ b/core/src/main/java/org/eqasim/core/scenario/cutter/population/trips/crossing/network/NetworkCrossingPointFinder.java
@@ -2,10 +2,13 @@ package org.eqasim.core.scenario.cutter.population.trips.crossing.network;
 
 import java.util.List;
 
+import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.population.Person;
 import org.matsim.core.population.routes.NetworkRoute;
 
 public interface NetworkCrossingPointFinder {
-	List<NetworkCrossingPoint> findCrossingPoints(String mode, NetworkRoute route, double departureTime);
+	List<NetworkCrossingPoint> findCrossingPoints(Id<Person> personId, int legIndex, String mode, NetworkRoute route,
+			double departureTime);
 
 	boolean isInside(NetworkRoute route);
 }

--- a/core/src/main/java/org/eqasim/core/scenario/cutter/population/trips/crossing/network/timing/LinkTimingData.java
+++ b/core/src/main/java/org/eqasim/core/scenario/cutter/population/trips/crossing/network/timing/LinkTimingData.java
@@ -1,0 +1,13 @@
+package org.eqasim.core.scenario.cutter.population.trips.crossing.network.timing;
+
+public class LinkTimingData {
+	public final double enterTime;
+	public final double leaveTime;
+	public final int legIndex;
+
+	LinkTimingData(double enterTime, double leaveTime, int legIndex) {
+		this.enterTime = enterTime;
+		this.leaveTime = leaveTime;
+		this.legIndex = legIndex;
+	}
+}

--- a/core/src/main/java/org/eqasim/core/scenario/cutter/population/trips/crossing/network/timing/LinkTimingRegistry.java
+++ b/core/src/main/java/org/eqasim/core/scenario/cutter/population/trips/crossing/network/timing/LinkTimingRegistry.java
@@ -1,0 +1,54 @@
+package org.eqasim.core.scenario.cutter.population.trips.crossing.network.timing;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.IdMap;
+import org.matsim.api.core.v01.network.Link;
+import org.matsim.api.core.v01.population.Person;
+
+public class LinkTimingRegistry {
+	private final IdMap<Person, Map<Id<Link>, List<LinkTimingData>>> data = new IdMap<>(Person.class);
+
+	public void register(Id<Person> personId, int legIndex, Id<Link> linkId, double enterTime, double leaveTime) {
+		data.computeIfAbsent(personId, key -> new HashMap<>()).computeIfAbsent(linkId, key -> new LinkedList<>())
+				.add(new LinkTimingData(enterTime, leaveTime, legIndex));
+	}
+
+	public Optional<LinkTimingData> getTimingData(Id<Person> personId, int legIndex, Id<Link> linkId) {
+		if (data.isEmpty()) {
+			return Optional.empty();
+		}
+
+		Map<Id<Link>, List<LinkTimingData>> personData = data.get(personId);
+
+		if (personData == null) {
+			return Optional.empty();
+		}
+
+		List<LinkTimingData> linkData = personData.get(linkId);
+
+		if (linkData == null) {
+			return Optional.empty();
+		}
+
+		Iterator<LinkTimingData> iterator = linkData.iterator();
+
+		while (iterator.hasNext()) {
+			LinkTimingData legData = iterator.next();
+
+			if (legData.legIndex == legIndex) {
+				return Optional.of(legData);
+			} else if (legData.legIndex > legIndex) {
+				break;
+			}
+		}
+
+		return Optional.empty();
+	}
+}

--- a/core/src/main/java/org/eqasim/core/scenario/cutter/population/trips/crossing/network/timing/LinkTimingRegistryHandler.java
+++ b/core/src/main/java/org/eqasim/core/scenario/cutter/population/trips/crossing/network/timing/LinkTimingRegistryHandler.java
@@ -1,0 +1,73 @@
+package org.eqasim.core.scenario.cutter.population.trips.crossing.network.timing;
+
+import org.eqasim.core.scenario.cutter.extent.ScenarioExtent;
+import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.IdMap;
+import org.matsim.api.core.v01.events.LinkEnterEvent;
+import org.matsim.api.core.v01.events.LinkLeaveEvent;
+import org.matsim.api.core.v01.events.PersonDepartureEvent;
+import org.matsim.api.core.v01.events.VehicleEntersTrafficEvent;
+import org.matsim.api.core.v01.events.VehicleLeavesTrafficEvent;
+import org.matsim.api.core.v01.events.handler.LinkEnterEventHandler;
+import org.matsim.api.core.v01.events.handler.LinkLeaveEventHandler;
+import org.matsim.api.core.v01.events.handler.PersonDepartureEventHandler;
+import org.matsim.api.core.v01.events.handler.VehicleEntersTrafficEventHandler;
+import org.matsim.api.core.v01.events.handler.VehicleLeavesTrafficEventHandler;
+import org.matsim.api.core.v01.network.Link;
+import org.matsim.api.core.v01.network.Network;
+import org.matsim.api.core.v01.population.Person;
+import org.matsim.vehicles.Vehicle;
+
+public class LinkTimingRegistryHandler implements PersonDepartureEventHandler, VehicleEntersTrafficEventHandler,
+		VehicleLeavesTrafficEventHandler, LinkEnterEventHandler, LinkLeaveEventHandler {
+	private final ScenarioExtent extent;
+	private final Network network;
+
+	private final LinkTimingRegistry timingRegistry;
+
+	private final IdMap<Person, Integer> tripIndices = new IdMap<>(Person.class);
+
+	private final IdMap<Person, LinkEnterEvent> enterEvents = new IdMap<>(Person.class);
+	private final IdMap<Vehicle, Id<Person>> driverRegistry = new IdMap<>(Vehicle.class);
+
+	public LinkTimingRegistryHandler(ScenarioExtent extent, Network network, LinkTimingRegistry timingRegistry) {
+		this.extent = extent;
+		this.network = network;
+		this.timingRegistry = timingRegistry;
+	}
+
+	@Override
+	public void handleEvent(VehicleEntersTrafficEvent event) {
+		driverRegistry.put(event.getVehicleId(), event.getPersonId());
+	}
+
+	@Override
+	public void handleEvent(VehicleLeavesTrafficEvent event) {
+		driverRegistry.remove(event.getVehicleId());
+	}
+
+	@Override
+	public void handleEvent(PersonDepartureEvent event) {
+		tripIndices.compute(event.getPersonId(), (id, value) -> value == null ? 0 : value + 1);
+	}
+
+	@Override
+	public void handleEvent(LinkEnterEvent event) {
+		Link link = network.getLinks().get(event.getLinkId());
+
+		if (extent.isInside(link.getFromNode().getCoord()) ^ extent.isInside(link.getToNode().getCoord())) {
+			enterEvents.put(driverRegistry.get(event.getVehicleId()), event);
+		}
+	}
+
+	@Override
+	public void handleEvent(LinkLeaveEvent event) {
+		Id<Person> driverId = driverRegistry.get(event.getVehicleId());
+		LinkEnterEvent enterEvent = enterEvents.remove(driverId);
+
+		if (enterEvent != null) {
+			timingRegistry.register(driverRegistry.get(event.getVehicleId()), tripIndices.get(driverId),
+					enterEvent.getLinkId(), enterEvent.getTime(), event.getTime());
+		}
+	}
+}

--- a/core/src/test/java/org/eqasim/scenario/cutter/population/trips/TestNetworkTripProcessor.java
+++ b/core/src/test/java/org/eqasim/scenario/cutter/population/trips/TestNetworkTripProcessor.java
@@ -1,5 +1,6 @@
 package org.eqasim.scenario.cutter.population.trips;
 
+import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
@@ -19,7 +20,9 @@ import org.matsim.api.core.v01.population.Leg;
 import org.matsim.api.core.v01.population.Person;
 import org.matsim.api.core.v01.population.PlanElement;
 import org.matsim.core.population.routes.NetworkRoute;
+import org.matsim.core.utils.misc.OptionalTime;
 import org.matsim.utils.objectattributes.attributable.Attributes;
+import org.mockito.Mockito;
 
 public class TestNetworkTripProcessor {
 	static private class NetworkFinderMock implements NetworkCrossingPointFinder {
@@ -65,11 +68,15 @@ public class TestNetworkTripProcessor {
 
 		Link linkA = createLinkMock("A");
 		Link linkB = createLinkMock("B");
+		
+		Leg mockLeg = Mockito.mock(Leg.class);
+		Mockito.when(mockLeg.getDepartureTime()).thenReturn(OptionalTime.defined(100.0));
+		Mockito.when(mockLeg.getMode()).thenReturn("car");
 
 		// No crossing points
 		finderMock = new NetworkFinderMock();
 		processor = new NetworkTripProcessor(finderMock, scenarioExtentMock);
-		result = processor.process(null, 0, "car", null, 100.0, false);
+		result = processor.process(null, 0, null, Arrays.asList(mockLeg), null);
 
 		Assert.assertEquals(1, result.size());
 		Assert.assertTrue(result.get(0) instanceof Leg);
@@ -80,7 +87,7 @@ public class TestNetworkTripProcessor {
 		finderMock.add(new NetworkCrossingPoint(0, linkA, 10.0, 20.0, true));
 
 		processor = new NetworkTripProcessor(finderMock, scenarioExtentMock);
-		result = processor.process(null, 0, "car", null, 100.0, false);
+		result = processor.process(null, 0, null, Arrays.asList(mockLeg), null);
 
 		Assert.assertEquals(3, result.size());
 		Assert.assertTrue(result.get(0) instanceof Leg);
@@ -97,7 +104,7 @@ public class TestNetworkTripProcessor {
 		finderMock.add(new NetworkCrossingPoint(0, linkA, 10.0, 20.0, false));
 
 		processor = new NetworkTripProcessor(finderMock, scenarioExtentMock);
-		result = processor.process(null, 0, "car", null, 100.0, false);
+		result = processor.process(null, 0, null, Arrays.asList(mockLeg), null);
 
 		Assert.assertEquals(3, result.size());
 		Assert.assertTrue(result.get(0) instanceof Leg);
@@ -115,7 +122,7 @@ public class TestNetworkTripProcessor {
 		finderMock.add(new NetworkCrossingPoint(0, linkB, 30.0, 40.0, false));
 
 		processor = new NetworkTripProcessor(finderMock, scenarioExtentMock);
-		result = processor.process(null, 0, "car", null, 100.0, false);
+		result = processor.process(null, 0, null, Arrays.asList(mockLeg), null);
 
 		Assert.assertEquals(5, result.size());
 		Assert.assertTrue(result.get(0) instanceof Leg);

--- a/core/src/test/java/org/eqasim/scenario/cutter/population/trips/TestNetworkTripProcessor.java
+++ b/core/src/test/java/org/eqasim/scenario/cutter/population/trips/TestNetworkTripProcessor.java
@@ -16,6 +16,7 @@ import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Node;
 import org.matsim.api.core.v01.population.Activity;
 import org.matsim.api.core.v01.population.Leg;
+import org.matsim.api.core.v01.population.Person;
 import org.matsim.api.core.v01.population.PlanElement;
 import org.matsim.core.population.routes.NetworkRoute;
 import org.matsim.utils.objectattributes.attributable.Attributes;
@@ -25,7 +26,7 @@ public class TestNetworkTripProcessor {
 		final private List<NetworkCrossingPoint> points = new LinkedList<>();
 
 		@Override
-		public List<NetworkCrossingPoint> findCrossingPoints(String mode, NetworkRoute route, double departureTime) {
+		public List<NetworkCrossingPoint> findCrossingPoints(Id<Person> personId, int legIndex, String mode, NetworkRoute route, double departureTime) {
 			return points;
 		}
 
@@ -68,7 +69,7 @@ public class TestNetworkTripProcessor {
 		// No crossing points
 		finderMock = new NetworkFinderMock();
 		processor = new NetworkTripProcessor(finderMock, scenarioExtentMock);
-		result = processor.process("car", null, 100.0, false);
+		result = processor.process(null, 0, "car", null, 100.0, false);
 
 		Assert.assertEquals(1, result.size());
 		Assert.assertTrue(result.get(0) instanceof Leg);
@@ -79,7 +80,7 @@ public class TestNetworkTripProcessor {
 		finderMock.add(new NetworkCrossingPoint(0, linkA, 10.0, 20.0, true));
 
 		processor = new NetworkTripProcessor(finderMock, scenarioExtentMock);
-		result = processor.process("car", null, 100.0, false);
+		result = processor.process(null, 0, "car", null, 100.0, false);
 
 		Assert.assertEquals(3, result.size());
 		Assert.assertTrue(result.get(0) instanceof Leg);
@@ -96,7 +97,7 @@ public class TestNetworkTripProcessor {
 		finderMock.add(new NetworkCrossingPoint(0, linkA, 10.0, 20.0, false));
 
 		processor = new NetworkTripProcessor(finderMock, scenarioExtentMock);
-		result = processor.process("car", null, 100.0, false);
+		result = processor.process(null, 0, "car", null, 100.0, false);
 
 		Assert.assertEquals(3, result.size());
 		Assert.assertTrue(result.get(0) instanceof Leg);
@@ -114,7 +115,7 @@ public class TestNetworkTripProcessor {
 		finderMock.add(new NetworkCrossingPoint(0, linkB, 30.0, 40.0, false));
 
 		processor = new NetworkTripProcessor(finderMock, scenarioExtentMock);
-		result = processor.process("car", null, 100.0, false);
+		result = processor.process(null, 0, "car", null, 100.0, false);
 
 		Assert.assertEquals(5, result.size());
 		Assert.assertTrue(result.get(0) instanceof Leg);

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,13 @@
 
 	<dependencies>
 		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<version>3.8.0</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
 			<groupId>com.fasterxml.jackson.dataformat</groupId>
 			<artifactId>jackson-dataformat-csv</artifactId>
 			<version>2.10.0</version>


### PR DESCRIPTION
This PR makes it possible to optionally process events from a previous simulation during the cutting process. The event information is used for two aspects:

1. Routing of trips through the network is performed based on recorded travel times. Travel time bins are defined based on the `travelTimeCalculator` group in the configuration file
2. Crossing points for network-based modes are obtained from the `LinkEnter`/`LinkLeave` events of the vehicles, i.e. delays along the plans will be considered in with this approach