### PR TITLE
fix: FeederDrt routing attributes in legs rather than in interaction activities

### DIFF
--- a/core/src/main/java/org/eqasim/core/simulation/modes/feeder_drt/mode_choice/utilities/estimator/DefaultFeederDrtUtilityEstimator.java
+++ b/core/src/main/java/org/eqasim/core/simulation/modes/feeder_drt/mode_choice/utilities/estimator/DefaultFeederDrtUtilityEstimator.java
@@ -33,17 +33,17 @@ public class DefaultFeederDrtUtilityEstimator implements UtilityEstimator {
 		UtilityEstimator ptEstimator = null;
 		UtilityEstimator drtEstimator = null;
 
-		FeederDrtRoutingModule.FeederDrtTripSegmentType nextSegmentType = FeederDrtRoutingModule.FeederDrtTripSegmentType.MAIN;
+		FeederDrtRoutingModule.FeederDrtTripSegmentType previousSegmentType = null;
 
 		for (PlanElement element : elements) {
 			if (element instanceof Activity stageActivity && stageActivity.getType().equals(stageActivityType)) {
-				FeederDrtRoutingModule.FeederDrtTripSegmentType previousSegmentType = (FeederDrtRoutingModule.FeederDrtTripSegmentType) stageActivity.getAttributes().getAttribute(FeederDrtRoutingModule.STAGE_ACTIVITY_PREVIOUS_SEGMENT_TYPE_ATTR);
+				if(previousSegmentType == null) {
+					throw new IllegalStateException("Encountered Feeder interaction activity before any leg");
+				}
 				if(previousSegmentType.equals(FeederDrtRoutingModule.FeederDrtTripSegmentType.MAIN)) {
 					totalUtility += ptEstimator.estimateUtility(person, trip, currentTrip);
-					nextSegmentType = FeederDrtRoutingModule.FeederDrtTripSegmentType.DRT;
 				} else if (previousSegmentType.equals(FeederDrtRoutingModule.FeederDrtTripSegmentType.DRT)) {
 					totalUtility += drtEstimator.estimateUtility(person, trip, currentTrip);
-					nextSegmentType = FeederDrtRoutingModule.FeederDrtTripSegmentType.MAIN;
 				} else {
 					throw new IllegalStateException(String.format("Unhandled previous segment type %s in trip of person %s", previousSegmentType, person.getId().toString()));
 				}
@@ -57,6 +57,7 @@ public class DefaultFeederDrtUtilityEstimator implements UtilityEstimator {
 						drtEstimator = this.drtEstimators.get(routingMode);
 						stageActivityType = routingMode + " interaction";
 					}
+					previousSegmentType = (FeederDrtRoutingModule.FeederDrtTripSegmentType) leg.getAttributes().getAttribute(FeederDrtRoutingModule.CURRENT_SEGMENT_TYPE_ATTR);
 				}
 			}
 		}
@@ -64,7 +65,7 @@ public class DefaultFeederDrtUtilityEstimator implements UtilityEstimator {
 			if(ptEstimator == null) {
 				throw new IllegalStateException(String.format("Plan of person %s has no legs", person.getId().toString()));
 			}
-			if (nextSegmentType.equals(FeederDrtRoutingModule.FeederDrtTripSegmentType.MAIN)) {
+			if (previousSegmentType.equals(FeederDrtRoutingModule.FeederDrtTripSegmentType.MAIN)) {
 				totalUtility += ptEstimator.estimateUtility(person, trip, currentTrip);
 			} else {
 				totalUtility += drtEstimator.estimateUtility(person, trip, currentTrip);

--- a/core/src/main/java/org/eqasim/core/simulation/modes/feeder_drt/router/FeederDrtRoutingModule.java
+++ b/core/src/main/java/org/eqasim/core/simulation/modes/feeder_drt/router/FeederDrtRoutingModule.java
@@ -12,9 +12,9 @@ import java.util.*;
 
 public class FeederDrtRoutingModule implements RoutingModule {
 
-    public enum FeederDrtTripSegmentType {MAIN, DRT};
+    public enum FeederDrtTripSegmentType {MAIN, DRT}
 
-    public static final String STAGE_ACTIVITY_PREVIOUS_SEGMENT_TYPE_ATTR = "previousSegmentType";
+    public static final String CURRENT_SEGMENT_TYPE_ATTR = "currentSegmentType";
 
     private final RoutingModule drtRoutingModule;
     private final RoutingModule transitRoutingModule;
@@ -63,11 +63,11 @@ public class FeederDrtRoutingModule implements RoutingModule {
                 if (element instanceof Leg leg) {
                     accessTime = Math.max(accessTime, leg.getDepartureTime().seconds());
                     accessTime += leg.getTravelTime().seconds();
+                    leg.getAttributes().putAttribute(CURRENT_SEGMENT_TYPE_ATTR, FeederDrtTripSegmentType.DRT);
                 }
             }
             Activity accessInteractionActivity = populationFactory.createActivityFromLinkId(this.mode + " interaction", accessFacility.getLinkId());
             accessInteractionActivity.setMaximumDuration(0);
-            accessInteractionActivity.getAttributes().putAttribute(STAGE_ACTIVITY_PREVIOUS_SEGMENT_TYPE_ATTR, FeederDrtTripSegmentType.DRT);
             intermodalRoute.add(accessInteractionActivity);
         }
 
@@ -79,6 +79,7 @@ public class FeederDrtRoutingModule implements RoutingModule {
             if (element instanceof Leg leg) {
                 egressTime = Math.max(egressTime, leg.getDepartureTime().seconds());
                 egressTime += leg.getTravelTime().seconds();
+                leg.getAttributes().putAttribute(CURRENT_SEGMENT_TYPE_ATTR, FeederDrtTripSegmentType.MAIN);
             }
         }
 
@@ -90,13 +91,15 @@ public class FeederDrtRoutingModule implements RoutingModule {
 
         // If no valid DRT route is found, we recompute a PT route from the access facility to the trip destination
         if (drtRoute == null) {
-            intermodalRoute.addAll(transitRoutingModule.calcRoute(DefaultRoutingRequest.withoutAttributes(accessFacility, toFacility, accessTime, person)));
+            ptRoute = new LinkedList<>(transitRoutingModule.calcRoute(DefaultRoutingRequest.withoutAttributes(accessFacility, toFacility, accessTime, person)));
+            ptRoute.stream().filter(planElement -> planElement instanceof Leg).map(planElement -> (Leg) planElement).forEach(leg -> leg.getAttributes().putAttribute(CURRENT_SEGMENT_TYPE_ATTR, FeederDrtTripSegmentType.MAIN));
+            intermodalRoute.addAll(ptRoute);
         } else {
             // Otherwise we add it as an egress to the whole route
             intermodalRoute.addAll(ptRoute);
             Activity egressInteractionActivity = populationFactory.createActivityFromLinkId(this.mode + " interaction", egressFacility.getLinkId());
             egressInteractionActivity.setMaximumDuration(0);
-            egressInteractionActivity.getAttributes().putAttribute(STAGE_ACTIVITY_PREVIOUS_SEGMENT_TYPE_ATTR, FeederDrtTripSegmentType.MAIN);
+            drtRoute.stream().filter(planElement -> planElement instanceof Leg).map(planElement -> (Leg) planElement).forEach(leg -> leg.getAttributes().putAttribute(CURRENT_SEGMENT_TYPE_ATTR, FeederDrtTripSegmentType.DRT));
             intermodalRoute.add(egressInteractionActivity);
             intermodalRoute.addAll(drtRoute);
         }


### PR DESCRIPTION
In the previous version Feeder Drt functionality proposed in PR #206, the `FeederDrtRoutingModule`  was putting attributes in feeder interaction activities to signal whether the previous segment of the trip result from the main router (PT) or the access egress one (DRT). This allows to easily separate them as is done in the `DefaultFeederDrtUtilityEstimator`. However, when trying to run a simulation with an input plans resulting from a previous one (with such attributes written in the plans file), the reader throws an exception as attributes in stage activities are not allowed. 

To fix this, the current PR writes the attributes in the legs of the trip segments rather than in the interaction activities.