### PR TITLE
fix: preventing the summing of two error terms in FeederDrtUtilityEst…

### DIFF
--- a/core/src/main/java/org/eqasim/core/simulation/mode_choice/epsilon/EpsilonAdapter.java
+++ b/core/src/main/java/org/eqasim/core/simulation/mode_choice/epsilon/EpsilonAdapter.java
@@ -24,4 +24,8 @@ public class EpsilonAdapter implements UtilityEstimator {
 		utility += epsilonProvider.getEpsilon(person.getId(), trip.getIndex(), mode);
 		return utility;
 	}
+
+	public UtilityEstimator getDelegate() {
+		return this.delegate;
+	}
 }


### PR DESCRIPTION
The `DefaultFeederDrtUtilityEstimator` proposed as part of the Feeder functionality in PR #206 just separates the segments resulting from the main router (PT) and the access egress router (DRT) and delegates to the respective utility estimators and then sums the whole. However when using the Epsilon functionality, this results in the error terms of each sub-estimator to be summed before adding the error term of the feeder mode on top of that.

This PR fixes this by checking whether the estimators are instances of `EpsilonAdapter` and unwraps the base estimator behind them.