### PR TITLE
fix: optional eqasim termination

### DIFF
--- a/core/src/main/java/org/eqasim/core/scenario/routing/RunPopulationRouting.java
+++ b/core/src/main/java/org/eqasim/core/scenario/routing/RunPopulationRouting.java
@@ -7,6 +7,7 @@ import java.util.Set;
 
 import org.eqasim.core.misc.InjectorBuilder;
 import org.eqasim.core.simulation.EqasimConfigurator;
+import org.eqasim.core.simulation.termination.EqasimTerminationConfigGroup;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.Scenario;
 import org.matsim.api.core.v01.population.Leg;
@@ -39,6 +40,8 @@ public class RunPopulationRouting {
 
 		EqasimConfigurator configurator = new EqasimConfigurator();
 		Config config = ConfigUtils.loadConfig(cmd.getOptionStrict("config-path"), configurator.getConfigGroups());
+        config.getModules().remove(EqasimTerminationConfigGroup.GROUP_NAME);
+		configurator.addOptionalConfigGroups(config);
 		cmd.applyConfiguration(config);
 		config.strategy().clearStrategySettings();
 

--- a/core/src/main/java/org/eqasim/core/simulation/EqasimConfigurator.java
+++ b/core/src/main/java/org/eqasim/core/simulation/EqasimConfigurator.java
@@ -16,6 +16,7 @@ import org.eqasim.core.components.traffic.EqasimTrafficQSimModule;
 import org.eqasim.core.components.transit.EqasimTransitModule;
 import org.eqasim.core.components.transit.EqasimTransitQSimModule;
 import org.eqasim.core.simulation.mode_choice.epsilon.EpsilonModule;
+import org.eqasim.core.simulation.termination.EqasimTerminationConfigGroup;
 import org.eqasim.core.simulation.termination.EqasimTerminationModule;
 import org.eqasim.core.simulation.termination.mode_share.ModeShareModule;
 import org.matsim.api.core.v01.Id;
@@ -64,7 +65,6 @@ public class EqasimConfigurator {
 				new DiscreteModeChoiceModule(), //
 				new EqasimComponentsModule(), //
 				new EpsilonModule(), //
-				new EqasimTerminationModule(), //
 				new ModeShareModule() //
 		));
 
@@ -80,6 +80,7 @@ public class EqasimConfigurator {
 						DvrpQSimComponents.activateAllModes((MultiModal<?>) controller.getConfig().getModules().get(MultiModeDrtConfigGroup.GROUP_NAME)).configure(components)));
 
 		this.registerOptionalConfigGroup(new DvrpConfigGroup(), Collections.singleton(new DvrpModule()));
+		this.registerOptionalConfigGroup(new EqasimTerminationConfigGroup(), Collections.singleton(new EqasimTerminationModule()));
 	}
 
 	public ConfigGroup[] getConfigGroups() {


### PR DESCRIPTION
I am in the process of updating the ile-de-france repo to use the latest version of Eqasim and I noticed a bug when running the RunPopulationRouting script during the generation of a synthetic population.
The EqasimConfigurator always adds an EqasimTerminationModule, which then requires an EqasimTerminationConfigGroup. This can lead to an error if the EqasimTerminationConfigGroup is there ithe xml but the object was not passed to the ConfigUtils.loadConfig. This will result in an error at the cast inside the EqasimTerminationConfigGroup::getOrCreate method.

To avoid forgetting to pass the EqasimTerminationConfigGroup object, this PR adds it in the EqasimConfigurator as an optional config group, in order to maintain backward compatibility. 

This still doesn't solve the problem for the synthetic population generation, the config file passed to the RunPopulationRouting script is generated by RunGenerateConfig which adds the EqasimTerminationConfigGroup by default.  In order to solve this, this PR makes sure this config group is removed from the config right after loading.