### PR TITLE
fix: using the person analysis filter in PublicTransportLegReaderFromPopulation

### DIFF
--- a/core/src/main/java/org/eqasim/core/analysis/pt/PublicTransportLegReaderFromPopulation.java
+++ b/core/src/main/java/org/eqasim/core/analysis/pt/PublicTransportLegReaderFromPopulation.java
@@ -38,7 +38,10 @@ public class PublicTransportLegReaderFromPopulation {
     }
 
     public Collection<PublicTransportLegItem> readPublicTransportLegs(Population population) {
-        return population.getPersons().values().stream().flatMap(person -> getPublicTransportLegs(person).stream()).collect(Collectors.toList());
+        return population.getPersons().values().stream()
+                .filter(person -> personAnalysisFilter.analyzePerson(person.getId()))
+                .flatMap(person -> getPublicTransportLegs(person).stream())
+                .collect(Collectors.toList());
     }
 
     public Collection<PublicTransportLegItem> getPublicTransportLegs(Person person) {


### PR DESCRIPTION
I had forgot to use the person analysis filter object in the PublicTransportLegReaderFromPopulation. This commit fixes it.