### PR TITLE
Swiss code cutout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ included in the (note yet determined) next version number.
 
 - Emissions tools have been moved to core package (from ile_de_france)
 - Switched to MATSim 2025 (PR)
+- In switzerland one can now switch off vehicles waiting to enter traffic
 
 **1.5.0**
 

--- a/switzerland/src/main/java/org/eqasim/switzerland/RunSimulation.java
+++ b/switzerland/src/main/java/org/eqasim/switzerland/RunSimulation.java
@@ -8,20 +8,30 @@ import org.matsim.core.config.CommandLine;
 import org.matsim.core.config.CommandLine.ConfigurationException;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigUtils;
+import org.matsim.core.config.groups.QSimConfigGroup;
 import org.matsim.core.controler.Controler;
 import org.matsim.core.scenario.ScenarioUtils;
 
 public class RunSimulation {
 	static public void main(String[] args) throws ConfigurationException {
+		// set preventwaitingtoentertraffic to y if you want to to prevent that waiting traffic has to wait for space in the link buffer
+		// this is especially important to avoid high waiting times when we cutout scenarios from a larger scenario.
 		CommandLine cmd = new CommandLine.Builder(args) //
 				.requireOptions("config-path") //
-				.allowPrefixes("mode-parameter", "cost-parameter") //
+				.allowPrefixes("mode-parameter", "cost-parameter", "preventwaitingtoentertraffic") //
 				.build();
 
 		SwitzerlandConfigurator configurator = new SwitzerlandConfigurator();
 		Config config = ConfigUtils.loadConfig(cmd.getOptionStrict("config-path"), configurator.getConfigGroups());
 		configurator.addOptionalConfigGroups(config);
 		cmd.applyConfiguration(config);
+
+		if (cmd.hasOption("preventwaitingtoentertraffic")) {
+			if (cmd.getOption("preventwaitingtoentertraffic").get().equals("y")) {
+				((QSimConfigGroup) config.getModules().get(QSimConfigGroup.GROUP_NAME))
+						.setPcuThresholdForFlowCapacityEasing(1.0);
+			}
+		}
 
 		Scenario scenario = ScenarioUtils.createScenario(config);
 


### PR DESCRIPTION
We now have a configurable parameter that allows vehicles to enter the buffer without waiting for enough flow capacity. THis prevents extremely long waiting times of vehicles after cutting scenarios.