### PR TITLE
Change routing parameter for waiting time to -1 for Ile-de-France

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ included in the (note yet determined) next version number.
 
 **Development version**
 
+- Set routing parameter for waiting time in Île-de-France to -1.0
 - Allow cutter to process events to (1) perform routing based on recorded travel time, and (2) find crossing points based on the actual link enter/leave times of a previous simulation
 - Simplify cutting by introducing `--plans-path` option which is interpreted as relative to CWD
 - Location assignment functionality for scenario preparation functionality has been removed. A more advanced is used in the upstream Python pipelines for scenario generation.

--- a/ile_de_france/src/main/java/org/eqasim/ile_de_france/scenario/RunAdaptConfig.java
+++ b/ile_de_france/src/main/java/org/eqasim/ile_de_france/scenario/RunAdaptConfig.java
@@ -8,6 +8,7 @@ import org.matsim.api.core.v01.TransportMode;
 import org.matsim.contribs.discrete_mode_choice.modules.config.DiscreteModeChoiceConfigGroup;
 import org.matsim.core.config.CommandLine.ConfigurationException;
 import org.matsim.core.config.Config;
+import org.matsim.core.config.groups.PlanCalcScoreConfigGroup;
 
 public class RunAdaptConfig {
 	static public void main(String[] args) throws ConfigurationException {
@@ -28,6 +29,11 @@ public class RunAdaptConfig {
 				.get(DiscreteModeChoiceConfigGroup.GROUP_NAME);
 
 		dmcConfig.setModeAvailability(IDFModeChoiceModule.MODE_AVAILABILITY_NAME);
+		
+		// Potentially should be moved to the general GenerateConfig class. Wait time
+		// should matter for routing!
+		PlanCalcScoreConfigGroup scoringConfig = config.planCalcScore();
+		scoringConfig.setMarginalUtlOfWaitingPt_utils_hr(-1.0);
 
 		// Calibration results for 5%
 


### PR DESCRIPTION
Before, waiting time was not considered in routing as described in #65. Changing this for Ile-de-France for the time being to not mess up other scenarios.