### PR TITLE
fix: optional eqasim termination (#204)

### DIFF
--- a/core/src/main/java/org/eqasim/core/scenario/routing/RunPopulationRouting.java
+++ b/core/src/main/java/org/eqasim/core/scenario/routing/RunPopulationRouting.java
@@ -7,6 +7,7 @@ import java.util.Set;
 
 import org.eqasim.core.misc.InjectorBuilder;
 import org.eqasim.core.simulation.EqasimConfigurator;
+import org.eqasim.core.simulation.termination.EqasimTerminationConfigGroup;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.Scenario;
 import org.matsim.api.core.v01.population.Leg;
@@ -39,6 +40,8 @@ public class RunPopulationRouting {
 
 		EqasimConfigurator configurator = new EqasimConfigurator();
 		Config config = ConfigUtils.loadConfig(cmd.getOptionStrict("config-path"), configurator.getConfigGroups());
+        config.getModules().remove(EqasimTerminationConfigGroup.GROUP_NAME);
+		configurator.addOptionalConfigGroups(config);
 		cmd.applyConfiguration(config);
 		config.strategy().clearStrategySettings();
 

--- a/core/src/main/java/org/eqasim/core/simulation/EqasimConfigurator.java
+++ b/core/src/main/java/org/eqasim/core/simulation/EqasimConfigurator.java
@@ -16,6 +16,7 @@ import org.eqasim.core.components.traffic.EqasimTrafficQSimModule;
 import org.eqasim.core.components.transit.EqasimTransitModule;
 import org.eqasim.core.components.transit.EqasimTransitQSimModule;
 import org.eqasim.core.simulation.mode_choice.epsilon.EpsilonModule;
+import org.eqasim.core.simulation.termination.EqasimTerminationConfigGroup;
 import org.eqasim.core.simulation.termination.EqasimTerminationModule;
 import org.eqasim.core.simulation.termination.mode_share.ModeShareModule;
 import org.matsim.api.core.v01.Id;
@@ -63,9 +64,7 @@ public class EqasimConfigurator {
 				new EqasimTransitModule(), //
 				new DiscreteModeChoiceModule(), //
 				new EqasimComponentsModule(), //
-				new EpsilonModule(), //
-				new EqasimTerminationModule(), //
-				new ModeShareModule() //
+				new EpsilonModule() //
 		));
 
 		qsimModules.addAll(Arrays.asList( //
@@ -80,6 +79,7 @@ public class EqasimConfigurator {
 						DvrpQSimComponents.activateAllModes((MultiModal<?>) controller.getConfig().getModules().get(MultiModeDrtConfigGroup.GROUP_NAME)).configure(components)));
 
 		this.registerOptionalConfigGroup(new DvrpConfigGroup(), Collections.singleton(new DvrpModule()));
+		this.registerOptionalConfigGroup(new EqasimTerminationConfigGroup(), List.of(new EqasimTerminationModule(), new ModeShareModule()));
 	}
 
 	public ConfigGroup[] getConfigGroups() {

--- a/ile_de_france/pom.xml
+++ b/ile_de_france/pom.xml
@@ -38,6 +38,12 @@
 									<transformers>
 										<transformer
 											implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+										<transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+											<manifestEntries>
+												<Implementation-Vendor>Eqasim</Implementation-Vendor>
+												<Implementation-Version>${parent.groupId}</Implementation-Version>
+											</manifestEntries>
+										</transformer>
 									</transformers>
 									<filters>
 										<filter>

--- a/ile_de_france/src/main/java/org/eqasim/ile_de_france/RunSimulation.java
+++ b/ile_de_france/src/main/java/org/eqasim/ile_de_france/RunSimulation.java
@@ -20,6 +20,7 @@ public class RunSimulation {
 
 		IDFConfigurator configurator = new IDFConfigurator();
 		Config config = ConfigUtils.loadConfig(cmd.getOptionStrict("config-path"), configurator.getConfigGroups());
+		configurator.addOptionalConfigGroups(config);
 		cmd.applyConfiguration(config);
 
 		Scenario scenario = ScenarioUtils.createScenario(config);

--- a/los_angeles/src/main/java/org/eqasim/los_angeles/RunSimulation.java
+++ b/los_angeles/src/main/java/org/eqasim/los_angeles/RunSimulation.java
@@ -23,6 +23,7 @@ public class RunSimulation {
 
 		EqasimConfigurator configurator = new EqasimConfigurator();
 		Config config = ConfigUtils.loadConfig(cmd.getOptionStrict("config-path"), configurator.getConfigGroups());
+		configurator.addOptionalConfigGroups(config);
 		EqasimConfigGroup.get(config).setAnalysisInterval(5);
 		EqasimConfigGroup.get(config).setDistanceUnit(DistanceUnit.foot);
 		cmd.applyConfiguration(config);

--- a/san_francisco/src/main/java/org/eqasim/san_francisco/RunSimulation.java
+++ b/san_francisco/src/main/java/org/eqasim/san_francisco/RunSimulation.java
@@ -23,6 +23,7 @@ public class RunSimulation {
 
 		EqasimConfigurator configurator = new EqasimConfigurator();
 		Config config = ConfigUtils.loadConfig(cmd.getOptionStrict("config-path"), configurator.getConfigGroups());
+		configurator.addOptionalConfigGroups(config);
 		EqasimConfigGroup.get(config).setAnalysisInterval(5);
 		EqasimConfigGroup.get(config).setDistanceUnit(DistanceUnit.foot);
 		cmd.applyConfiguration(config);

--- a/sao_paulo/src/main/java/org/eqasim/sao_paulo/RunSimulation.java
+++ b/sao_paulo/src/main/java/org/eqasim/sao_paulo/RunSimulation.java
@@ -29,6 +29,7 @@ public class RunSimulation {
 
 		EqasimConfigurator configurator = new EqasimConfigurator();
 		Config config = ConfigUtils.loadConfig(cmd.getOptionStrict("config-path"), configurator.getConfigGroups());
+		configurator.addOptionalConfigGroups(config);
 		EqasimConfigGroup.get(config).setAnalysisInterval(1);
 		cmd.applyConfiguration(config);
 

--- a/switzerland/src/main/java/org/eqasim/switzerland/RunSimulation.java
+++ b/switzerland/src/main/java/org/eqasim/switzerland/RunSimulation.java
@@ -20,6 +20,7 @@ public class RunSimulation {
 
 		SwitzerlandConfigurator configurator = new SwitzerlandConfigurator();
 		Config config = ConfigUtils.loadConfig(cmd.getOptionStrict("config-path"), configurator.getConfigGroups());
+		configurator.addOptionalConfigGroups(config);
 		cmd.applyConfiguration(config);
 
 		Scenario scenario = ScenarioUtils.createScenario(config);


### PR DESCRIPTION
* feat:  Optional EqasimTermination module

* fix: making sure no EqasimTerminationModule is instantiated during RunPopulationRouting

* fix: ModeShareModule is part of the Eqasim Termination

* feat: optional config groups added in all run scripts

* fix: imageio requiring vendor name and version in some settings