### PR TITLE
feat: a new scenario cutter without mode choice limitations

### DIFF
--- a/core/src/main/java/org/eqasim/core/scenario/cutter/RunScenarioCutter.java
+++ b/core/src/main/java/org/eqasim/core/scenario/cutter/RunScenarioCutter.java
@@ -41,7 +41,7 @@ import com.google.inject.Injector;
 
 public class RunScenarioCutter {
 	static public void main(String[] args)
-			throws ConfigurationException, MalformedURLException, IOException, InterruptedException {
+			throws ConfigurationException, IOException, InterruptedException {
 		CommandLine cmd = new CommandLine.Builder(args) //
 				.requireOptions("config-path", "output-path", "extent-path") //
 				.allowOptions("threads", "prefix", "extent-attribute", "extent-value", "plans-path", "events-path") //

--- a/core/src/main/java/org/eqasim/core/scenario/cutter/RunScenarioCutter.java
+++ b/core/src/main/java/org/eqasim/core/scenario/cutter/RunScenarioCutter.java
@@ -45,6 +45,7 @@ public class RunScenarioCutter {
 		CommandLine cmd = new CommandLine.Builder(args) //
 				.requireOptions("config-path", "output-path", "extent-path") //
 				.allowOptions("threads", "prefix", "extent-attribute", "extent-value", "plans-path", "events-path") //
+				.allowOptions("skip-routing") //
 				.build();
 
 		// Load some configuration
@@ -160,11 +161,14 @@ public class RunScenarioCutter {
 				.addOverridingModule(new TimeInterpretationModule()) //
 				.build();
 
-		PopulationRouter router = routingInjector.getInstance(PopulationRouter.class);
-		router.run(scenario.getPopulation());
+		boolean skipRouting = Boolean.parseBoolean(cmd.getOption("skip-routing").orElse("false"));
 
-		// Check validity after cutting
-		scenarioValidator.checkScenario(scenario);
+		if(!skipRouting) {
+			PopulationRouter router = routingInjector.getInstance(PopulationRouter.class);
+			router.run(scenario.getPopulation());
+			// Check validity after cutting
+			scenarioValidator.checkScenario(scenario);
+		}
 
 		// Write scenario
 		ScenarioWriter scenarioWriter = new ScenarioWriter(config, scenario, prefix);

--- a/core/src/main/java/org/eqasim/core/scenario/cutter/RunScenarioCutter.java
+++ b/core/src/main/java/org/eqasim/core/scenario/cutter/RunScenarioCutter.java
@@ -2,8 +2,9 @@ package org.eqasim.core.scenario.cutter;
 
 import java.io.File;
 import java.io.IOException;
-import java.net.MalformedURLException;
+import java.util.Collection;
 import java.util.Optional;
+import java.util.Set;
 
 import org.eqasim.core.components.travel_time.RecordedTravelTime;
 import org.eqasim.core.misc.InjectorBuilder;
@@ -40,12 +41,15 @@ import org.matsim.core.utils.timing.TimeInterpretationModule;
 import com.google.inject.Injector;
 
 public class RunScenarioCutter {
+
+	public static final Collection<String> REQUIRED_ARGS = Set.of("config-path", "output-path", "extent-path");
+	public static final Collection<String> OPTIONAL_ARGS = Set.of("threads", "prefix", "extent-attribute", "extent-value", "plans-path", "events-path", "skip-routing");
+
 	static public void main(String[] args)
 			throws ConfigurationException, IOException, InterruptedException {
 		CommandLine cmd = new CommandLine.Builder(args) //
-				.requireOptions("config-path", "output-path", "extent-path") //
-				.allowOptions("threads", "prefix", "extent-attribute", "extent-value", "plans-path", "events-path") //
-				.allowOptions("skip-routing") //
+				.requireOptions(REQUIRED_ARGS) //
+				.allowOptions(OPTIONAL_ARGS) //
 				.build();
 
 		// Load some configuration

--- a/core/src/main/java/org/eqasim/core/scenario/cutter/RunScenarioCutterV2.java
+++ b/core/src/main/java/org/eqasim/core/scenario/cutter/RunScenarioCutterV2.java
@@ -8,11 +8,15 @@ import org.eqasim.core.simulation.vdf.VDFConfigGroup;
 import org.eqasim.core.simulation.vdf.engine.VDFEngineConfigGroup;
 import org.matsim.api.core.v01.IdSet;
 import org.matsim.api.core.v01.Scenario;
+import org.matsim.api.core.v01.network.Link;
+import org.matsim.api.core.v01.network.Network;
 import org.matsim.api.core.v01.population.Person;
 import org.matsim.core.config.CommandLine;
 import org.matsim.core.config.CommandLine.ConfigurationException;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigUtils;
+import org.matsim.core.network.NetworkUtils;
+import org.matsim.core.network.algorithms.TransportModeNetworkFilter;
 import org.matsim.core.population.io.PopulationReader;
 import org.matsim.core.scenario.ScenarioUtils;
 
@@ -105,6 +109,14 @@ public class RunScenarioCutterV2 {
         vdfConfigGroup.setUpdateAreaShapefile("extent/" + extentPath.getName());
         // We also set the VDF config to use the vdf.bin file for initial travel times
         vdfConfigGroup.setInputFile("vdf.bin");
+
+        // "Cut" config
+        // (we need to reload it, because it has become locked at this point)
+        config = ConfigUtils.loadConfig(cmd.getOptionStrict("config-path"), eqasimConfigurator.getConfigGroups());
+        cmd.applyConfiguration(config);
+        eqasimConfigurator.addOptionalConfigGroups(config);
+        ConfigCutter configCutter = new ConfigCutter(prefix);
+        configCutter.run(config);
 
         new ScenarioWriter(config, scenario, prefix).run(new File(outputPath).getAbsoluteFile());
 

--- a/core/src/main/java/org/eqasim/core/scenario/cutter/RunScenarioCutterV2.java
+++ b/core/src/main/java/org/eqasim/core/scenario/cutter/RunScenarioCutterV2.java
@@ -109,6 +109,14 @@ public class RunScenarioCutterV2 {
             }
         }
 
+        // "Cut" config
+        // (we need to reload it, because it has become locked at this point)
+        config = ConfigUtils.loadConfig(cmd.getOptionStrict("config-path"), eqasimConfigurator.getConfigGroups());
+        cmd.applyConfiguration(config);
+        eqasimConfigurator.addOptionalConfigGroups(config);
+        ConfigCutter configCutter = new ConfigCutter(prefix);
+        configCutter.run(config);
+
         // Before writing the config, we make sure we configure VDF to update the travel times only in the study area
         String extentBasePath = Paths.get(outputPath, "extent").toAbsolutePath().toString();
         String copiedExtentPath = Paths.get(extentBasePath, extentPath.getName()).toString();
@@ -118,14 +126,6 @@ public class RunScenarioCutterV2 {
         vdfConfigGroup.setUpdateAreaShapefile("extent/" + extentPath.getName());
         // We also set the VDF config to use the vdf.bin file for initial travel times
         vdfConfigGroup.setInputFile("vdf.bin");
-
-        // "Cut" config
-        // (we need to reload it, because it has become locked at this point)
-        config = ConfigUtils.loadConfig(cmd.getOptionStrict("config-path"), eqasimConfigurator.getConfigGroups());
-        cmd.applyConfiguration(config);
-        eqasimConfigurator.addOptionalConfigGroups(config);
-        ConfigCutter configCutter = new ConfigCutter(prefix);
-        configCutter.run(config);
 
         new ScenarioWriter(config, scenario, prefix).run(new File(outputPath).getAbsoluteFile());
 

--- a/core/src/main/java/org/eqasim/core/scenario/cutter/RunScenarioCutterV2.java
+++ b/core/src/main/java/org/eqasim/core/scenario/cutter/RunScenarioCutterV2.java
@@ -1,0 +1,125 @@
+package org.eqasim.core.scenario.cutter;
+
+import org.apache.commons.io.FileUtils;
+import org.eqasim.core.scenario.cutter.extent.ScenarioExtent;
+import org.eqasim.core.scenario.cutter.extent.ShapeScenarioExtent;
+import org.eqasim.core.simulation.EqasimConfigurator;
+import org.eqasim.core.simulation.vdf.VDFConfigGroup;
+import org.eqasim.core.simulation.vdf.engine.VDFEngineConfigGroup;
+import org.matsim.api.core.v01.IdSet;
+import org.matsim.api.core.v01.Scenario;
+import org.matsim.api.core.v01.population.Person;
+import org.matsim.core.config.CommandLine;
+import org.matsim.core.config.CommandLine.ConfigurationException;
+import org.matsim.core.config.Config;
+import org.matsim.core.config.ConfigUtils;
+import org.matsim.core.population.io.PopulationReader;
+import org.matsim.core.scenario.ScenarioUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.*;
+
+public class RunScenarioCutterV2 {
+
+    public static final String[] SHAPEFILE_EXTENSIONS = new String[]{".shp", ".cpg", ".dbf", ".qmd", ".shx", ".prj"};
+
+    static public void main(String[] args)
+            throws ConfigurationException, IOException, InterruptedException {
+        CommandLine cmd = new CommandLine.Builder(args) //
+                .requireOptions("config-path", "output-path", "extent-path", "vdf-travel-times-path") //
+                .allowOptions("threads", "prefix", "extent-attribute", "extent-value", "plans-path", "events-path") //
+                .allowOptions("flag-area-link-modes") //
+                .build();
+
+        String outputPath = cmd.getOptionStrict("output-path");
+
+        EqasimConfigurator eqasimConfigurator = new EqasimConfigurator();
+        Config config = ConfigUtils.loadConfig(cmd.getOptionStrict("config-path"), eqasimConfigurator.getConfigGroups());
+        cmd.applyConfiguration(config);
+        eqasimConfigurator.addOptionalConfigGroups(config);
+
+        if(!config.getModules().containsKey(VDFConfigGroup.GROUP_NAME) || !config.getModules().containsKey(VDFEngineConfigGroup.GROUP_NAME)) {
+            throw new IllegalStateException(String.format("This scenario cutter only works with configs where both '%s' and '%s' modules are used", VDFConfigGroup.GROUP_NAME, VDFEngineConfigGroup.GROUP_NAME));
+        }
+
+        List<String> scenarioCutterArgs = new ArrayList<>();
+        for(String requiredOption: RunScenarioCutter.REQUIRED_ARGS) {
+            scenarioCutterArgs.add("--"+requiredOption);
+            scenarioCutterArgs.add(cmd.getOptionStrict(requiredOption));
+        }
+        for(String optionalOption: RunScenarioCutter.OPTIONAL_ARGS) {
+            if(cmd.hasOption(optionalOption)) {
+                scenarioCutterArgs.add("--"+optionalOption);
+                scenarioCutterArgs.add(cmd.getOptionStrict(optionalOption));
+            }
+        }
+        scenarioCutterArgs.add("--skip-routing");
+        scenarioCutterArgs.add("true");
+
+        RunScenarioCutter.main(scenarioCutterArgs.toArray(String[]::new));
+
+        String prefix = cmd.getOption("prefix").orElse("");
+
+        Scenario scenario = ScenarioUtils.createScenario(ConfigUtils.createConfig());
+        eqasimConfigurator.configureScenario(scenario);
+        // We first load the population resulting from the legacy cutter and store the person ids
+        new PopulationReader(scenario).readFile(Paths.get(outputPath, prefix+"population.xml.gz").toString());
+        IdSet<Person> personIds = new IdSet<>(Person.class);
+        scenario.getPopulation().getPersons().values().stream().map(Person::getId).forEach(personIds::add);
+
+        // We now read the data from the original scenario
+        scenario = ScenarioUtils.createScenario(config);
+        eqasimConfigurator.configureScenario(scenario);
+        ScenarioUtils.loadScenario(scenario);
+        eqasimConfigurator.adjustScenario(scenario);
+
+        // We remove from the original population, the persons that do not appear in the one resulting from the legacy cutter
+        IdSet<Person> personsToRemove = new IdSet<>(Person.class);
+        scenario.getPopulation().getPersons().values().stream().map(Person::getId).filter(personId -> !personIds.contains(personId)).forEach(personsToRemove::add);
+        personsToRemove.forEach(scenario.getPopulation()::removePerson);
+
+        // Now we process the network
+        File extentPath = new File(cmd.getOptionStrict("extent-path"));
+        Optional<String> extentAttribute = cmd.getOption("extent-attribute");
+        Optional<String> extentValue = cmd.getOption("extent-value");
+        ScenarioExtent extent = new ShapeScenarioExtent.Builder(extentPath, extentAttribute, extentValue).build();
+
+        if(Boolean.parseBoolean(cmd.getOption("flag-area-link-modes").orElse("false"))) {
+            scenario.getNetwork().getLinks().values()
+                    .stream().filter(link -> extent.isInside(link.getFromNode().getCoord()) && extent.isInside(link.getFromNode().getCoord()))
+                    .forEach(link -> {
+                        Set<String> linkModes = new HashSet<>(link.getAllowedModes());
+                        link.getAllowedModes().stream().toList().stream().map(mode -> "inside_"+mode).forEach(linkModes::add);
+                        link.setAllowedModes(linkModes);
+                    });
+        }
+
+        // Before writing the config, we make sure we configure VDF to update the travel times only in the study area
+        String extentBasePath = Paths.get(outputPath, "extent").toAbsolutePath().toString();
+        String copiedExtentPath = Paths.get(extentBasePath, extentPath.getName()).toString();
+        FileUtils.forceMkdir(new File(extentBasePath));
+        copyExtentFiles(extentPath.getAbsolutePath(), copiedExtentPath);
+        VDFConfigGroup vdfConfigGroup = VDFConfigGroup.getOrCreate(config);
+        vdfConfigGroup.setUpdateAreaShapefile("extent/" + extentPath.getName());
+        // We also set the VDF config to use the vdf.bin file for initial travel times
+        vdfConfigGroup.setInputFile("vdf.bin");
+
+        new ScenarioWriter(config, scenario, prefix).run(new File(outputPath).getAbsoluteFile());
+
+        FileUtils.copyFile(new File(cmd.getOptionStrict("vdf-travel-times-path")), new File(outputPath, "vdf.bin"));
+    }
+
+    private static void copyExtentFiles(String sourcePath, String destPath) throws IOException {
+        if(sourcePath.endsWith(".shp")) {
+            sourcePath = sourcePath.substring(0, sourcePath.length()-4);
+            destPath = destPath.substring(0, destPath.length()-4);
+            for(String extension: SHAPEFILE_EXTENSIONS) {
+                FileUtils.copyFile(new File(sourcePath + extension), new File(destPath + extension));
+            }
+        } else {
+            FileUtils.copyFile(new File(sourcePath), new File(destPath));
+        }
+    }
+}

--- a/core/src/test/java/org/eqasim/TestSimulationPipeline.java
+++ b/core/src/test/java/org/eqasim/TestSimulationPipeline.java
@@ -14,6 +14,7 @@ import org.eqasim.core.analysis.run.RunLegAnalysis;
 import org.eqasim.core.analysis.run.RunPublicTransportLegAnalysis;
 import org.eqasim.core.analysis.run.RunTripAnalysis;
 import org.eqasim.core.scenario.cutter.RunScenarioCutter;
+import org.eqasim.core.scenario.cutter.RunScenarioCutterV2;
 import org.eqasim.core.simulation.EqasimConfigurator;
 import org.eqasim.core.simulation.analysis.EqasimAnalysisModule;
 import org.eqasim.core.simulation.mode_choice.AbstractEqasimExtension;
@@ -213,6 +214,17 @@ public class TestSimulationPipeline {
     	});
     }
 
+    public void runCutterV2() throws CommandLine.ConfigurationException, IOException, InterruptedException {
+        RunScenarioCutterV2.main(new String[] {
+                "--config-path", "melun_test/input/config_vdf.xml",
+                "--events-path", "melun_test/output_vdf/output_events.xml.gz",
+                "--vdf-travel-times-path", "melun_test/output_vdf/vdf.bin",
+                "--output-path", "melun_test/cutter_v2",
+                "--prefix", "center_",
+                "--extent-path", "melun_test/input/center.shp",
+        });
+    }
+
     @Test
     public void testDrt() throws IOException, CommandLine.ConfigurationException {
         CreateDrtVehicles.main(new String[]{
@@ -335,8 +347,7 @@ public class TestSimulationPipeline {
         runMelunSimulation("melun_test/input/config_abstract_access.xml", "melun_test/output_abstract_access");
     }
 
-    @Test
-    public void testVDF() throws CommandLine.ConfigurationException, IOException {
+    public void runVdf() throws CommandLine.ConfigurationException, IOException {
         AdaptConfigForVDF.main(new String[] {
                 "--input-config-path", "melun_test/input/config.xml",
                 "--output-config-path", "melun_test/input/config_vdf.xml",
@@ -344,6 +355,8 @@ public class TestSimulationPipeline {
                 // We need to do this for DRT as DRT drivers are not PlanAgents
                 "--config:eqasim:vdf_engine.generateNetworkEvents", "true"
         });
+
+        runMelunSimulation("melun_test/input/config_vdf.xml", "melun_test/output_vdf");
 
         CreateDrtVehicles.main(new String[]{
                 "--network-path", "melun_test/input/network.xml.gz",
@@ -365,6 +378,7 @@ public class TestSimulationPipeline {
     public void testPipeline() throws Exception {
         runMelunSimulation("melun_test/input/config.xml", "melun_test/output");
         runStandaloneModeChoice();
+        runVdf();
         runAnalyses();
         runExports();
         runCutter();

--- a/core/src/test/java/org/eqasim/TestSimulationPipeline.java
+++ b/core/src/test/java/org/eqasim/TestSimulationPipeline.java
@@ -222,7 +222,26 @@ public class TestSimulationPipeline {
                 "--output-path", "melun_test/cutter_v2",
                 "--prefix", "center_",
                 "--extent-path", "melun_test/input/center.shp",
+                "--flag-area-link-modes", "true"
         });
+
+        CreateDrtVehicles.main(new String[]{
+                "--network-path", "melun_test/cutter_v2/center_network.xml.gz",
+                "--output-vehicles-path", "melun_test/cutter_v2/drt_vehicles.xml",
+                "--vehicles-number", "25",
+                "--network-modes", "inside_car"
+        });
+
+        AdaptConfigForDrt.main(new String[]{
+                "--input-config-path", "melun_test/cutter_v2/center_config.xml",
+                "--output-config-path", "melun_test/cutter_v2/center_config_drt.xml",
+                "--vehicles-paths", "melun_test/cutter_v2/drt_vehicles.xml",
+                "--operational-schemes", "serviceAreaBased",
+                "--config:multiModeDrt.drt[mode=drt].drtServiceAreaShapeFile", "extent/center.shp",
+                "--config:dvrp.networkModes", "inside_car"
+        });
+
+        runMelunSimulation("melun_test/cutter_v2/center_config_drt.xml", "melun_test/output_cutter_v2_drt");
     }
 
     @Test
@@ -382,6 +401,7 @@ public class TestSimulationPipeline {
         runAnalyses();
         runExports();
         runCutter();
+        runCutterV2();
     }
 
 


### PR DESCRIPTION
## Introduction
The existing `RunScenarioCutter` allows to focus on one small area of a large simulation by considering only the agents that travel in that area at some point during the simulation. The road network, the transit schedule as well as the plans of the concerned agents are 'cut' inside this area. `outside` activities are inserted in the agent plans when they enter or leave the area, and the whole activity sub-chains that take place outside are replaced with trips using the mode `outside`.  This functionality allows, for instance, to study DRT systems on a small scale and perform fleet sizing simulations that take much less time than simulations of the whole area. 

However, one limitiation of the  the current functionalitty is the restriction introduced on the mode choice. To keep plans that are coherent on the global level, tours with an outside activity are not considered by the DMC model. In some cases, these can represent a large proportion of the overall tours. Which prevents from fully assessing the impact that a new service would have. 

## Functionality
In this PR, we trade this limitation against another one. We propose an approach that does not restrict the mode choice model but rather assume that the travel times outside the study area are not impacted by the new services that will be added later on. 

The `RunScenarioCutterV2` does not exactly cut the network, the transit schedule or the plans. Rather, the population is filtered to keep only the persons that travel in the study area, the same ones that would be left by the old functionality, with the difference that the plans remain intact. A first run of the overall simulation is required beforehand as the converged travel times need to be measured before being fixed outside the area of interest. In this version, we require the input config and the original simulation to use the VDF functionality available in Eqasim.

The resulting scenario will the same network and transit schedule, have a smaller population and a DMC model configuration that considers all tours. So a simulation of it will take longer than a simulation of a scenario resulting form the base cutter, but still faster than the original simulation. 

## Technical implementation
The tool, available in the `org.eqasim.core.scenario.cutter.RunPopulationCutterV2`, requires the following arguments, most of the arguments supported are also supported by `RunPopulationCutter` with the same meaning, these will not be elaborated further here:.
- `--vdf-travel-times-path` (required): A binary file, named `vdf.bin` by default, written by Eqasim and containing the travel times observed by the VDF module.  The travel times recorded in this file will be the input of the VDF module in the resulting scenario for the first iteration. Moreover, the VDF module will be configured to update only the travel times that are inside the study area. For the rest of the network, the travel times recorded in this file will be used during the whle simulation. 
- `--flag-area-link-modes` (optional): true or false. If true, the tool will tag the links inside the study area by adding allowed modes that are the same as the pre-existing ones prefixed with `inside_`. However, the subnetworks consisting of each of the new modes are cleaned to make sure they are fully connected (So not every link inside the study area will end up with `inside_...` modes).

A simple approach was adopted for the code implementation of this functionality. We basically call the exisitng `RunScenarioCutter` and then we process the original population and remove all persons with an ID that does not appear in the scenario resulting from the first cutter.  This takes more time than necessary as the network, transit schedule and plans are processed whereas we only need to know which agents are in the area at some point during the day. Future works will simplify the code to speed-up the tool. 

## Unit test
This functionality is tested during the `TestSimulationPipeline.testPipeline` unit test. The cutter is executed on the output of a simulation using the VDF functionality. Then, a DRT simulations is performed with a service active only in the cut-out area. We make use of the flag modes added by the cutter to have a smaller DvrpTravelTime matrix. 


## First results
We tested this functionality on a simulation of ile-de-france, focusing on the area of Dourdan in the south of Paris, and simulating an intermodal DRT system enabled by the `feederDrt` module available in Eqasim.  We compare the simulations of the whole Ile-de-France area with the whole population (with the intermodal DRT system available only in Dourdan), the simulation of the scenario resulting from the existing `RunScenarioCutter`, and the simulation resulting from the cutter proposed here. We measure the run times and the number of requests generated by the DMC model in each simulation. 

The results show that this cutter is able to identify a demand close to the one that would be identified by a full simulation while still requiring much less time as shown in the table and figure below. 

| simulation      	| number of requests  in the last iteration 	| run time  (minutes) 	| number of requests  compared to Full IdF 	| run time  compared to Full IdF 	|
|-----------------	|-------------------------------------------	|---------------------	|------------------------------------------	|--------------------------------	|
| Full IdF        	| 2999                                      	| 4086                	| 100%                                     	| 100%                           	|
| Legacy cutter   	| 1470                                      	| 25                  	| 49.0%                                    	| 0.6%                           	|
| Proposed cutter 	| 2975                                      	| 98                  	| 99.1%                                    	| 2.4%                           	|

![plot_requests_number (1)](https://github.com/user-attachments/assets/da6cec93-17a1-493c-aea4-feec3275e8a8)

## Conclusion 
This work is described in more details in a paper  submitted for presentation at TRB2025 (Chouaki, T., Hörl, S. (2025) A method for efficiently assessing the impact of local mobility services in large-scale agent-based simulations). 

In the following months, the code will be reworked and the process simplified as explained above. Moreover, further benchmarks of this functionality will be performed in the next months. A proper documentation on how to use it will also be written. 