### PR TITLE
fix: move emission tests to core

### DIFF
--- a/core/src/main/java/org/eqasim/core/components/emissions/RunComputeEmissionsEvents.java
+++ b/core/src/main/java/org/eqasim/core/components/emissions/RunComputeEmissionsEvents.java
@@ -1,0 +1,113 @@
+package org.eqasim.core.components.emissions;
+
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.eqasim.core.misc.ClassUtils;
+import org.eqasim.core.simulation.EqasimConfigurator;
+import org.matsim.api.core.v01.Scenario;
+import org.matsim.api.core.v01.network.Link;
+import org.matsim.api.core.v01.network.Network;
+import org.matsim.contrib.emissions.EmissionModule;
+import org.matsim.contrib.emissions.OsmHbefaMapping;
+import org.matsim.contrib.emissions.utils.EmissionsConfigGroup;
+import org.matsim.core.api.experimental.events.EventsManager;
+import org.matsim.core.config.CommandLine;
+import org.matsim.core.config.Config;
+import org.matsim.core.config.ConfigGroup;
+import org.matsim.core.config.ConfigUtils;
+import org.matsim.core.controler.AbstractModule;
+import org.matsim.core.controler.Injector;
+import org.matsim.core.events.EventsUtils;
+import org.matsim.core.events.MatsimEventsReader;
+import org.matsim.core.events.algorithms.EventWriterXML;
+import org.matsim.core.network.NetworkUtils;
+import org.matsim.core.scenario.ScenarioUtils;
+
+public class RunComputeEmissionsEvents {
+
+    public static void main(String[] args) throws CommandLine.ConfigurationException {
+
+        CommandLine cmd = new CommandLine.Builder(args) //
+                .requireOptions("config-path", "hbefa-cold-avg", "hbefa-hot-avg") //
+                .allowOptions("hbefa-cold-detailed", "hbefa-hot-detailed", "configurator-class")
+                .build();
+        
+        EqasimConfigurator configurator;
+        if(cmd.hasOption("configurator-class")) {
+            configurator = ClassUtils.getInstanceOfClassExtendingOtherClass(cmd.getOptionStrict("configurator-class"), EqasimConfigurator.class);
+        } else {
+            configurator = new EqasimConfigurator();
+        }
+
+        ConfigGroup[] configGroups = ArrayUtils.addAll(configurator.getConfigGroups(), new EmissionsConfigGroup());
+
+        Config config = ConfigUtils.loadConfig(cmd.getOptionStrict("config-path"), configGroups);
+        cmd.applyConfiguration(config);
+
+        EmissionsConfigGroup emissionsConfig = (EmissionsConfigGroup) config.getModules().get("emissions");
+        emissionsConfig.setHbefaVehicleDescriptionSource(EmissionsConfigGroup.HbefaVehicleDescriptionSource.asEngineInformationAttributes);
+        emissionsConfig.setDetailedVsAverageLookupBehavior(
+                EmissionsConfigGroup.DetailedVsAverageLookupBehavior.tryDetailedThenTechnologyAverageThenAverageTable);
+        emissionsConfig.setNonScenarioVehicles(EmissionsConfigGroup.NonScenarioVehicles.abort);
+        emissionsConfig.setHbefaTableConsistencyCheckingLevel(EmissionsConfigGroup.HbefaTableConsistencyCheckingLevel.consistent);
+
+        emissionsConfig.setAverageColdEmissionFactorsFile(cmd.getOptionStrict("hbefa-cold-avg"));
+        emissionsConfig.setAverageWarmEmissionFactorsFile(cmd.getOptionStrict("hbefa-hot-avg"));
+
+        if (cmd.hasOption("hbefa-cold-detailed") && cmd.hasOption("hbefa-hot-detailed")) {
+            emissionsConfig.setDetailedColdEmissionFactorsFile(cmd.getOptionStrict("hbefa-cold-detailed"));
+            emissionsConfig.setDetailedWarmEmissionFactorsFile(cmd.getOptionStrict("hbefa-hot-detailed"));
+        }
+
+        Scenario scenario = ScenarioUtils.createScenario(config);
+        ScenarioUtils.loadScenario(scenario);
+
+        OsmHbefaMapping osmHbefaMapping = OsmHbefaMapping.build();
+        Network network = scenario.getNetwork();
+        // if the network is from pt2matsim it might not have "type" but "osm:way:highway" attribute instead
+        for (Link link: network.getLinks().values()) {
+            String roadTypeAttribute = NetworkUtils.getType(link);
+            String osmRoadTypeAttribute = (String) link.getAttributes().getAttribute("osm:way:highway");
+            if (StringUtils.isBlank(roadTypeAttribute)) {
+                if (!StringUtils.isBlank(osmRoadTypeAttribute)) {
+                    NetworkUtils.setType(link, osmRoadTypeAttribute);
+                }
+                else { // not a road (railway for example)
+                    NetworkUtils.setType(link, "unclassified");
+                }
+            }
+            // '_link' types are not defined in the OSM mapping, set t undefined
+            if (NetworkUtils.getType(link).contains("_link")) {
+                NetworkUtils.setType(link, "unclassified");
+            }
+            if (NetworkUtils.getType(link).equals("living_street")) {
+                NetworkUtils.setType(link, "living");
+            }
+        }
+        osmHbefaMapping.addHbefaMappings(network);
+
+        EventsManager eventsManager = EventsUtils.createEventsManager();
+        AbstractModule module = new AbstractModule(){
+            @Override
+            public void install(){
+                bind( Scenario.class ).toInstance( scenario );
+                bind( EventsManager.class ).toInstance( eventsManager );
+                bind( EmissionModule.class ) ;
+            }
+        };
+
+        com.google.inject.Injector injector = Injector.createInjector(config, module );
+        EmissionModule emissionModule = injector.getInstance(EmissionModule.class);
+
+        final String outputDirectory = scenario.getConfig().controler().getOutputDirectory() + "/";
+        EventWriterXML emissionEventWriter = new EventWriterXML( outputDirectory + "output_emissions_events.xml.gz" ) ;
+        emissionModule.getEmissionEventsManager().addHandler(emissionEventWriter);
+
+        eventsManager.initProcessing();
+        MatsimEventsReader matsimEventsReader = new MatsimEventsReader(eventsManager);
+        matsimEventsReader.readFile( outputDirectory + "./output_events.xml.gz" );
+        eventsManager.finishProcessing();
+
+        emissionEventWriter.closeFile();
+    }
+}

--- a/core/src/main/java/org/eqasim/core/components/emissions/RunComputeEmissionsGrid.java
+++ b/core/src/main/java/org/eqasim/core/components/emissions/RunComputeEmissionsGrid.java
@@ -1,0 +1,64 @@
+package org.eqasim.core.components.emissions;
+
+import org.apache.commons.lang3.ArrayUtils;
+import org.eqasim.core.misc.ClassUtils;
+import org.eqasim.core.simulation.EqasimConfigurator;
+import org.locationtech.jts.geom.Geometry;
+import org.matsim.api.core.v01.network.Network;
+import org.matsim.contrib.emissions.analysis.EmissionGridAnalyzer;
+import org.matsim.contrib.emissions.utils.EmissionsConfigGroup;
+import org.matsim.core.config.CommandLine;
+import org.matsim.core.config.Config;
+import org.matsim.core.config.ConfigGroup;
+import org.matsim.core.config.ConfigUtils;
+import org.matsim.core.network.NetworkUtils;
+import org.matsim.core.network.io.MatsimNetworkReader;
+import org.matsim.core.utils.gis.ShapeFileReader;
+import org.opengis.feature.simple.SimpleFeature;
+
+public class RunComputeEmissionsGrid {
+
+    public static void main(String[] args) throws CommandLine.ConfigurationException {
+
+        CommandLine cmd = new CommandLine.Builder(args) //
+                .requireOptions("config-path", "domain-shp-path") //
+                .allowOptions("scale-factor", "grid-size", "smooth-radius", "time-bin-size", "configurator-class")
+                .build();
+        
+        EqasimConfigurator configurator;
+        if(cmd.hasOption("configurator-class")) {
+            configurator = ClassUtils.getInstanceOfClassExtendingOtherClass(cmd.getOptionStrict("configurator-class"), EqasimConfigurator.class);
+        } else {
+            configurator = new EqasimConfigurator();
+        }
+
+        ConfigGroup[] configGroups = ArrayUtils.addAll(configurator.getConfigGroups(), new EmissionsConfigGroup());
+
+        Config config = ConfigUtils.loadConfig(cmd.getOptionStrict("config-path"), configGroups);
+        cmd.applyConfiguration(config);
+        final String outputDirectory = config.controler().getOutputDirectory() + "/";
+
+        Network network = NetworkUtils.createNetwork();
+        new MatsimNetworkReader(network).readFile(outputDirectory + "output_network.xml.gz");
+
+        SimpleFeature analysisFeature = ShapeFileReader.getAllFeatures(cmd.getOptionStrict("domain-shp-path")).iterator().next();
+        Geometry analysisGeometry = (Geometry) analysisFeature.getDefaultGeometry();
+
+        double scaleFactor = Double.parseDouble(cmd.getOption("scale-factor").orElse("1.0"));
+        int gridSize = Integer.parseInt(cmd.getOption("grid-size").orElse("25"));
+        int smoothRadius = Integer.parseInt(cmd.getOption("smooth-radius").orElse("50"));
+        int timeBinSize = Integer.parseInt(cmd.getOption("time-bin-size").orElse("3600"));
+
+        new EmissionGridAnalyzer.Builder() //
+                .withBounds(analysisGeometry) //
+                .withNetwork(network) //
+                .withCountScaleFactor(scaleFactor) //
+                .withGridSize(gridSize) //
+                .withSmoothingRadius(smoothRadius) //
+                .withTimeBinSize(timeBinSize) //
+                .withGridType(EmissionGridAnalyzer.GridType.Square) //
+                .build() //
+                .processToJsonFile(outputDirectory + "output_emissions_events.xml.gz", outputDirectory + "output_emissions.json");
+    }
+
+}

--- a/core/src/main/java/org/eqasim/core/components/emissions/RunExportEmissionsNetwork.java
+++ b/core/src/main/java/org/eqasim/core/components/emissions/RunExportEmissionsNetwork.java
@@ -1,0 +1,124 @@
+package org.eqasim.core.components.emissions;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.lang3.ArrayUtils;
+import org.eqasim.core.misc.ClassUtils;
+import org.eqasim.core.simulation.EqasimConfigurator;
+import org.locationtech.jts.geom.Coordinate;
+import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.network.Link;
+import org.matsim.api.core.v01.network.Network;
+import org.matsim.contrib.analysis.time.TimeBinMap;
+import org.matsim.contrib.emissions.Pollutant;
+import org.matsim.contrib.emissions.analysis.EmissionsByPollutant;
+import org.matsim.contrib.emissions.analysis.EmissionsOnLinkEventHandler;
+import org.matsim.contrib.emissions.events.EmissionEventsReader;
+import org.matsim.contrib.emissions.utils.EmissionsConfigGroup;
+import org.matsim.core.api.experimental.events.EventsManager;
+import org.matsim.core.config.CommandLine;
+import org.matsim.core.config.Config;
+import org.matsim.core.config.ConfigGroup;
+import org.matsim.core.config.ConfigUtils;
+import org.matsim.core.events.EventsUtils;
+import org.matsim.core.network.NetworkUtils;
+import org.matsim.core.network.io.MatsimNetworkReader;
+import org.matsim.core.utils.geometry.geotools.MGC;
+import org.matsim.core.utils.gis.PolylineFeatureFactory;
+import org.matsim.core.utils.gis.ShapeFileWriter;
+import org.opengis.feature.simple.SimpleFeature;
+
+public class RunExportEmissionsNetwork {
+
+    public static void main(String[] args) throws CommandLine.ConfigurationException {
+
+        CommandLine cmd = new CommandLine.Builder(args) //
+                .requireOptions("config-path") //
+                .allowOptions("time-bin-size")
+                .allowOptions("pollutants", "configurator-class")
+                .build();
+
+        EqasimConfigurator configurator;
+        if(cmd.hasOption("configurator-class")) {
+            configurator = ClassUtils.getInstanceOfClassExtendingOtherClass(cmd.getOptionStrict("configurator-class"), EqasimConfigurator.class);
+        } else {
+            configurator = new EqasimConfigurator();
+        }
+        
+        ConfigGroup[] configGroups = ArrayUtils.addAll(configurator.getConfigGroups(), new EmissionsConfigGroup());
+
+        Config config = ConfigUtils.loadConfig(cmd.getOptionStrict("config-path"), configGroups);
+        cmd.applyConfiguration(config);
+        final String outputDirectory = config.controler().getOutputDirectory() + "/";
+
+        int timeBinSize = Integer.parseInt(cmd.getOption("time-bin-size").orElse("3600"));
+
+        String[] wanted_pollutants = cmd.getOption("pollutants").orElse("PM,CO,NOx").split(",");
+
+        EventsManager eventsManager = EventsUtils.createEventsManager();
+        EmissionsOnLinkEventHandler handler = new EmissionsOnLinkEventHandler(timeBinSize);
+
+        EmissionEventsReader eventsReader = new EmissionEventsReader(eventsManager);
+
+        eventsManager.addHandler(handler);
+        eventsManager.initProcessing();
+        eventsReader.readFile(outputDirectory + "output_emissions_events.xml.gz");
+        eventsManager.finishProcessing();
+
+        Network network = NetworkUtils.createNetwork();
+        new MatsimNetworkReader(network).readFile(outputDirectory + "output_network.xml.gz");
+        Map<Id<Link>, ? extends Link> links = network.getLinks();
+        TimeBinMap<Map<Id<Link>, EmissionsByPollutant>> res = handler.getTimeBins();
+        Collection<SimpleFeature> features = new LinkedList<>();
+        PolylineFeatureFactory.Builder builder = new PolylineFeatureFactory.Builder() //
+                .setCrs(MGC.getCRS("epsg:2154")).setName("Emissions") //
+                .addAttribute("link", String.class) //
+                .addAttribute("time", Integer.class);
+        for (String pollutant: wanted_pollutants) {
+            builder.addAttribute(pollutant, Double.class);
+        }
+        PolylineFeatureFactory linkFactory = builder.create();
+
+        for (TimeBinMap.TimeBin<Map<Id<Link>, EmissionsByPollutant>> timeBin : res.getTimeBins()) {
+            int startTime = (int) timeBin.getStartTime();
+            Map<Id<Link>, EmissionsByPollutant> map = timeBin.getValue();
+            for (Map.Entry<Id<Link>, EmissionsByPollutant> entry : map.entrySet()) {
+                Id<Link> link_id = entry.getKey();
+                Link link = links.get(link_id);
+                Coordinate fromCoordinate = new Coordinate(link.getFromNode().getCoord().getX(),
+                        link.getFromNode().getCoord().getY());
+                Coordinate toCoordinate = new Coordinate(link.getToNode().getCoord().getX(),
+                        link.getToNode().getCoord().getY());
+
+                List<Object> attributes = new ArrayList<>();
+
+                attributes.add(link_id.toString());
+                attributes.add(startTime);
+                EmissionsByPollutant emissions = entry.getValue();
+                Map<Pollutant, Double> pollutants = emissions.getEmissions();
+                for (String pollutant: wanted_pollutants) {
+                    try {
+                        Pollutant pollutant_key = Pollutant.valueOf(pollutant);
+                        attributes.add(pollutants.getOrDefault(pollutant_key, Double.NaN));
+                    }
+                    catch (IllegalArgumentException e) {
+                        attributes.add(Double.NaN);
+                    }
+
+                }
+
+                SimpleFeature feature = linkFactory.createPolyline( //
+                        new Coordinate[] { fromCoordinate, toCoordinate }, //
+                        attributes.toArray(),
+                        null);
+
+                features.add(feature);
+            }
+        }
+        ShapeFileWriter.writeGeometries(features, outputDirectory + "emissions_network.shp");
+    }
+}

--- a/core/src/test/java/org/eqasim/TestEmissions.java
+++ b/core/src/test/java/org/eqasim/TestEmissions.java
@@ -1,13 +1,24 @@
-package org.eqasim.ile_de_france;
+package org.eqasim;
+
+import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
 
 import org.apache.commons.io.FileUtils;
+import org.eqasim.core.components.emissions.RunComputeEmissionsEvents;
+import org.eqasim.core.components.emissions.RunExportEmissionsNetwork;
 import org.eqasim.core.simulation.EqasimConfigurator;
 import org.eqasim.core.simulation.analysis.EqasimAnalysisModule;
 import org.eqasim.core.simulation.mode_choice.AbstractEqasimExtension;
 import org.eqasim.core.simulation.mode_choice.EqasimModeChoiceModule;
 import org.eqasim.core.simulation.mode_choice.parameters.ModeParameters;
-import org.eqasim.ile_de_france.emissions.RunComputeEmissionsEvents;
-import org.eqasim.ile_de_france.emissions.RunExportEmissionsNetwork;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -28,19 +39,12 @@ import org.matsim.core.scenario.ScenarioUtils;
 import org.matsim.core.utils.gis.ShapeFileReader;
 import org.matsim.examples.ExamplesUtils;
 import org.matsim.utils.objectattributes.attributable.Attributes;
-import org.matsim.vehicles.*;
+import org.matsim.vehicles.MatsimVehicleWriter;
+import org.matsim.vehicles.Vehicle;
+import org.matsim.vehicles.VehicleType;
+import org.matsim.vehicles.VehicleUtils;
+import org.matsim.vehicles.Vehicles;
 import org.opengis.feature.simple.SimpleFeature;
-
-import java.io.File;
-import java.io.IOException;
-import java.net.URL;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.Set;
-
-import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 
 public class TestEmissions {
 


### PR DESCRIPTION
Apparently, it is difficult to access the resources of another package once it is actually packaged in a JAR (meaning in the `package` / `verify` / `deploy` phase of Maven, rather than in the `test` phase). So it was not possible anymore to deploy all packages. This PR moves the emissions tests to `core` so it can access the test files for Melun.