### PR TITLE
feat: separate transit routing costs

### DIFF
--- a/core/src/main/java/org/eqasim/core/components/raptor/EqasimRaptorConfigGroup.java
+++ b/core/src/main/java/org/eqasim/core/components/raptor/EqasimRaptorConfigGroup.java
@@ -1,0 +1,35 @@
+package org.eqasim.core.components.raptor;
+
+import org.matsim.core.config.ReflectiveConfigGroup;
+
+public class EqasimRaptorConfigGroup extends ReflectiveConfigGroup {
+	static public final String GROUP_NAME = "eqasim:raptor";
+
+	public EqasimRaptorConfigGroup() {
+		super(GROUP_NAME);
+	}
+
+	@Parameter
+	public double travelTimeRail_u_h = -7.0;
+
+	@Parameter
+	public double travelTimeSubway_u_h = -7.0;
+
+	@Parameter
+	public double travelTimeBus_u_h = -7.0;
+
+	@Parameter
+	public double travelTimeTram_u_h = -7.0;
+
+	@Parameter
+	public double travelTimeOther_u_h = -7.0;
+
+	@Parameter
+	public double perTransfer_u = -1.0;
+
+	@Parameter
+	public double waitTime_u_h = -6.0;
+
+	@Parameter
+	public double walkTime_u_h = -7.0;
+}

--- a/core/src/main/java/org/eqasim/core/components/raptor/EqasimRaptorModule.java
+++ b/core/src/main/java/org/eqasim/core/components/raptor/EqasimRaptorModule.java
@@ -1,0 +1,24 @@
+package org.eqasim.core.components.raptor;
+
+import org.matsim.core.controler.AbstractModule;
+import org.matsim.pt.transitSchedule.api.TransitSchedule;
+
+import com.google.inject.Provides;
+import com.google.inject.Singleton;
+
+import ch.sbb.matsim.routing.pt.raptor.RaptorParameters;
+import ch.sbb.matsim.routing.pt.raptor.RaptorParametersForPerson;
+
+public class EqasimRaptorModule extends AbstractModule {
+	@Override
+	public void install() {
+	}
+
+	@Provides
+	@Singleton
+	RaptorParametersForPerson provideRaptorParametersForPerson(EqasimRaptorConfigGroup raptorConfig,
+			TransitSchedule schedule) {
+		RaptorParameters parameters = EqasimRaptorUtils.createParameters(getConfig(), raptorConfig, schedule);
+		return person -> parameters;
+	}
+}

--- a/core/src/main/java/org/eqasim/core/components/raptor/EqasimRaptorUtils.java
+++ b/core/src/main/java/org/eqasim/core/components/raptor/EqasimRaptorUtils.java
@@ -1,0 +1,57 @@
+package org.eqasim.core.components.raptor;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.matsim.core.config.Config;
+import org.matsim.pt.transitSchedule.api.TransitLine;
+import org.matsim.pt.transitSchedule.api.TransitRoute;
+import org.matsim.pt.transitSchedule.api.TransitSchedule;
+
+import ch.sbb.matsim.routing.pt.raptor.RaptorParameters;
+import ch.sbb.matsim.routing.pt.raptor.RaptorUtils;
+
+public class EqasimRaptorUtils {
+	private final static Logger logger = LogManager.getLogger(EqasimRaptorUtils.class);
+
+	static public RaptorParameters createParameters(Config config, EqasimRaptorConfigGroup raptorConfig,
+			TransitSchedule schedule) {
+		RaptorParameters parameters = RaptorUtils.createParameters(config);
+
+		// use transportMode from TransitRoute in schedule
+		parameters.setUseTransportModeUtilities(true);
+
+		parameters.setMarginalUtilityOfTravelTime_utl_s("rail", raptorConfig.travelTimeRail_u_h / 3600.0);
+		parameters.setMarginalUtilityOfTravelTime_utl_s("subway", raptorConfig.travelTimeSubway_u_h / 3600.0);
+		parameters.setMarginalUtilityOfTravelTime_utl_s("bus", raptorConfig.travelTimeBus_u_h / 3600.0);
+		parameters.setMarginalUtilityOfTravelTime_utl_s("tram", raptorConfig.travelTimeTram_u_h / 3600.0);
+
+		parameters.setTransferPenaltyFixCostPerTransfer(-raptorConfig.perTransfer_u);
+
+		parameters.setMarginalUtilityOfWaitingPt_utl_s(raptorConfig.waitTime_u_h / 3600.0);
+		parameters.setMarginalUtilityOfTravelTime_utl_s("walk", raptorConfig.walkTime_u_h / 3600.0);
+
+		Set<String> requiredModes = new HashSet<>();
+
+		for (TransitLine transitLine : schedule.getTransitLines().values()) {
+			for (TransitRoute transitRoute : transitLine.getRoutes().values()) {
+				requiredModes.add(transitRoute.getTransportMode());
+			}
+		}
+
+		requiredModes.removeAll(Arrays.asList("rail", "subway", "bus", "tram", "walk"));
+
+		if (requiredModes.size() > 0) {
+			logger.warn("Setting 'other' routing cost for following modes: " + String.join(", ", requiredModes));
+
+			for (String mode : requiredModes) {
+				parameters.setMarginalUtilityOfTravelTime_utl_s(mode, raptorConfig.travelTimeOther_u_h / 3600.0);
+			}
+		}
+
+		return parameters;
+	}
+}

--- a/core/src/main/java/org/eqasim/core/scenario/config/GenerateConfig.java
+++ b/core/src/main/java/org/eqasim/core/scenario/config/GenerateConfig.java
@@ -95,7 +95,7 @@ public class GenerateConfig {
 		ScoringConfigGroup scoringConfig = config.scoring();
 
 		scoringConfig.setMarginalUtilityOfMoney(0.0);
-		scoringConfig.setMarginalUtlOfWaitingPt_utils_hr(0.0);
+		scoringConfig.setMarginalUtlOfWaitingPt_utils_hr(-1.0);
 
 		for (String activityType : ACTIVITY_TYPES) {
 			ActivityParams activityParams = scoringConfig.getActivityParams(activityType);
@@ -119,7 +119,7 @@ public class GenerateConfig {
 			modeParams.setMarginalUtilityOfTraveling(-1.0);
 			modeParams.setMonetaryDistanceRate(0.0);
 		}
-
+		
 		// Routing configuration
 		RoutingConfigGroup routingConfig = config.routing();
 

--- a/core/src/main/java/org/eqasim/core/simulation/EqasimConfigurator.java
+++ b/core/src/main/java/org/eqasim/core/simulation/EqasimConfigurator.java
@@ -12,6 +12,8 @@ import java.util.function.BiConsumer;
 
 import org.eqasim.core.components.EqasimComponentsModule;
 import org.eqasim.core.components.config.EqasimConfigGroup;
+import org.eqasim.core.components.raptor.EqasimRaptorConfigGroup;
+import org.eqasim.core.components.raptor.EqasimRaptorModule;
 import org.eqasim.core.components.traffic.EqasimTrafficQSimModule;
 import org.eqasim.core.components.transit.EqasimTransitModule;
 import org.eqasim.core.components.transit.EqasimTransitQSimModule;
@@ -65,7 +67,8 @@ public class EqasimConfigurator {
         configGroups.addAll(Arrays.asList( //
                 new SwissRailRaptorConfigGroup(), //
                 new EqasimConfigGroup(), //
-                new DiscreteModeChoiceConfigGroup() //
+                new DiscreteModeChoiceConfigGroup(), //
+                new EqasimRaptorConfigGroup() //
         ));
 
         modules.addAll(Arrays.asList( //
@@ -73,7 +76,8 @@ public class EqasimConfigurator {
                 new EqasimTransitModule(), //
                 new DiscreteModeChoiceModule(), //
                 new EqasimComponentsModule(), //
-                new EpsilonModule() //
+                new EpsilonModule(), //
+                new EqasimRaptorModule() //
         ));
 
         qsimModules.addAll(Arrays.asList( //

--- a/core/src/test/java/org/eqasim/mode_choice/TestSpecialModeChoiceCases.java
+++ b/core/src/test/java/org/eqasim/mode_choice/TestSpecialModeChoiceCases.java
@@ -14,6 +14,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.eqasim.core.components.config.EqasimConfigGroup;
+import org.eqasim.core.components.raptor.EqasimRaptorConfigGroup;
 import org.eqasim.core.misc.InjectorBuilder;
 import org.eqasim.core.scenario.config.GenerateConfig;
 import org.eqasim.core.simulation.EqasimConfigurator;
@@ -145,6 +146,7 @@ public class TestSpecialModeChoiceCases {
 		CommandLine cmd = new CommandLine.Builder(new String[] {}).build();
 
 		new GenerateConfig(cmd, "", 1.0, 1, 1).run(config);
+		config.addModule(new EqasimRaptorConfigGroup());
 
 		// Make sure the two relevant options (walk vs. bike) both get zero utility
 		DiscreteModeChoiceConfigGroup.getOrCreate(config).setModeAvailability("static");

--- a/ile_de_france/src/main/java/org/eqasim/ile_de_france/scenario/RunAdaptConfig.java
+++ b/ile_de_france/src/main/java/org/eqasim/ile_de_france/scenario/RunAdaptConfig.java
@@ -8,7 +8,6 @@ import org.matsim.api.core.v01.TransportMode;
 import org.matsim.contribs.discrete_mode_choice.modules.config.DiscreteModeChoiceConfigGroup;
 import org.matsim.core.config.CommandLine.ConfigurationException;
 import org.matsim.core.config.Config;
-import org.matsim.core.config.groups.ScoringConfigGroup;
 
 public class RunAdaptConfig {
 	static public void main(String[] args) throws ConfigurationException {
@@ -30,11 +29,6 @@ public class RunAdaptConfig {
 				.get(DiscreteModeChoiceConfigGroup.GROUP_NAME);
 
 		dmcConfig.setModeAvailability(IDFModeChoiceModule.MODE_AVAILABILITY_NAME);
-
-		// Potentially should be moved to the general GenerateConfig class. Wait time
-		// should matter for routing!
-		ScoringConfigGroup scoringConfig = config.scoring();
-		scoringConfig.setMarginalUtlOfWaitingPt_utils_hr(-1.0);
 
 		// Calibration results for 5%
 


### PR DESCRIPTION
- A recent matsim-libs PR makes it possible to look up costs when routing via the SwissRailRaptor based on the `transportMode` of the respective `TransitRoute`
- In our experimental branches we previously added a similar functionality (routing costs by transport mode) using other hacks
- This PR now integrates the new functionality so we can use it easily without overrides in our code
- The PR introduces the `eqasim:raptor` config module which contains the utility parameters for the most important modes
- The new functionality is activated by default. Currently, the config values are set such that the simulations produce exactly the same results as before. Note that the values may seem a bit odd (-6 and -7), which is due to the "utility of performing and activity" that was previously integrated as an opportunity cost for the construction of the arc costs used in SRR
- Future PRs will set more sensible values based on a survey calibration