### PR TITLE
DrtModeAvailabilityWrapper and FeederDrtModeAvailabilityWrapper are now compatible with non-drt simulations

### DIFF
--- a/core/src/main/java/org/eqasim/core/simulation/modes/drt/mode_choice/DrtModeAvailabilityWrapper.java
+++ b/core/src/main/java/org/eqasim/core/simulation/modes/drt/mode_choice/DrtModeAvailabilityWrapper.java
@@ -4,16 +4,26 @@ import org.matsim.api.core.v01.population.Person;
 import org.matsim.contrib.drt.run.MultiModeDrtConfigGroup;
 import org.matsim.contribs.discrete_mode_choice.model.DiscreteModeChoiceTrip;
 import org.matsim.contribs.discrete_mode_choice.model.mode_availability.ModeAvailability;
+import org.matsim.core.config.Config;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 public class DrtModeAvailabilityWrapper implements ModeAvailability {
     private final Collection<String> drtModes;
     private final ModeAvailability delegate;
 
+    public DrtModeAvailabilityWrapper(Config config, ModeAvailability delegate) {
+        this((MultiModeDrtConfigGroup) config.getModules().get(MultiModeDrtConfigGroup.GROUP_NAME), delegate);
+    }
+
     public DrtModeAvailabilityWrapper(MultiModeDrtConfigGroup multiModeDrtConfigGroup, ModeAvailability delegate) {
-        this.drtModes = multiModeDrtConfigGroup.modes().toList();
+        if(multiModeDrtConfigGroup != null) {
+            this.drtModes = multiModeDrtConfigGroup.modes().toList();
+        } else {
+            this.drtModes = Collections.emptyList();
+        }
         this.delegate = delegate;
     }
 

--- a/core/src/main/java/org/eqasim/core/simulation/modes/feeder_drt/mode_choice/FeederDrtModeAvailabilityWrapper.java
+++ b/core/src/main/java/org/eqasim/core/simulation/modes/feeder_drt/mode_choice/FeederDrtModeAvailabilityWrapper.java
@@ -1,25 +1,43 @@
 package org.eqasim.core.simulation.modes.feeder_drt.mode_choice;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.eqasim.core.simulation.modes.feeder_drt.config.MultiModeFeederDrtConfigGroup;
 import org.matsim.api.core.v01.population.Person;
 import org.matsim.contrib.drt.run.MultiModeDrtConfigGroup;
 import org.matsim.contribs.discrete_mode_choice.model.DiscreteModeChoiceTrip;
 import org.matsim.contribs.discrete_mode_choice.model.mode_availability.ModeAvailability;
+import org.matsim.core.config.Config;
 
-import java.util.Collection;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 public class FeederDrtModeAvailabilityWrapper implements ModeAvailability {
+    private final static Logger logger = LogManager.getLogger(FeederDrtModeAvailabilityWrapper.class);
     private final Set<String> extraModes;
     private final ModeAvailability delegate;
 
+    public FeederDrtModeAvailabilityWrapper(Config config, ModeAvailability delegate) {
+        this((MultiModeDrtConfigGroup) config.getModules().get(MultiModeDrtConfigGroup.GROUP_NAME), (MultiModeFeederDrtConfigGroup) config.getModules().get(MultiModeFeederDrtConfigGroup.GROUP_NAME), delegate);
+    }
+
     public FeederDrtModeAvailabilityWrapper(MultiModeDrtConfigGroup multiModeDrtConfigGroup, MultiModeFeederDrtConfigGroup multiModeFeederDrtConfigGroup, ModeAvailability delegate) {
         this.delegate = delegate;
-        this.extraModes = multiModeFeederDrtConfigGroup.modes().collect(Collectors.toSet());
-        Collection<String> coveredDrtModes = multiModeFeederDrtConfigGroup.getModalElements().stream().map(cfg -> cfg.accessEgressModeName).toList();
-        this.extraModes.addAll(multiModeDrtConfigGroup.modes().filter(mode -> !coveredDrtModes.contains(mode)).toList());
+        Collection<String> coveredDrtModes;
+        if(multiModeFeederDrtConfigGroup == null) {
+            this.extraModes = new HashSet<>();
+            coveredDrtModes = Collections.emptyList();
+        } else {
+            this.extraModes = multiModeFeederDrtConfigGroup.modes().collect(Collectors.toSet());
+            coveredDrtModes = multiModeFeederDrtConfigGroup.getModalElements().stream().map(cfg -> cfg.accessEgressModeName).toList();
+        }
+        if(multiModeDrtConfigGroup == null) {
+            if(multiModeFeederDrtConfigGroup != null) {
+                logger.warn(String.format("A %s config was supplied but a %s was not, DRT modes not covered by a feeder mode will not be considered", MultiModeFeederDrtConfigGroup.GROUP_NAME, MultiModeDrtConfigGroup.GROUP_NAME));
+            }
+        } else {
+            this.extraModes.addAll(multiModeDrtConfigGroup.modes().filter(mode -> !coveredDrtModes.contains(mode)).toList());
+        }
     }
 
     @Override


### PR DESCRIPTION
The DrtModeAvailabilityWrapper and FeederDrtModeAvailaibilityWrapper offer the functionality of detecting DRT and Feeder DRT modes in the config and adding them as available modes for users, to quickly deploy these modes on the basis of an existing ModeAvailability. 
However the first implementation was not compatible with config files that do not contain these modes, always requiring a mutliModeDrt and a multiModeFeederDrt to work. This PR fixes this by allowing these wrappers to handle null values for the config groups. 
The FeederDrtModeAvailaibilityWrapper is now used in the test instead of explictly passing a list of extra modes to the runMelunSimulation method.