### PR TITLE
Leg time constraint

### DIFF
--- a/core/src/main/java/org/eqasim/core/simulation/EqasimConfigurator.java
+++ b/core/src/main/java/org/eqasim/core/simulation/EqasimConfigurator.java
@@ -11,6 +11,8 @@ import org.eqasim.core.components.traffic.EqasimTrafficQSimModule;
 import org.eqasim.core.components.transit.EqasimTransitModule;
 import org.eqasim.core.components.transit.EqasimTransitQSimModule;
 import org.eqasim.core.simulation.mode_choice.EqasimModeChoiceModule;
+import org.eqasim.core.simulation.mode_choice.constraints.leg_time.LegTimeConstraintConfigGroup;
+import org.eqasim.core.simulation.mode_choice.constraints.leg_time.LegTimeConstraintModule;
 import org.eqasim.core.simulation.mode_choice.epsilon.EpsilonModule;
 import org.eqasim.core.simulation.modes.feeder_drt.MultiModeFeederDrtModule;
 import org.eqasim.core.simulation.modes.feeder_drt.config.MultiModeFeederDrtConfigGroup;
@@ -107,6 +109,7 @@ public class EqasimConfigurator {
                 List.of(new VDFEngineModule()),
                 Collections.emptyList(),
                 Collections.singletonList((controller, components) -> components.addNamedComponent(VDFEngineModule.COMPONENT_NAME)));
+        this.registerOptionalConfigGroup(new LegTimeConstraintConfigGroup(), Collections.singleton(new LegTimeConstraintModule()));
     }
 
     public ConfigGroup[] getConfigGroups() {

--- a/core/src/main/java/org/eqasim/core/simulation/mode_choice/constraints/leg_time/LegTimeConstraint.java
+++ b/core/src/main/java/org/eqasim/core/simulation/mode_choice/constraints/leg_time/LegTimeConstraint.java
@@ -1,0 +1,53 @@
+package org.eqasim.core.simulation.mode_choice.constraints.leg_time;
+
+import org.matsim.api.core.v01.population.Leg;
+import org.matsim.api.core.v01.population.Person;
+import org.matsim.api.core.v01.population.PlanElement;
+import org.matsim.contribs.discrete_mode_choice.model.DiscreteModeChoiceTrip;
+import org.matsim.contribs.discrete_mode_choice.model.constraints.AbstractTripConstraint;
+import org.matsim.contribs.discrete_mode_choice.model.trip_based.TripConstraint;
+import org.matsim.contribs.discrete_mode_choice.model.trip_based.TripConstraintFactory;
+import org.matsim.contribs.discrete_mode_choice.model.trip_based.candidates.RoutedTripCandidate;
+import org.matsim.contribs.discrete_mode_choice.model.trip_based.candidates.TripCandidate;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+public class LegTimeConstraint extends AbstractTripConstraint {
+    Map<String, Map<String, LegTimeConstraintSingleLegConfigGroup>> singleLegParameterSetByMainModeByLegMode;
+
+    public LegTimeConstraint(Map<String, Map<String, LegTimeConstraintSingleLegConfigGroup>> singleLegParameterSetByMainModeByLegMode) {
+        this.singleLegParameterSetByMainModeByLegMode = singleLegParameterSetByMainModeByLegMode;
+    }
+
+    public boolean validateAfterEstimation(DiscreteModeChoiceTrip trip, TripCandidate tripCandidate, List<TripCandidate> previousCandidates) {
+        if(this.singleLegParameterSetByMainModeByLegMode.containsKey(tripCandidate.getMode()) && tripCandidate instanceof RoutedTripCandidate routedTripCandidate) {
+            Map<String, LegTimeConstraintSingleLegConfigGroup> timeSlotsPerLegMode = singleLegParameterSetByMainModeByLegMode.get(tripCandidate.getMode());
+            for(PlanElement planElement: routedTripCandidate.getRoutedPlanElements()) {
+                if(planElement instanceof Leg leg && timeSlotsPerLegMode.containsKey(leg.getMode())) {
+                    LegTimeConstraintSingleLegConfigGroup legTimeConstraintSingleLegConfigGroup = timeSlotsPerLegMode.get(leg.getMode());
+                    double departureTime = leg.getDepartureTime().seconds();
+                    double arrivalTime = departureTime + (legTimeConstraintSingleLegConfigGroup.checkBothDepartureAndArrivalTimes ? leg.getTravelTime().orElse(0.0): 0.0);
+                    if(legTimeConstraintSingleLegConfigGroup.getTimeSlotsParameterSets().stream().noneMatch(slot -> departureTime >= slot.beginTime && arrivalTime <= slot.endTime)) {
+                        return false;
+                    }
+                }
+            }
+        }
+        return true;
+    }
+
+    public static class Factory implements TripConstraintFactory {
+        Map<String, Map<String, LegTimeConstraintSingleLegConfigGroup>> singleLegParameterSetByMainModeByLegMode;
+
+        public Factory(Map<String, Map<String, LegTimeConstraintSingleLegConfigGroup>> singleLegParameterSetByMainModeByLegMode) {
+            this.singleLegParameterSetByMainModeByLegMode = singleLegParameterSetByMainModeByLegMode;
+        }
+
+        @Override
+        public TripConstraint createConstraint(Person person, List<DiscreteModeChoiceTrip> list, Collection<String> collection) {
+            return new LegTimeConstraint(this.singleLegParameterSetByMainModeByLegMode);
+        }
+    }
+}

--- a/core/src/main/java/org/eqasim/core/simulation/mode_choice/constraints/leg_time/LegTimeConstraintConfigGroup.java
+++ b/core/src/main/java/org/eqasim/core/simulation/mode_choice/constraints/leg_time/LegTimeConstraintConfigGroup.java
@@ -1,0 +1,67 @@
+package org.eqasim.core.simulation.mode_choice.constraints.leg_time;
+
+import org.matsim.core.config.Config;
+import org.matsim.core.config.ConfigGroup;
+import org.matsim.core.config.ReflectiveConfigGroup;
+
+import java.util.*;
+
+public class LegTimeConstraintConfigGroup extends ReflectiveConfigGroup {
+
+    public final static String GROUP_NAME = "eqasim:legTimeConstraint";
+
+    public LegTimeConstraintConfigGroup() {
+        super(GROUP_NAME);
+    }
+
+    @Override
+    public ConfigGroup createParameterSet(String type) {
+        if(LegTimeConstraintSingleLegConfigGroup.GROUP_NAME.equals(type)) {
+            return new LegTimeConstraintSingleLegConfigGroup();
+        }
+        throw new IllegalStateException(String.format("Parameter set '%s' not supported", type));
+    }
+
+    @Override
+    public void addParameterSet(ConfigGroup set) {
+        if(set instanceof LegTimeConstraintSingleLegConfigGroup) {
+            super.addParameterSet(set);
+        } else {
+            throw new IllegalStateException("Unsupported parameter set class: " + set);
+        }
+    }
+
+    @Override
+    protected void checkConsistency(Config config) {
+        super.checkConsistency(config);
+        getSingleLegParameterSetByMainModeByLegMode();
+    }
+
+    public static LegTimeConstraintConfigGroup getOrCreate(Config config) {
+        LegTimeConstraintConfigGroup legTimeConstraintConfigGroup = (LegTimeConstraintConfigGroup) config.getModules().get(LegTimeConstraintConfigGroup.GROUP_NAME);
+        if(legTimeConstraintConfigGroup == null) {
+            legTimeConstraintConfigGroup = new LegTimeConstraintConfigGroup();
+            config.addModule(legTimeConstraintConfigGroup);
+        }
+        return legTimeConstraintConfigGroup;
+    }
+
+    public Map<String, Map<String, LegTimeConstraintSingleLegConfigGroup>> getSingleLegParameterSetByMainModeByLegMode() {
+        Map<String, Map<String, LegTimeConstraintSingleLegConfigGroup>> singleLegParameterSetByMainModeByLegMode = new HashMap<>();
+        Collection<? extends ConfigGroup> parameterSets = getParameterSets(LegTimeConstraintSingleLegConfigGroup.GROUP_NAME);
+        for(ConfigGroup parameterSet: parameterSets) {
+            if(!(parameterSet instanceof LegTimeConstraintSingleLegConfigGroup legTimeConstraintSingleLegConfigGroup)) {
+                throw new IllegalStateException("This should not happen");
+            }
+            if(singleLegParameterSetByMainModeByLegMode.computeIfAbsent(legTimeConstraintSingleLegConfigGroup.mainMode, key -> new HashMap<>()).containsKey(legTimeConstraintSingleLegConfigGroup.legMode)) {
+                throw new IllegalStateException(String.format("The combination (mainMode, legMode) = (%s, %s) appears more than once in the %s module config",
+                        legTimeConstraintSingleLegConfigGroup.mainMode,
+                        legTimeConstraintSingleLegConfigGroup.legMode,
+                        GROUP_NAME));
+            }
+            singleLegParameterSetByMainModeByLegMode.get(legTimeConstraintSingleLegConfigGroup.mainMode)
+                    .put(legTimeConstraintSingleLegConfigGroup.legMode, legTimeConstraintSingleLegConfigGroup);
+        }
+        return singleLegParameterSetByMainModeByLegMode;
+    }
+}

--- a/core/src/main/java/org/eqasim/core/simulation/mode_choice/constraints/leg_time/LegTimeConstraintModule.java
+++ b/core/src/main/java/org/eqasim/core/simulation/mode_choice/constraints/leg_time/LegTimeConstraintModule.java
@@ -1,0 +1,22 @@
+package org.eqasim.core.simulation.mode_choice.constraints.leg_time;
+
+import com.google.inject.Provides;
+import com.google.inject.Singleton;
+import org.eqasim.core.simulation.mode_choice.AbstractEqasimExtension;
+import org.matsim.core.config.CommandLine;
+
+public class LegTimeConstraintModule extends AbstractEqasimExtension {
+
+    public static final String LEG_TIME_CONSTRAINT_NAME = "LegTimeConstraint";
+
+    @Override
+    protected void installEqasimExtension() {
+        bindTripConstraintFactory(LEG_TIME_CONSTRAINT_NAME).to(LegTimeConstraint.Factory.class);
+    }
+
+    @Provides
+    @Singleton
+    public LegTimeConstraint.Factory provideLegTimeConstraintFactory(LegTimeConstraintConfigGroup legTimeConstraintConfigGroup) throws CommandLine.ConfigurationException {
+        return new LegTimeConstraint.Factory(legTimeConstraintConfigGroup.getSingleLegParameterSetByMainModeByLegMode());
+    }
+}

--- a/core/src/main/java/org/eqasim/core/simulation/mode_choice/constraints/leg_time/LegTimeConstraintSingleLegConfigGroup.java
+++ b/core/src/main/java/org/eqasim/core/simulation/mode_choice/constraints/leg_time/LegTimeConstraintSingleLegConfigGroup.java
@@ -1,0 +1,93 @@
+package org.eqasim.core.simulation.mode_choice.constraints.leg_time;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import org.matsim.core.config.Config;
+import org.matsim.core.config.ConfigGroup;
+import org.matsim.core.config.ReflectiveConfigGroup;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+public class LegTimeConstraintSingleLegConfigGroup extends ReflectiveConfigGroup {
+
+    public static final String GROUP_NAME = "singleLegTimeConstraintDefinition";
+
+    @Parameter
+    @Comment("Main mode in which the given leg type will be verified against the time slots")
+    public @NotBlank String mainMode;
+
+    @Parameter
+    @Comment("Leg mode to verify against the time slots")
+    public @NotBlank String legMode;
+
+    @Parameter
+    @Comment("Whether to ensure that both departure and arrival time are within the timeslots or departure time only")
+    public @NotNull boolean checkBothDepartureAndArrivalTimes;
+
+    public LegTimeConstraintSingleLegConfigGroup() {
+        super(GROUP_NAME);
+    }
+
+    @Override
+    public ConfigGroup createParameterSet(String type) {
+        if(TimeSlotConfigGroup.GROUP_NAME.equals(type)) {
+            return new TimeSlotConfigGroup();
+        }
+        throw new IllegalStateException(String.format("Parameter set '%s' not supported", type));
+    }
+
+    @Override
+    public void addParameterSet(ConfigGroup set) {
+        if(set instanceof TimeSlotConfigGroup) {
+            super.addParameterSet(set);
+        } else {
+            throw new IllegalStateException("Unsupported parameter set class: " + set);
+        }
+    }
+
+    public List<TimeSlotConfigGroup> getTimeSlotsParameterSets() {
+        List<TimeSlotConfigGroup> timeSlotsParameterSets = new ArrayList<>();
+        Collection<? extends ConfigGroup> parameterSets = getParameterSets(TimeSlotConfigGroup.GROUP_NAME);
+        for(ConfigGroup parameterSet: parameterSets) {
+            if(!(parameterSet instanceof TimeSlotConfigGroup timeSlotsParameterSet)) {
+                throw new IllegalStateException("This should not happen");
+            }
+            timeSlotsParameterSets.add(timeSlotsParameterSet);
+        }
+        return timeSlotsParameterSets;
+    }
+
+    @Override
+    protected void checkConsistency(Config config) {
+        if(getParameterSets().size() == 0) {
+            throw new IllegalStateException(String.format("%s parameter set must have at least one %s child parameter set", LegTimeConstraintSingleLegConfigGroup.GROUP_NAME, TimeSlotConfigGroup.GROUP_NAME));
+        }
+        super.checkConsistency(config);
+    }
+
+    public static class TimeSlotConfigGroup extends ReflectiveConfigGroup {
+        public static final String GROUP_NAME = "timeSlot";
+
+        @Parameter
+        @Comment("Begin time of the slot")
+        public @NotNull double beginTime;
+
+        @Parameter
+        @Comment("End time of the slot")
+        public @NotNull double endTime;
+
+        public TimeSlotConfigGroup() {
+            super(GROUP_NAME);
+        }
+
+        @Override
+        protected void checkConsistency(Config config) {
+            if(endTime < beginTime) {
+                throw new IllegalStateException("beginTime must be less or equal than endTime");
+            }
+        }
+    }
+}

--- a/core/src/test/java/org/eqasim/TestSimulationPipeline.java
+++ b/core/src/test/java/org/eqasim/TestSimulationPipeline.java
@@ -227,14 +227,17 @@ public class TestSimulationPipeline {
                 "--network-path", "melun_test/input/network.xml.gz",
                 "--output-vehicles-path", "melun_test/input/drt_vehicles_b.xml.gz",
                 "--vehicles-number", "50",
-                "--vehicle-id-prefix", "vehicle_drt_b_"
+                "--vehicle-id-prefix", "vehicle_drt_b_",
+                "--service-begin-time", "36000",
+                "--service-end-time", "50400"
         });
 
         AdaptConfigForDrt.main(new String[]{
                 "--input-config-path", "melun_test/input/config.xml",
                 "--output-config-path", "melun_test/input/config_drt.xml",
                 "--mode-names", "drt_a,drt_b",
-                "--vehicles-paths", "melun_test/input/drt_vehicles_a.xml.gz,melun_test/input/drt_vehicles_b.xml.gz"
+                "--vehicles-paths", "melun_test/input/drt_vehicles_a.xml.gz,melun_test/input/drt_vehicles_b.xml.gz",
+                "--add-leg-time-constraint", "false,true"
         });
 
         runMelunSimulation("melun_test/input/config_drt.xml", "melun_test/output_drt");
@@ -267,14 +270,17 @@ public class TestSimulationPipeline {
                 "--network-path", "melun_test/input/network.xml.gz",
                 "--output-vehicles-path", "melun_test/input/feeder_drt_vehicles_b.xml.gz",
                 "--vehicles-number", "50",
-                "--vehicle-id-prefix", "vehicle_drt_feeder_b_"
+                "--vehicle-id-prefix", "vehicle_drt_feeder_b_",
+                "--service-begin-time", "36000",
+                "--service-end-time", "50400"
         });
 
         AdaptConfigForDrt.main(new String[]{
                 "--input-config-path", "melun_test/input/config.xml",
                 "--output-config-path", "melun_test/input/config_feeder.xml",
                 "--mode-names", "drt_for_feeder_a,drt_for_feeder_b",
-                "--vehicles-paths", "melun_test/input/feeder_drt_vehicles_a.xml.gz,melun_test/input/feeder_drt_vehicles_b.xml.gz"
+                "--vehicles-paths", "melun_test/input/feeder_drt_vehicles_a.xml.gz,melun_test/input/feeder_drt_vehicles_b.xml.gz",
+                "--add-leg-time-constraint", "false,true"
         });
 
 


### PR DESCRIPTION
This development started with the need of supporting service times for DRT at the mode choice level. Since the DRT router doesn't check against the vehicles' service time, DRT routes are computed and then the related requests are rejected during Mobsim. A TripConstraint was then implemented to ensure that DRT trip alternatives are considered only in hardcoded time slots. This first version has been developed further to become more generic and not DRT specific and converged to the code base presented in this PR.

The main functionality is made available by the `org.eqasim.core.simulation.mode_choice.constraints.leg_time` package for which the `LegTimeConstraintModule` class is the entry point. The latter is an `AbstractEqasimExtension` that installs the `LegTimeConstraint` in the mode choice model. This constraint is configured by the module using a `LegTimeConstraintConfigGroup` that looks like the example below:

```xml
<module name="eqasim:legTimeConstraint" >
<parameterset type="singleLegTimeConstraintDefinition" >
	<!-- Whether to ensure that both departure and arrival time are within the timeslots or departure time only -->
	<param name="checkBothDepartureAndArrivalTimes" value="true" />
	<!-- Leg mode to verify against the time slots -->
	<param name="legMode" value="drt_b" />
	<!-- Main mode in which the given leg type will be verified against the time slots -->
	<param name="mainMode" value="drt_b" />
	<parameterset type="timeSlot" >
		<!-- Begin time of the slot -->
		<param name="beginTime" value="36000.0" />
		<!-- End time of the slot -->
		<param name="endTime" value="50400.0" />
	</parameterset>
</parameterset>
</module>
```

Multiple `singleLegTimeConstraintDefinition` parameter sets can be provided, each specifying a leg mode that is concerned by the constraint alongside the main mode of the trips in which they are constrained. This will allow for instance to have a DRT fleet that is usable in intermodality only during certain hours and in monomodality in other hours. If the `checkBothDepartureAndArrivalTimes` set to true, both the leg departure time and arrival time (computed with the travel time) need to be inside an authorized time slot. Otherwise only the departure time is constrained. Multiple time slots can be provided.

To activate this functionality, the `eqasim:legTimeConstraint` module needs to be configured in the config file and the `LegTimeConstraint` added in the `DiscreteModeChoice.tripConstraints` parameter. No changes are required on the run scripts.


To showcase this functionality and test it in the pipeline, The `AdaptConfigForDrt` script is updated to support a boolean `--add--leg-time-constraint` argument. If set to true, the tool will add the constraint and configure it for the period spanned by the service times of the vehicles. The `AdaptConfigForFeeder` script is also modify to propagate existing constraints on the base modes into the new intermodal ones. 