### PR TITLE
Add cutter related docs and examples

### DIFF
--- a/core/src/main/java/org/eqasim/core/scenario/cutter/RunScenarioCutter.java
+++ b/core/src/main/java/org/eqasim/core/scenario/cutter/RunScenarioCutter.java
@@ -36,6 +36,8 @@ import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.scenario.ScenarioUtils;
 import org.matsim.core.utils.timing.TimeInterpretationModule;
+import ch.sbb.matsim.routing.pt.raptor.SwissRailRaptorModule;
+
 
 import com.google.inject.Injector;
 
@@ -158,6 +160,7 @@ public class RunScenarioCutter {
 				.addOverridingModule(new PopulationRouterModule(numberOfThreads, 100, false)) //
 				.addOverridingModule(new CutterTravelTimeModule(travelTime)) //
 				.addOverridingModule(new TimeInterpretationModule()) //
+				.addOverridingModule(new SwissRailRaptorModule()) //
 				.build();
 
 		PopulationRouter router = routingInjector.getInstance(PopulationRouter.class);

--- a/core/src/main/java/org/eqasim/core/scenario/cutter/RunScenarioCutter.java
+++ b/core/src/main/java/org/eqasim/core/scenario/cutter/RunScenarioCutter.java
@@ -36,7 +36,6 @@ import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.scenario.ScenarioUtils;
 import org.matsim.core.utils.timing.TimeInterpretationModule;
-import ch.sbb.matsim.routing.pt.raptor.SwissRailRaptorModule;
 
 
 import com.google.inject.Injector;
@@ -160,7 +159,6 @@ public class RunScenarioCutter {
 				.addOverridingModule(new PopulationRouterModule(numberOfThreads, 100, false)) //
 				.addOverridingModule(new CutterTravelTimeModule(travelTime)) //
 				.addOverridingModule(new TimeInterpretationModule()) //
-				.addOverridingModule(new SwissRailRaptorModule()) //
 				.build();
 
 		PopulationRouter router = routingInjector.getInstance(PopulationRouter.class);

--- a/core/src/main/java/org/eqasim/core/scenario/cutter/RunScenarioCutter.java
+++ b/core/src/main/java/org/eqasim/core/scenario/cutter/RunScenarioCutter.java
@@ -37,7 +37,6 @@ import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.scenario.ScenarioUtils;
 import org.matsim.core.utils.timing.TimeInterpretationModule;
 
-
 import com.google.inject.Injector;
 
 public class RunScenarioCutter {

--- a/core/src/main/java/org/eqasim/core/scenario/cutter/population/PopulationCutterModule.java
+++ b/core/src/main/java/org/eqasim/core/scenario/cutter/population/PopulationCutterModule.java
@@ -4,6 +4,8 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
+import java.util.List;
+import java.util.Arrays;
 
 import org.eqasim.core.scenario.cutter.extent.ScenarioExtent;
 import org.eqasim.core.scenario.cutter.population.trips.ModeAwareTripProcessor;
@@ -136,7 +138,10 @@ public class PopulationCutterModule extends AbstractModule {
 
 		if (transitConfig.isUseTransit()) {
 			// TODO: This may not only be "pt"!
-			tripProcessor.setProcessor(TransportMode.pt, transitTripProcessor);
+			List<String> transitModes = Arrays.asList("pt", "bus", "rail", "subway", "ferry", "taxi", "tram");
+			for (String mode : transitModes) {
+				tripProcessor.setProcessor(mode, transitTripProcessor);
+			}
 		}
 
 		return tripProcessor;

--- a/docs/cutting-scenarios-CML/cutting-scenarios-Transport-East.md
+++ b/docs/cutting-scenarios-CML/cutting-scenarios-Transport-East.md
@@ -143,7 +143,7 @@ bitsim batch run matsim \
 ```
 After rerunning the simulation, the `output_facilities.xml` will be updated accordingly. This file will be used as an input for the cutter.
 
- For 10% simulations, the matsim config file path for generating the facilities file:
+For 10% simulations, the matsim config file path for generating the facilities file can be found [here](https://github.com/arup-group/eqasim-java/docs/cutting-scenarios-CML/matsim_configs_example/matsim_config_generate_facilities.xml) or on TE AWS account at:
 ```
 /mnt/efs/simulations_refresh/10pc/2019_freight_update_baseline_20240726/0/matsim_config_generate_facilities.xml
 ```
@@ -279,6 +279,10 @@ java -Xmx12G -cp "core-1.5.0.jar:libs/matsim-2024.0/matsim-2024.0.jar:libs/matsi
 ```
 
 For cutting the 10% sims:
+
+The example of the matsim config for cutter can be found [here](https://github.com/arup-group/eqasim-java/docs/cutting-scenarios-CML/matsim_configs_example/matsim_config_cutter_no_intermodal_bike.xml)
+
+Command to run the cutter:
 ```sh
 java -Xmx12G -cp "core-1.5.0.jar:libs/matsim-2024.0/matsim-2024.0.jar:libs/matsim-2024.0/libs/*" \
  org.eqasim.core.scenario.cutter.RunScenarioCutter \
@@ -335,8 +339,8 @@ For rerun the 10%, when repeating the same process, it threw another errors sayi
 
 There is python script using to remove the freight population in the population xml at `/eqasim-java/docs/cutting-scenarios-CML/python_scripts/remove_freight_subpop.py`.
 
-The updated config for 10% simulation can be found at `/mnt/efs/analysis/ys/matsim_cutter/output_no_intermodal_20240909_10pct/matsim_config_TE_cutting_validation_no_intermodal.xml`.
-
+The updated config for 10% simulation can be found at [here](https://github.com/arup-group/eqasim-java/docs/cutting-scenarios-CML/matsim_configs_example/matsim_config_TE_cutting_validation_no_intermodal_no_freight.xml) or TE AWS account at:
+`/mnt/efs/analysis/ys/matsim_cutter/output_no_intermodal_20240909_10pct/matsim_config_TE_cutting_validation_no_intermodal.xml`.
 
 For 10% simulations, the command to rerun the simulation is as follows:
 ```

--- a/docs/cutting-scenarios-CML/cutting-scenarios-Transport-East.md
+++ b/docs/cutting-scenarios-CML/cutting-scenarios-Transport-East.md
@@ -1,0 +1,348 @@
+## Background and use case
+
+Since the movements of millions of agents need to be simulated in MATSim, simulations
+are computationally expensive. Two strategies are commonly applied to reduce computational cost. First, the population can be scaled down  such that, for instance, only 10% or less of all households are simulated. 
+
+Second, if possible, only the region of interest should be simulated. While it is in principle possible to just create a scenario for a city or region from scratch, cutting them out from a larger scenario makes sense as interactions with the surroundings can be considered in the cutting process.
+
+Here is an example of 10% populations statisitcs before cutting:
+```
+Population Stats:
++--------------+--------+
+|         stat | total  |
++--------------+--------+
+|          hhs | 398691 |
+|      persons | 398691 |
++--------------+--------+
+Modes:
++---------------+--------+
+|         modes | total  |
++---------------+--------+
+|           car | 793577 |
+|          bike | 53111  |
+|          rail | 90146  |
+|          tram |  2156  |
+|        subway | 26145  |
+|           bus | 96143  |
+|          taxi | 73516  |
+|         ferry |  185   |
+| car_passenger | 155192 |
+|          walk | 565795 |
++---------------+--------+
+```
+
+After cutting: 
+```
+Population Stats:
++--------------+-------+
+|         stat | total |
++--------------+-------+
+|          hhs | 15367 |
+|      persons | 15367 |
++--------------+-------+
+Modes:
++---------------+-------+
+|         modes | total |
++---------------+-------+
+|           car | 24208 |
+|           bus |  501  |
+|          taxi |  120  |
+|          walk |  6009 |
+|          bike |  764  |
+| car_passenger |  3341 |
+|       outside |  5397 |
++---------------+-------+
+```
+
+The cutter is based on the [eqasim-java](https://github.com/eqasim-org/eqasim-java/tree/develop) open-source framework.
+There is a short description of cutting process [here](https://github.com/eqasim-org/eqasim-java/blob/develop/docs/cutting.md) where the cutter can been implemented on eqasim scenarios.
+
+More details of the cutting tool development can be found in chapter 4.2 [here](https://www.research-collection.ethz.ch/handle/20.500.11850/419837).
+
+This following document provides detailed instructions on setting up and running the cutter with simulations running by **city-modelling**.
+
+## Cutter Setup Guidance
+Since our simulation inputs (network, population) and configuration setup differ from the simulations supported by eqasim, a few changes are necessary to get the cutter working with the Transport East (TE) simulations.
+
+The inputs files we used cutter are based on the **Transport East AWS account #815306348607** simulations. Two scales of the simulations were tested via the whole cutting process(0.01% and 10%).  You can test the cutter process on the same AWS account by following the guidance described below.
+
+Please follow the instructions from the section to ensure the necessary configurations and files are correctly prepared. 
+
+## Prerequisites
+
+Before starting the cutting procedure, the following files need to be prepared:
+
+- MATSim configurations and simulation inputs
+- Network car geometry for snapping facilities to activities
+- A shapefile for cutting, set in the correct coordinate reference system (CRS). For cutting Transport East(TE) simulation, the CRS is `EPSG:27700`.
+
+### Step 1: Snap Facilities to Nearest Car Links
+The cutter expects all of the links used in the agent plans that allow to use the `car` mode since code is hardcoding [here](https://github.com/eqasim-org/eqasim-java/blob/develop/core/src/main/java/org/eqasim/core/scenario/validation/ScenarioValidator.java#L113).
+If cars are not allowed on the link, an error is logged, indicating that the person has an activity attached to a non-car link. 
+
+The solution is to use the [PAM CLI](https://github.com/arup-group/pam/pull/276) to snap facilities to the nearest car links, which is mapping activity locations to the agents' activities.
+
+**Command Example:**
+```
+pam snap-facilities \
+/mnt/efs/population/SE_2019_v1_1pct_2019_20231123/combined_intermodal/final/plans_001.xml \
+/mnt/efs/population/SE_2019_v1_1pct_2019_20231123/combined_intermodal/final/plans_001_snapped_facilities.xml \
+/mnt/efs/networks/network_with_access_and_0.75_freespeed_v2/standard_outputs/graph/geometry_only_subgraphs/subgraph_geometry_car_27700.geojson 
+```
+
+The first argument in the above command is the population input file, and the second argument is the output file where the snapped population data will be saved. The third argument is the network geometry of car links. By doing so, the population data will be updated with adding links attributes to the activity element and the updated plans files will be saved to a new xml file.
+
+An example of the 0.01% population file after snapping the facilities can be found at: 
+`/mnt/efs/population/SE_2019_v1_1pct_2019_20231123/combined_intermodal/final/plans_001_facilities_20240705.xml`
+
+For the 10% population, the example command to snap the facilities:
+```
+pam snap-facilities \
+/mnt/efs/population/SE_2019_v1_1pct_2019_20231123/combined_intermodal/final/plans.xml \
+/mnt/efs/population/SE_2019_v1_10pct_2019_20240702/combined/final/plans_20240731_kdtree.xml \
+/mnt/efs/networks/network_with_access_and_0.75_freespeed_v2/standard_outputs/graph/geometry_only_subgraphs/subgraph_geometry_car_27700.geojson 
+```
+The file updated 10% population xml file after snapping the facilities can be found at:
+`/mnt/efs/population/SE_2019_v1_10pct_2019_20240702/combined/final/plans_20240731_kdtree.xml`
+
+Example of the agent's activity before snapping:
+```xml
+<activity type="home" start_time="00:00:00" end_time="06:57:00" x="623126.0" y="262969.0"/>
+```
+
+Example of the agent's activity after snapping:
+
+```xml
+<activity type="home" start_time="00:00:00" end_time="06:57:00" link="402201" x="623126.0" y="262969.0"/>
+``` 
+
+### Step 2: Ensure a Non-Empty Facilities File
+
+The cutter requires a non-empty facilities file to function properly. The TE simulations did not previously extract the facility data. Therefore, it is necessary to generate this file from the simulation plans by rerunning the simulations.
+
+TO create a output_facilities.xml, it requires to add the following module to the MATSim config:
+**MATSim Config Example:**
+```xml
+<module name="facilities">
+  <param name="facilitiesSource" value="onePerActivityLocationsInPlansFile"/>
+</module>
+```
+
+For 0.01% simulations, config file path for generating the facilities file:
+```
+/mnt/efs/simulations_refresh/1pc/skims_fix_new_population_20231123/0/matsim_config_generate_facilities_locations.xml
+```
+
+Example command to run the simulations via bitsim:
+```
+bitsim batch run matsim \
+  -c "com.arup.cm.RunArupMatsim /mnt/efs/simulations_refresh/1pc/skims_fix_new_population_20231123/0/matsim_config_generate_facilities_locations.xml" \
+  -d "758645626094.dkr.ecr.eu-west-1.amazonaws.com/columbus:arup-matsim" \
+  -m 160000 \
+  -q spot_100_queue
+```
+After rerunning the simulation, the `output_facilities.xml` will be updated accordingly. This file will be used as an input for the cutter.
+
+ For 10% simulations, the matsim config file path for generating the facilities file:
+```
+/mnt/efs/simulations_refresh/10pc/2019_freight_update_baseline_20240726/0/matsim_config_generate_facilities.xml
+```
+
+Example command to run the simulations via bitsim:
+```
+bitsim batch run matsim 
+  -c "com.arup.cm.RunArupMatsim /efs/simulations_refresh/10pc/2019_freight_update_baseline_20240726/0/matsim_config_generate_facilities.xml" 
+  -d "758645626094.dkr.ecr.eu-west-1.amazonaws.com/columbus:arup-matsim" 
+  -m 240000 
+  -q spot_100_queue
+```
+
+
+### Step 3: Provide a Shapefile
+Ensure the shapefile is saved with the `.shp` extension and uses the same CRS as input data. You can use [geojson.io](https://geojson.io/) to draw the shape for cutting. Make sure it is a compact shape without holes. The shapefile should only contain a single polygon feature.
+The cordinate system can be found at the very beginning of the matsim config:
+```xml
+<param name="coordinateSystem" value="EPSG:27700"/>
+```
+
+Shapefile example was saved at:
+```
+/mnt/efs/analysis/ys/matsim_cutter/cut_shape_file/te_bury_st_edmund_27700.shp
+```
+
+
+### Step 4: Update MATSim Configuration
+
+Several input files need to be prepared for cutting, and most of them come from the previous simulations:
+1. Matsim config: Use the previous input `matsim_config.xml` (the one when previous ran simulations to generate the facilities) as a new config to make some changes for cutter. Then a few more changes need to be made to matsim config when rerun the simulations with the outputs from the cutter
+2. Population: Use the `output_plans.xml.gz` and `output_vehicles.xml.gz` from simulation outputs. 
+3. Network and transit files: Use the `output_network.xml.gz`, `output_transitSchedule.xml.gz`, `output_transitVehicles.xml.gz` from simulation outputs
+4. Facilty: Use the `output_facilities.xml.gz` from simulation outputs
+5. Shape files: The subset area shape file `te_bury_st_edmund_27700.shp` as descibed in the previous step.
+
+#### Updates to the `matsim_config.xml`
+1. Update the input file paths to the correct files, including the paths of network, population, and transit files.
+
+2. Add teleported `outside` mode into the `planscalcroute` module
+```xml
+<parameterset type="teleportedModeParameters">
+  <param name="beelineDistanceFactor" value="1.3"/>
+  <param name="mode" value="outside"/>
+  <param name="teleportedModeFreespeedFactor" value="null"/>
+  <param name="teleportedModeSpeed" value="4.166666666666667"/>
+</parameterset>
+```
+
+3. Update the `facilities` module setting in the config.
+Update the config to use pre-defined facilities data from the previous simulations facilities outputs.
+```xml
+<module name="facilities">
+  <param name="facilitiesSource" value="fromFile"/>
+  <param name="inputFacilitiesFile" value="output_facilities.xml.gz"/>
+</module>
+```
+
+4. Make changes to the `swissRailRaptor` module.
+During the cutting process, we found the routing algorithm is being given requests between facilities with link IDs that are in the cut network. Raptor has a reference to a network here and that network is a subsetted network. But when raptor is being asked to calculate the route, it produces legs referencing links that no longer exist in the network which induced an NullPointerException error.
+
+The temporary solution is to comment out the `intermodalAccessEgress` parametersets in the `swissRailRaptor` for `bike`, `car`, `taxi` and `car_passenger` since it's not compatible with the cutter, as shown below:
+
+```xml
+<parameterset type="intermodalAccessEgress">
+      <param name="mode" value="bike"/>
+      <param name="initialSearchRadius" value="2000"/>
+      <param name="maxRadius" value="5000"/>
+      <param name="personFilterAttribute" value="intermodalBike"/>
+      <param name="personFilterValue" value="yes"/>
+      <param name="stopFilterAttribute" value="bikeAccessible"/>
+      <param name="stopFilterValue" value="true"/>
+    </parameterset>
+    <parameterset type="intermodalAccessEgress">
+      <param name="mode" value="car"/>
+      <param name="initialSearchRadius" value="5000"/>
+      <param name="searchExtensionRadius" value="1000.0"/>
+      <param name="maxRadius" value="10000"/>
+      <param name="linkIdAttribute" value="accessLinkId_car"/>
+      <param name="personFilterAttribute" value="intermodalCar"/>
+      <param name="personFilterValue" value="yes"/>
+      <param name="stopFilterAttribute" value="carAccessible"/>
+      <param name="stopFilterValue" value="true"/>
+    </parameterset>
+    <parameterset type="intermodalAccessEgress">
+      <param name="mode" value="taxi"/>
+      <param name="initialSearchRadius" value="5000"/>
+      <param name="searchExtensionRadius" value="1000.0"/>
+      <param name="maxRadius" value="10000"/>
+      <param name="linkIdAttribute" value="accessLinkId_car"/>
+      <param name="personFilterAttribute" value="intermodalTaxi"/>
+      <param name="personFilterValue" value="yes"/>
+      <param name="stopFilterAttribute" value="carAccessible"/>
+      <param name="stopFilterValue" value="true"/>
+    </parameterset>
+    <parameterset type="intermodalAccessEgress">
+      <param name="mode" value="car_passenger"/>
+      <param name="initialSearchRadius" value="5000"/>
+      <param name="searchExtensionRadius" value="1000.0"/>
+      <param name="maxRadius" value="10000"/>
+      <param name="linkIdAttribute" value="accessLinkId_car"/>
+      <param name="personFilterAttribute" value="intermodalPassenger"/>
+      <param name="personFilterValue" value="yes"/>
+      <param name="stopFilterAttribute" value="carAccessible"/>
+      <param name="stopFilterValue" value="true"/>
+    </parameterset>
+```
+
+5. Comment out `FastAStarLandmarks` since the cutter didn't support this parameter.
+
+```xml
+<param name="routingAlgorithmType" value="FastAStarLandmarks"/> 
+```
+
+6. Run the cutter
+Here are examples of the updated MATSim config can be found at:
+
+For cutting 0.01% sims: `/mnt/efs/analysis/ys/matsim_cutter/input_files_locations_facilities/matsim_config_cutter.xml`
+For cutting the 10% sims: `/mnt/efs/analysis/ys/matsim_cutter/input_files_locations_facilities_10pc_20240909/matsim_config_cutter_no_intermodal_bike.xml`
+
+The example running command is saved in a bash script: `/mnt/efs/analysis/ys/matsim_cutter/run_cutter.sh`
+
+For cutting 0.01% sims:
+```sh
+java -Xmx12G -cp "core-1.5.0.jar:libs/matsim-2024.0/matsim-2024.0.jar:libs/matsim-2024.0/libs/*" \
+ org.eqasim.core.scenario.cutter.RunScenarioCutter \
+ --config-path /mnt/efs/analysis/ys/matsim_cutter/input_files_locations_facilities/matsim_config_cutter.xml \
+ --output-path output_20240729_001pct \
+ --extent-path /mnt/efs/analysis/ys/matsim_cutter/cut_shape_file/te_bury_st_edmund_27700.shp \
+ --config:plans.inputPlansFile /mnt/efs/analysis/ys/matsim_cutter/input_files_locations_facilities/output_plans.xml\
+ --prefix TE_cutter_ \
+ --threads 4 
+```
+
+For cutting the 10% sims:
+```sh
+java -Xmx12G -cp "core-1.5.0.jar:libs/matsim-2024.0/matsim-2024.0.jar:libs/matsim-2024.0/libs/*" \
+ org.eqasim.core.scenario.cutter.RunScenarioCutter \
+ --config-path /mnt/efs/analysis/ys/matsim_cutter/input_files_locations_facilities_10pc_20240909/matsim_config_cutter_no_intermodal_bike.xml \
+ --output-path /mnt/efs/analysis/ys/matsim_cutter/output_no_intermodal_20240912_10pct \
+ --extent-path /mnt/efs/analysis/ys/matsim_cutter/cut_shape_file/te_bury_st_edmund_27700.shp \
+ --config:plans.inputPlansFile /mnt/efs/analysis/ys/matsim_cutter/input_files_locations_facilities_10pc_20240909/output_plans.xml.gz \
+ --prefix TE_cutter_ \
+ --threads 4
+```
+
+### Changes to the Cutter Source Code
+
+The JAR file `core-1.5.0.jar` was compiled using the `eqasim-java/core/pom.xml`. One change was made to the source code to make the cutter work. The changes can be found in the forked eqasim repo on the branch named `cutter_test` ([link](https://github.com/arup-group/eqasim-java/tree/cutter-test)).
+Michael helped with creating the `matsim-2024.0.jar` from the latest version of the [matsim-libs](https://github.com/matsim-org/matsim-libs). It was built from the latest source for all of matsim, contribs, and dependencies, and then dumped into a libs directory grabbed all of the config, shape, with editing them as required to fix paths, put them all in a input-files directory. The jar files and dependencies can be found at TE AWS account: `/mnt/efs/analysis/ys/matsim_cutter`. 
+
+
+1. We need to update the `provideModeAwareTripProcessor` method to register the modes with their appropriate processors from the input plans. The original code can be found [here](https://github.com/eqasim-org/eqasim-java/blob/develop/core/src/main/java/org/eqasim/core/scenario/cutter/population/PopulationCutterModule.java#L137-L139). 
+Otherwise, it will throw `NullPointerException` error since the used transit modes are not available. 
+
+Updated code:
+```java
+		if (transitConfig.isUseTransit()) {
+			// TODO: This may not only be "pt"!
+			List<String> transitModes = Arrays.asList("pt", "bus", "rail", "subway", "ferry", "taxi", "tram");
+			for (String mode : transitModes) {
+				tripProcessor.setProcessor(mode, transitTripProcessor);
+			}
+		}
+```
+
+After making changes, compile the code using the Maven POM file located at `eqasim-java/core/pom.xml`. 
+
+If the cutter runs successfully to the end, you will obtain the outputs including facilities, network, population, transit schedule vehicles, and the MATSim config.
+
+
+### Re-run the simulations with cutting inputs
+The final step is to rerun and validate the simulation outputs. 
+
+It is recommended to make some changes to the original matsim config by adding the `outside` activity and mode into the `planCalcScore` module, and add `outside` into the `transitModes` parameter in the `transit` module.
+
+The updated config for 0.01% simulation can be found at `/mnt/efs/analysis/ys/matsim_cutter/output_20240729_001pct/matsim_config_TE_cutting_validation.xml`.
+
+For 0.01% simulations, the command to rerun the simulation is as follows:
+```
+bitsim batch run matsim 
+  -c "com.arup.cm.RunArupMatsim /efs/simulations_refresh/10pc/2019_freight_update_baseline_20240726/0/matsim_config_generate_facilities.xml" 
+  -d "758645626094.dkr.ecr.eu-west-1.amazonaws.com/columbus:arup-matsim" 
+  -m 240000 
+  -q spot_100_queue
+```
+
+For rerun the 10%, when repeating the same process, it threw another errors saying the scoring parameters for the `walk` mode may not have been properly initialized or accessed. From the investigations, the error was likely caused by a mode or scoring mismatch between the freight subpopulation (which should not have been using the `walk` mode but it seems somehow) and the config of the simulation. By removing the freight agents, using the simplified population xml file, the simulation and avoided the scenario where missing walk mode error. This allowed the simulation to complete successfully. More investigations need to be done to understand why the freight subpopulation are incompatible with simulations.
+
+There is python script using to remove the freight population in the population xml at `/eqasim-java/docs/cutting-scenarios-CML/python_scripts/remove_freight_subpop.py`.
+
+The updated config for 10% simulation can be found at `/mnt/efs/analysis/ys/matsim_cutter/output_no_intermodal_20240909_10pct/matsim_config_TE_cutting_validation_no_intermodal.xml`.
+
+
+For 10% simulations, the command to rerun the simulation is as follows:
+```
+bitsim batch run matsim 
+  -c "com.arup.cm.RunArupMatsim /efs/analysis/ys/matsim_cutter/output_no_intermodal_20240909_10pct/matsim_config_TE_cutting_validation_no_intermodal_no_freight.xml" 
+  -d "758645626094.dkr.ecr.eu-west-1.amazonaws.com/columbus:arup-matsim" 
+  -m 240000 
+  -q spot_100_queue
+```

--- a/docs/cutting-scenarios-CML/matsim-cutter-debug-notes.md
+++ b/docs/cutting-scenarios-CML/matsim-cutter-debug-notes.md
@@ -2,11 +2,11 @@ MATSim cutter debug notes
 ===================================
 This is the notes for recording of the debug process with matsim cutter for cutting tranpost east simulations.
 
-Remainning bugs when dealing with the TE cutting process:
+Remainning bugs when testing with the cutting process for 10% TE siulations:
 1. `NullPointerException` error during the cutting process:
-This the bug that the cutter routed the post-cutting population More details are listed from [here]()
+This the bug that the cutter routed the post-cutting population and more details are described below
+
 2. Missing `walk` parameters when validated the TE 10% post-cutting simulation.
-More details are listed from [here]()
 
 
 ### Progress of debugging the `NullPointerException` when processing the cutter. 

--- a/docs/cutting-scenarios-CML/matsim-cutter-debug-notes.md
+++ b/docs/cutting-scenarios-CML/matsim-cutter-debug-notes.md
@@ -1,0 +1,1158 @@
+MATSim cutter debug notes
+===================================
+This is the notes for recording of the debug process with matsim cutter for cutting tranpost east simulations.
+
+Remainning bugs when dealing with the TE cutting process:
+1. `NullPointerException` error during the cutting process:
+This the bug that the cutter routed the post-cutting population More details are listed from [here]()
+2. Missing `walk` parameters when validated the TE 10% post-cutting simulation.
+More details are listed from [here]()
+
+
+### Progress of debugging the `NullPointerException` when processing the cutter. 
+
+It failed with the following error when ran the cutter for TE simulations:
+
+```xml
+2024-07-18T12:44:53,471  INFO SpeedyALTData:173 calculate min travelcost...
+2024-07-18T12:44:53,526  INFO SpeedyALTData:173 calculate min travelcost...
+2024-07-18T12:44:53,530  INFO SpeedyALTData:173 calculate min travelcost...
+java.lang.NullPointerException: Cannot invoke "org.matsim.pt.transitSchedule.api.TransitStopFacility.getCoord()" because "nearestStop" is null
+        at ch.sbb.matsim.routing.pt.raptor.DefaultRaptorStopFinder.addInitialStopsForParamSet(DefaultRaptorStopFinder.java:197)
+        at ch.sbb.matsim.routing.pt.raptor.DefaultRaptorStopFinder.findIntermodalStops(DefaultRaptorStopFinder.java:153)
+        at ch.sbb.matsim.routing.pt.raptor.DefaultRaptorStopFinder.findAccessStops(DefaultRaptorStopFinder.java:103)
+        at ch.sbb.matsim.routing.pt.raptor.DefaultRaptorStopFinder.findStops(DefaultRaptorStopFinder.java:91)
+        at ch.sbb.matsim.routing.pt.raptor.SwissRailRaptor.findAccessStops(SwissRailRaptor.java:250)
+        at ch.sbb.matsim.routing.pt.raptor.SwissRailRaptor.calcRoute(SwissRailRaptor.java:91)
+        at ch.sbb.matsim.routing.pt.raptor.SwissRailRaptorRoutingModule.calcRoute(SwissRailRaptorRoutingModule.java:70)
+        at org.matsim.core.router.TripRouter.calcRoute(TripRouter.java:180)
+        at org.eqasim.core.scenario.routing.PlanRouter.run(PlanRouter.java:58)
+        at org.eqasim.core.scenario.routing.PopulationRouter$Worker.run(PopulationRouter.java:90)
+        at java.base/java.lang.Thread.run(Thread.java:840)
+Exception in thread "main" java.lang.RuntimeException: Found errors in routing threads
+        at org.eqasim.core.scenario.routing.PopulationRouter.run(PopulationRouter.java:61)
+        at org.eqasim.core.scenario.cutter.RunScenarioCutter.main(RunScenarioCutter.java:167)
+```
+
+with setting up the intermodal access
+```xml
+ <parameterset type="intermodalAccessEgress">
+      <param name="mode" value="bike"/>
+      <param name="initialSearchRadius" value="2000"/>
+      <param name="maxRadius" value="5000"/>
+      <param name="personFilterAttribute" value="intermodalBike"/>
+      <param name="personFilterValue" value="yes"/>
+      <param name="stopFilterAttribute" value="bikeAccessible"/>
+      <param name="stopFilterValue" value="true"/>
+    </parameterset>
+    <parameterset type="intermodalAccessEgress">
+      <param name="mode" value="car"/>
+      <param name="initialSearchRadius" value="5000"/>
+      <param name="searchExtensionRadius" value="1000.0"/>
+      <param name="maxRadius" value="10000"/>
+      <param name="linkIdAttribute" value="accessLinkId_car"/>
+      <param name="personFilterAttribute" value="intermodalCar"/>
+      <param name="personFilterValue" value="yes"/>
+      <param name="stopFilterAttribute" value="carAccessible"/>
+      <param name="stopFilterValue" value="true"/>
+    </parameterset>
+    <parameterset type="intermodalAccessEgress">
+      <param name="mode" value="taxi"/>
+      <param name="initialSearchRadius" value="5000"/>
+      <param name="searchExtensionRadius" value="1000.0"/>
+      <param name="maxRadius" value="10000"/>
+      <param name="linkIdAttribute" value="accessLinkId_car"/>
+      <param name="personFilterAttribute" value="intermodalTaxi"/>
+      <param name="personFilterValue" value="yes"/>
+      <param name="stopFilterAttribute" value="carAccessible"/>
+      <param name="stopFilterValue" value="true"/>
+    </parameterset>
+    <parameterset type="intermodalAccessEgress">
+      <param name="mode" value="car_passenger"/>
+      <param name="initialSearchRadius" value="5000"/>
+      <param name="searchExtensionRadius" value="1000.0"/>
+      <param name="maxRadius" value="10000"/>
+      <param name="linkIdAttribute" value="accessLinkId_car"/>
+      <param name="personFilterAttribute" value="intermodalPassenger"/>
+      <param name="personFilterValue" value="yes"/>
+      <param name="stopFilterAttribute" value="carAccessible"/>
+      <param name="stopFilterValue" value="true"/>
+    </parameterset>
+```
+
+The intermodal access settings(also known as raptor) in the `swissRailRaptor` in the matsim config file lead to issues when trying to find the corresponding stops for each mode. It might not have stops which leading to issues when the SwissRailRaptor tries to find suitable stops.
+
+
+## RUNNING THE CUTTER LOCALLY ON TE
+
+The following notes were from Michael when ran the cutter locally via dubbger. 
+
+- Yuhao's launch command (on an EC2 instance):
+
+``` 
+--config-path /mnt/efs/analysis/ys/matsim_cutter/input_files_locations_facilities_10pc_20240807/matsim_config_cutter_intermodal_bike.xml \
+ --output-path /mnt/efs/analysis/ys/matsim_cutter/output_with_intermodal_bike_20240813_10pct \
+ --extent-path /mnt/efs/analysis/ys/matsim_cutter/cut_shape_file/te_bury_st_edmund_27700.shp \
+ --config:plans.inputPlansFile /mnt/efs/analysis/ys/matsim_cutter/input_files_locations_facilities_10pc_20240807/output_plans.xml.gz\
+ --prefix TE_cutter_ \
+ --prefix TE_cutter_ \
+ --threads 4
+ ```
+
+- Grabbed all of the input files off the TE EFS, dropped them into `/Users/mickyfitz/matsim-cutter/cutter-inputs/te/`
+
+- Edited cutter output in the `~/matsim-cutter/cutter-inputs/te/matsim_config_cutter_intermodal_bike.xml` config file:
+  - previously pointed to the EFS
+  - changed to `/Users/mickyfitz/matsim-cutter/cutter-outputs/te` 
+
+- My local runtime params (running in IntelliJ):
+
+```
+--config-path /Users/mickyfitz/matsim-cutter/cutter-inputs/te/matsim_config_cutter_intermodal_bike.xml
+--output-path /Users/mickyfitz/matsim-cutter/cutter-outputs/te
+--extent-path /Users/mickyfitz/matsim-cutter/cutter-inputs/te/shape-file/te_bury_st_edmund_27700.shp
+--config:plans.inputPlansFile /Users/mickyfitz/matsim-cutter/cutter-inputs/te/output_plans.xml.gz
+--prefix TE_cutter_
+--threads 4
+```
+
+- Some model metadata:
+  - network nodes: 447,610
+  - network links: 985,170
+  - number of agents: 
+
+- Failed with the same NPE:
+
+```
+java.lang.NullPointerException: Cannot invoke "org.matsim.pt.transitSchedule.api.TransitStopFacility.getCoord()" because "nearestStop" is null
+  at ch.sbb.matsim.routing.pt.raptor.DefaultRaptorStopFinder.addInitialStopsForParamSet(DefaultRaptorStopFinder.java:197)
+  at ch.sbb.matsim.routing.pt.raptor.DefaultRaptorStopFinder.findIntermodalStops(DefaultRaptorStopFinder.java:153)
+  at ch.sbb.matsim.routing.pt.raptor.DefaultRaptorStopFinder.findAccessStops(DefaultRaptorStopFinder.java:103)
+  at ch.sbb.matsim.routing.pt.raptor.DefaultRaptorStopFinder.findStops(DefaultRaptorStopFinder.java:91)
+  at ch.sbb.matsim.routing.pt.raptor.SwissRailRaptor.findAccessStops(SwissRailRaptor.java:250)
+  at ch.sbb.matsim.routing.pt.raptor.SwissRailRaptor.calcRoute(SwissRailRaptor.java:91)
+  at ch.sbb.matsim.routing.pt.raptor.SwissRailRaptorRoutingModule.calcRoute(SwissRailRaptorRoutingModule.java:70)
+  at org.matsim.core.router.TripRouter.calcRoute(TripRouter.java:180)
+  at org.eqasim.core.scenario.routing.PlanRouter.run(PlanRouter.java:58)
+  at org.eqasim.core.scenario.routing.PopulationRouter$Worker.run(PopulationRouter.java:91)
+  at java.base/java.lang.Thread.run(Thread.java:833)
+Exception in thread "main" java.lang.RuntimeException: Found errors in routing threads
+  at org.eqasim.core.scenario.routing.PopulationRouter.run(PopulationRouter.java:61)
+  at org.eqasim.core.scenario.cutter.RunScenarioCutter.main(RunScenarioCutter.java:167)
+```
+
+
+- I added some logging around the error to pinpoint the agent and plan in `PopulationRouter.Worker.run()` (ln 93)
+```java
+        for (Person person : localTasks) {
+          for (Plan plan : person.getPlans()) {
+            try {
+              router.run(plan, replaceExistingRoutes, modes);
+            } catch (Exception e) {
+              System.err.println(String.format("Error routing plan for agent %s", person.getId()));
+              System.err.println(String.format("The problematic plan is %s", plan.getId()));
+              System.err.println(String.format("The problematic plan is %s", plan));
+              throw e;
+            }
+          }
+        }
+```
+
+- Some warnings about network links at cutter startup:
+```
+length=0.0 of link id 5174822858083189091_5174822858083189091 may cause problems
+```
+
+- The problematic agents:
+```
+Error routing plan for agent 100416
+The problematic plan is null
+The problematic plan is [score=undefined][nof_acts_legs=5][type=null][personId=100416]
+```
+```xml
+        <person id="100416">
+                <attributes>
+                        <attribute name="age" class="java.lang.Integer">23</attribute>
+                        <attribute name="age_group" class="java.lang.String">21 to 25</attribute>
+                        <attribute name="area_type" class="java.lang.String">urban</attribute>
+                        <attribute name="carAvail" class="java.lang.Boolean">true</attribute>
+                        <attribute name="car_avail" class="java.lang.String">yes</attribute>
+                        <attribute name="car_competition" class="java.lang.Double">1.0</attribute>
+                        <attribute name="disabled" class="java.lang.String">no</attribute>
+                        <attribute name="ev" class="java.lang.Boolean">false</attribute>
+                        <attribute name="gender" class="java.lang.String">male</attribute>
+                        <attribute name="hasBike" class="java.lang.Boolean">true</attribute>
+                        <attribute name="hasCar" class="java.lang.Boolean">true</attribute>
+                        <attribute name="hasDisability" class="java.lang.Boolean">false</attribute>
+                        <attribute name="hasLicence" class="java.lang.Boolean">true</attribute>
+                        <attribute name="hcounty" class="java.lang.String">Suffolk</attribute>
+                        <attribute name="hhincome" class="java.lang.String">high</attribute>
+                        <attribute name="hholdnumchildren" class="java.lang.Integer">0</attribute>
+                        <attribute name="hhsize" class="java.lang.Integer">2</attribute>
+                        <attribute name="hid" class="java.lang.String">100416</attribute>
+                        <attribute name="hid_old" class="java.lang.String">2006006952_6</attribute>
+                        <attribute name="householdid" class="java.lang.Integer">2006006952</attribute>
+                        <attribute name="hzone" class="java.lang.String">E02006277</attribute>
+                        <attribute name="indincome" class="java.lang.String">low</attribute>
+                        <attribute name="individualid" class="java.lang.Integer">2006016698</attribute>
+                        <attribute name="intermodalBike" class="java.lang.String">yes</attribute>
+                        <attribute name="intermodalCar" class="java.lang.String">yes</attribute>
+                        <attribute name="intermodalPassenger" class="java.lang.String">no</attribute>
+                        <attribute name="intermodalTaxi" class="java.lang.String">yes</attribute>
+                        <attribute name="marital_status" class="java.lang.String">single</attribute>
+                        <attribute name="region" class="java.lang.String">East of England</attribute>
+                        <attribute name="seasontickettype" class="java.lang.String">season_ticket</attribute>
+                        <attribute name="sex" class="java.lang.String">m</attribute>
+                        <attribute name="subpopulation" class="java.lang.String">high</attribute>
+                        <attribute name="surveyyear" class="java.lang.Integer">2006</attribute>
+                        <attribute name="vehicles" class="org.matsim.vehicles.PersonVehicles">{"car":"100416","taxi":"100416_taxi","car_passenger":"100416_car_passenger"}</attribute>
+                        <attribute name="workstatus" class="java.lang.String">full-time</attribute>
+                </attributes>
+                <plan score="153.7967889176747" selected="no">
+                        <activity type="home" link="5176972368624430675_5176972369251901811" facility="f_auto_3957" x="586860.0" y="264147.0" start_time="00:00:00" end_time="07:15:00" >
+                        </activity>
+                        <leg mode="walk" dep_time="07:15:00" trav_time="00:43:34">
+                                <attributes>
+                                        <attribute name="routingMode" class="java.lang.String">bus</attribute>
+                                </attributes>
+                                <route type="generic" start_link="5176972368624430675_5176972369251901811" end_link="5176971628156524759_5176971628129992151" trav_time="00:43:34" distance="2178.834128610987"></route>
+                        </leg>
+                        <activity type="work" link="5176971628156524759_5176971628129992151" facility="f_auto_1012" x="585190.0" y="264289.0" start_time="08:15:00" end_time="18:20:00" >
+                        </activity>
+                        <leg mode="walk" dep_time="18:20:00" trav_time="00:06:34">
+                                <attributes>
+                                        <attribute name="routingMode" class="java.lang.String">bus</attribute>
+                                </attributes>
+                                <route type="generic" start_link="5176971628156524759_5176971628129992151" end_link="5176971626509406753_5176971626509406753" trav_time="00:06:34" distance="329.14342336546457"></route>
+                        </leg>
+                        <activity type="pt interaction" link="5176971626509406753_5176971626509406753" x="585113.7817854984" y="264552.37120805687" max_dur="00:00:00" >
+                        </activity>
+                        <leg mode="walk" dep_time="18:26:34" trav_time="00:00:01">
+                                <attributes>
+                                        <attribute name="routingMode" class="java.lang.String">bus</attribute>
+                                </attributes>
+                                <route type="generic" start_link="5176971626509406753_5176971626509406753" end_link="5176971626509406753_5176971626509406753" trav_time="00:00:01" distance="0.0"></route>
+                        </leg>
+                        <activity type="pt interaction" link="5176971626509406753_5176971626509406753" x="585132.9173118277" y="264535.6685015094" max_dur="00:00:00" >
+                        </activity>
+                        <leg mode="bus" dep_time="18:26:35" trav_time="00:15:25">
+                                <attributes>
+                                        <attribute name="routingMode" class="java.lang.String">bus</attribute>
+                                </attributes>
+                                <route type="default_pt" start_link="5176971626509406753_5176971626509406753" end_link="5176971781817045223_5176971781817045223" trav_time="00:15:25" distance="764.3628558597625">{"transitRouteId":"12298_3","boardingTime":"18:40:00","transitLineId":"12298","accessFacilityId":"390GBURY1","egressFacilityId":"390050800"}</route>
+                        </leg>
+                        <activity type="pt interaction" link="5176971781817045223_5176971781817045223" x="585350.9101181736" y="265156.846492815" max_dur="00:00:00" >
+                        </activity>
+                        <leg mode="walk" dep_time="18:42:00" trav_time="00:01:44">
+                                <attributes>
+                                        <attribute name="routingMode" class="java.lang.String">bus</attribute>
+                                </attributes>
+                                <route type="generic" start_link="5176971781817045223_5176971781817045223" end_link="5176971782047279209_5176971782047279209" trav_time="00:01:44" distance="87.0"></route>
+                        </leg>
+                        <activity type="pt interaction" link="5176971782047279209_5176971782047279209" x="585301.8659321591" y="265201.775893673" max_dur="00:00:00" >
+                        </activity>
+                        <leg mode="walk" dep_time="18:43:44" trav_time="00:00:00">
+                                <attributes>
+                                        <attribute name="routingMode" class="java.lang.String">bus</attribute>
+                                </attributes>
+                                <route type="generic" start_link="5176971782047279209_5176971782047279209" end_link="351882" trav_time="00:00:00" distance="0.0"></route>
+                        </leg>
+                        <activity type="pt interaction" link="351882" x="584873.589101083" y="265219.2209167288" max_dur="00:00:00" >
+                        </activity>
+                        <leg mode="car" dep_time="18:43:44" trav_time="00:05:08">
+                                <attributes>
+                                        <attribute name="routingMode" class="java.lang.String">bus</attribute>
+                                </attributes>
+                                <route type="links" start_link="351882" end_link="5176972368624430675_5176972369251901811" trav_time="00:05:08" distance="4252.04439399038" vehicleRefId="null">351882 149803 173985 5176971781650859901_5176971620856238905 66628 114785 5176971621009784379_5176971621013124615 619265 517281 198796 5176971779363914867_5176971779453028437 278389 571492 5176971779669336995_5176971779678391225 129891 609458 172720 162570 5176972406610113833_5176972406600626477 133548 311113 11811 250171 5176972407293168211_5176972407501322301 188897 396780 75816 5176972368624430675_5176972369251901811</route>
+                        </leg>
+                        <activity type="home" link="5176972368624430675_5176972369251901811" facility="f_auto_3957" x="586860.0" y="264147.0" start_time="19:30:00" end_time="24:00:00" >
+                        </activity>
+                </plan>
+
+                <plan score="209.4593927492598" selected="yes">
+                        <activity type="home" link="5176972368624430675_5176972369251901811" facility="f_auto_3957" x="586860.0" y="264147.0" start_time="00:00:00" end_time="07:02:03" >
+                        </activity>
+                        <leg mode="walk" dep_time="07:02:03" trav_time="00:43:34">
+                                <attributes>
+                                        <attribute name="routingMode" class="java.lang.String">bus</attribute>
+                                </attributes>
+                                <route type="generic" start_link="5176972368624430675_5176972369251901811" end_link="5176971628156524759_5176971628129992151" trav_time="00:43:34" distance="2178.834128610987"></route>
+                        </leg>
+                        <activity type="work" link="5176971628156524759_5176971628129992151" facility="f_auto_1012" x="585190.0" y="264289.0" start_time="08:15:00" end_time="18:21:48" >
+                        </activity>
+                        <leg mode="walk" dep_time="18:21:48" trav_time="00:43:34">
+                                <attributes>
+                                        <attribute name="routingMode" class="java.lang.String">bus</attribute>
+                                </attributes>
+                                <route type="generic" start_link="5176971628156524759_5176971628129992151" end_link="5176972368624430675_5176972369251901811" trav_time="00:43:34" distance="2178.834128610987"></route>
+                        </leg>
+                        <activity type="home" link="5176972368624430675_5176972369251901811" facility="f_auto_3957" x="586860.0" y="264147.0" start_time="19:30:00" end_time="24:12:58" >
+                        </activity>
+                </plan>
+
+        </person>
+```
+
+```
+Error routing plan for agent 103660
+The problematic plan is null
+The problematic plan is [score=undefined][nof_acts_legs=7][type=null][personId=103660]
+```
+```xml
+        <person id="103660">
+                <attributes>
+                        <attribute name="age" class="java.lang.Integer">18</attribute>
+                        <attribute name="age_group" class="java.lang.String">16 to 20</attribute>
+                        <attribute name="area_type" class="java.lang.String">urban</attribute>
+                        <attribute name="carAvail" class="java.lang.Boolean">true</attribute>
+                        <attribute name="car_avail" class="java.lang.String">yes</attribute>
+                        <attribute name="car_competition" class="java.lang.Double">1.0</attribute>
+                        <attribute name="disabled" class="java.lang.String">no</attribute>
+                        <attribute name="ev" class="java.lang.Boolean">false</attribute>
+                        <attribute name="gender" class="java.lang.String">female</attribute>
+                        <attribute name="hasBike" class="java.lang.Boolean">true</attribute>
+                        <attribute name="hasCar" class="java.lang.Boolean">true</attribute>
+                        <attribute name="hasDisability" class="java.lang.Boolean">false</attribute>
+                        <attribute name="hasLicence" class="java.lang.Boolean">true</attribute>
+                        <attribute name="hcounty" class="java.lang.String">Suffolk</attribute>
+                        <attribute name="hhincome" class="java.lang.String">low</attribute>
+                        <attribute name="hholdnumchildren" class="java.lang.Integer">0</attribute>
+                        <attribute name="hhsize" class="java.lang.Integer">2</attribute>
+                        <attribute name="hid" class="java.lang.String">103660</attribute>
+                        <attribute name="hid_old" class="java.lang.String">2006008433_5</attribute>
+                        <attribute name="householdid" class="java.lang.Integer">2006008433</attribute>
+                        <attribute name="hzone" class="java.lang.String">E02006278</attribute>
+                        <attribute name="indincome" class="java.lang.String">low</attribute>
+                        <attribute name="individualid" class="java.lang.Integer">2006020140</attribute>
+                        <attribute name="intermodalBike" class="java.lang.String">yes</attribute>
+                        <attribute name="intermodalCar" class="java.lang.String">yes</attribute>
+                        <attribute name="intermodalPassenger" class="java.lang.String">no</attribute>
+                        <attribute name="intermodalTaxi" class="java.lang.String">yes</attribute>
+                        <attribute name="marital_status" class="java.lang.String">single</attribute>
+                        <attribute name="region" class="java.lang.String">East of England</attribute>
+                        <attribute name="seasontickettype" class="java.lang.String">season_ticket</attribute>
+                        <attribute name="sex" class="java.lang.String">f</attribute>
+                        <attribute name="subpopulation" class="java.lang.String">low</attribute>
+                        <attribute name="surveyyear" class="java.lang.Integer">2006</attribute>
+                        <attribute name="vehicles" class="org.matsim.vehicles.PersonVehicles">{"car":"103660","taxi":"103660_taxi","car_passenger":"103660_car_passenger"}</attribute>
+                        <attribute name="workstatus" class="java.lang.String">full-time</attribute>
+                </attributes>
+                <plan score="102.83088242589389" selected="yes">
+                        <activity type="home" link="5176971422848555195_5176971422678725439" facility="f_auto_5287" x="584480.0" y="265597.0" start_time="00:00:00" end_time="13:20:00" >
+                        </activity>
+                        <leg mode="walk" dep_time="13:20:00" trav_time="00:07:40">
+                                <attributes>
+                                        <attribute name="routingMode" class="java.lang.String">rail</attribute>
+                                </attributes>
+                                <route type="generic" start_link="5176971422848555195_5176971422678725439" end_link="5176971428130569763_5176971428130569763" trav_time="00:07:40" distance="383.93481572394035"></route>
+                        </leg>
+                        <activity type="pt interaction" link="5176971428130569763_5176971428130569763" x="584318.3487180443" y="265333.49845732463" max_dur="00:00:00" >
+                        </activity>
+                        <leg mode="walk" dep_time="13:27:40" trav_time="00:00:01">
+                                <attributes>
+                                        <attribute name="routingMode" class="java.lang.String">rail</attribute>
+                                </attributes>
+                                <route type="generic" start_link="5176971428130569763_5176971428130569763" end_link="5176971428130569763_5176971428130569763" trav_time="00:00:01" distance="0.0"></route>
+                        </leg>
+                        <activity type="pt interaction" link="5176971428130569763_5176971428130569763" x="584322.8886494723" y="265346.92306213506" max_dur="00:00:00" >
+                        </activity>
+                        <leg mode="bus" dep_time="13:27:41" trav_time="00:06:00">
+                                <attributes>
+                                        <attribute name="routingMode" class="java.lang.String">rail</attribute>
+                                </attributes>
+                                <route type="default_pt" start_link="5176971428130569763_5176971428130569763" end_link="5176971782264587763_5176971782264587763" trav_time="00:06:00" distance="2062.1549659646353">{"transitRouteId":"6761_1","boardingTime":"13:28:00","transitLineId":"6761","accessFacilityId":"390050846","egressFacilityId":"390050804"}</route>
+                        </leg>
+                        <activity type="pt interaction" link="5176971782264587763_5176971782264587763" x="585373.8724144999" y="265218.841602804" max_dur="00:00:00" >
+                        </activity>
+                        <leg mode="walk" dep_time="13:33:41" trav_time="00:01:51">
+                                <attributes>
+                                        <attribute name="routingMode" class="java.lang.String">rail</attribute>
+                                </attributes>
+                                <route type="generic" start_link="5176971782264587763_5176971782264587763" end_link="5176971782047279209_5176971782047279209" trav_time="00:01:51" distance="97.0"></route>
+                        </leg>
+                        <activity type="pt interaction" link="5176971782047279209_5176971782047279209" x="585301.8661946068" y="265201.778045431" max_dur="00:00:00" >
+                        </activity>
+                        <leg mode="rail" dep_time="13:35:37" trav_time="01:05:23">
+                                <attributes>
+                                        <attribute name="routingMode" class="java.lang.String">rail</attribute>
+                                </attributes>
+                                <route type="default_pt" start_link="5176971782047279209_5176971782047279209" end_link="5177011483058159475_5177011483058159475" trav_time="01:05:23" distance="41551.1341413336">{"transitRouteId":"55095_2","boardingTime":"13:55:00","transitLineId":"55095","accessFacilityId":"910GBSTEDMS","egressFacilityId":"910GCAMBDGE"}</route>
+                        </leg>
+                        <activity type="pt interaction" link="5177011483058159475_5177011483058159475" x="546196.9010489563" y="257246.6591357863" max_dur="00:00:00" >
+                        </activity>
+                        <leg mode="walk" dep_time="14:41:00" trav_time="00:00:00">
+                                <attributes>
+                                        <attribute name="routingMode" class="java.lang.String">rail</attribute>
+                                </attributes>
+                                <route type="generic" start_link="5177011483058159475_5177011483058159475" end_link="72085" trav_time="00:00:00" distance="0.0"></route>
+                        </leg>
+                        <activity type="pt interaction" link="72085" x="546110.2881200865" y="256703.126647814" max_dur="00:00:00" >
+                        </activity>
+                        <leg mode="car" dep_time="14:41:00" trav_time="00:01:44">
+                                <attributes>
+                                        <attribute name="routingMode" class="java.lang.String">rail</attribute>
+                                </attributes>
+                                <route type="links" start_link="72085" end_link="417585" trav_time="00:01:44" distance="1616.2390590780249" vehicleRefId="null">72085 402743 176248 475628 5177011590460321117_5177011590309233653 313606 45072 300363 5177011585251686375_5177011585831667673 567970 223505 417585</route>
+                        </leg>
+                        <activity type="work" link="417585" facility="f_auto_494" x="545271.0" y="258180.0" start_time="13:45:00" end_time="21:55:00" >
+                        </activity>
+                        <leg mode="bike" dep_time="21:55:00" trav_time="00:06:50">
+                                <attributes>
+                                        <attribute name="routingMode" class="java.lang.String">rail</attribute>
+                                </attributes>
+                                <route type="generic" start_link="417585" end_link="5177011483058159475_5177011483058159475" trav_time="00:06:50" distance="1709.1010171858297"></route>
+                        </leg>
+                        <activity type="pt interaction" link="5177011483058159475_5177011483058159475" x="546196.8985057314" y="257246.6632130217" max_dur="00:00:00" >
+                        </activity>
+                        <leg mode="walk" dep_time="22:01:50" trav_time="00:00:01">
+                                <attributes>
+                                        <attribute name="routingMode" class="java.lang.String">rail</attribute>
+                                </attributes>
+                                <route type="generic" start_link="5177011483058159475_5177011483058159475" end_link="5177011483058159475_5177011483058159475" trav_time="00:00:01" distance="0.0"></route>
+                        </leg>
+                        <activity type="pt interaction" link="5177011483058159475_5177011483058159475" x="546196.9010489563" y="257246.6591357863" max_dur="00:00:00" >
+                        </activity>
+                        <leg mode="rail" dep_time="22:01:51" trav_time="01:27:09">
+                                <attributes>
+                                        <attribute name="routingMode" class="java.lang.String">rail</attribute>
+                                </attributes>
+                                <route type="default_pt" start_link="5177011483058159475_5177011483058159475" end_link="5176971782047279209_5176971782047279209" trav_time="01:27:09" distance="43100.41522111105">{"transitRouteId":"55095_5","boardingTime":"22:47:00","transitLineId":"55095","accessFacilityId":"910GCAMBDGE","egressFacilityId":"910GBSTEDMS"}</route>
+                        </leg>
+                        <activity type="pt interaction" link="5176971782047279209_5176971782047279209" x="585301.8661946068" y="265201.778045431" max_dur="00:00:00" >
+                        </activity>
+                        <leg mode="walk" dep_time="23:29:00" trav_time="00:00:00">
+                                <attributes>
+                                        <attribute name="routingMode" class="java.lang.String">rail</attribute>
+                                </attributes>
+                                <route type="generic" start_link="5176971782047279209_5176971782047279209" end_link="351882" trav_time="00:00:00" distance="0.0"></route>
+                        </leg>
+                        <activity type="pt interaction" link="351882" x="584873.589101083" y="265219.2209167288" max_dur="00:00:00" >
+                        </activity>
+                        <leg mode="car" dep_time="23:29:00" trav_time="00:03:58">
+                                <attributes>
+                                        <attribute name="routingMode" class="java.lang.String">rail</attribute>
+                                </attributes>
+                                <route type="links" start_link="351882" end_link="5176971422848555195_5176971422678725439" trav_time="00:03:58" distance="2111.3364227782304" vehicleRefId="null">351882 149803 5176971781593483131_5176971782264587763 5176971782264587763_5176971782266928655 5176971782266928655_5176971782288252011 5176971782288252011_5176971782370369451 5176971782370369451_5176971785393766433 438549 5176971786148556487_5176971786294073777 5176971786294073777_5176971810418408001 5176971810418408001_5176971810471052063 59819 5176971810218828391_5176971810928830397 221894 5176971809472173411_5176971809440890277 550156 5176971809398977613_5176971809248564755 5176971809248564755_5176971809182413881 5176971809182413881_5176971799083264243 551553 5176971799369299617_5176971799369892369 5176971799369892369_5176971799550374741 460797 268673 12495 5176971800887596115_5176971801588016817 5176971801588016817_5176971801526896535 524022 5176971417707667685_5176971417717510415 523192 425397 5176971417824443831_5176971417800606061 5176971417800606061_5176971423086769507 303139 5176971422678725439_5176971422848555195 5176971422848555195_5176971422678725439</route>
+                        </leg>
+                        <activity type="home" link="5176971422848555195_5176971422678725439" facility="f_auto_5287" x="584480.0" y="265597.0" start_time="22:15:00" end_time="24:00:00" >
+                        </activity>
+                </plan>
+
+                <plan score="-142.94496100135188" selected="no">
+                        <activity type="home" link="5176971422848555195_5176971422678725439" facility="f_auto_5287" x="584480.0" y="265597.0" start_time="00:00:00" end_time="13:33:42" >
+                        </activity>
+                        <leg mode="taxi" dep_time="13:33:42" trav_time="00:03:03">
+                                <attributes>
+                                        <attribute name="routingMode" class="java.lang.String">rail</attribute>
+                                </attributes>
+                                <route type="links" start_link="5176971422848555195_5176971422678725439" end_link="351882" trav_time="00:03:03" distance="2110.4628954533277" vehicleRefId="null">5176971422848555195_5176971422678725439 546049 5176971423086769507_5176971417800606061 5176971417800606061_5176971417824443831 479151 624260 5176971417717510415_5176971417707667685 339356 5176971801526896535_5176971801588016817 5176971801588016817_5176971800887596115 201183 124775 96881 5176971799550374741_5176971799369892369 5176971799369892369_5176971799369299617 398607 5176971799083264243_5176971809182413881 5176971809182413881_5176971809248564755 354415 5176971809284191073_5176971809302446207 364152 276859 456343 5176971810974267095_5176971810971127253 5176971810971127253_5176971810928830397 5176971810928830397_5176971810218828391 244593 5176971810471052063_5176971810418408001 5176971810418408001_5176971786294073777 5176971786294073777_5176971786148556487 377296 5176971785393766433_5176971782370369451 5176971782370369451_5176971782288252011 5176971782288252011_5176971782266928655 5176971782266928655_5176971782264587763 5176971782264587763_5176971781593483131 351882</route>
+                        </leg>
+                        <activity type="pt interaction" link="351882" x="584873.589101083" y="265219.2209167288" max_dur="00:00:00" >
+                        </activity>
+                        <leg mode="walk" dep_time="13:36:45" trav_time="00:00:00">
+                                <attributes>
+                                        <attribute name="routingMode" class="java.lang.String">rail</attribute>
+                                </attributes>
+                                <route type="generic" start_link="351882" end_link="5176971782047279209_5176971782047279209" trav_time="00:00:00" distance="0.0"></route>
+                        </leg>
+                        <activity type="pt interaction" link="5176971782047279209_5176971782047279209" x="585301.8659321591" y="265201.775893673" max_dur="00:00:00" >
+                        </activity>
+                        <leg mode="walk" dep_time="13:36:45" trav_time="00:00:01">
+                                <attributes>
+                                        <attribute name="routingMode" class="java.lang.String">rail</attribute>
+                                </attributes>
+                                <route type="generic" start_link="5176971782047279209_5176971782047279209" end_link="5176971782047279209_5176971782047279209" trav_time="00:00:01" distance="0.0"></route>
+                        </leg>
+                        <activity type="pt interaction" link="5176971782047279209_5176971782047279209" x="585301.8661946068" y="265201.778045431" max_dur="00:00:00" >
+                        </activity>
+                        <leg mode="rail" dep_time="13:36:46" trav_time="01:04:14">
+                                <attributes>
+                                        <attribute name="routingMode" class="java.lang.String">rail</attribute>
+                                </attributes>
+                                <route type="default_pt" start_link="5176971782047279209_5176971782047279209" end_link="5177011483058159475_5177011483058159475" trav_time="01:04:14" distance="41551.1341413336">{"transitRouteId":"55095_2","boardingTime":"13:55:00","transitLineId":"55095","accessFacilityId":"910GBSTEDMS","egressFacilityId":"910GCAMBDGE"}</route>
+                        </leg>
+                        <activity type="pt interaction" link="5177011483058159475_5177011483058159475" x="546196.9010489563" y="257246.6591357863" max_dur="00:00:00" >
+                        </activity>
+                        <leg mode="walk" dep_time="14:41:00" trav_time="00:03:55">
+                                <attributes>
+                                        <attribute name="routingMode" class="java.lang.String">rail</attribute>
+                                </attributes>
+                                <route type="generic" start_link="5177011483058159475_5177011483058159475" end_link="5177011476836422541_5177011476836422541" trav_time="00:03:55" distance="200.0"></route>
+                        </leg>
+                        <activity type="pt interaction" link="5177011476836422541_5177011476836422541" x="546097.8844187699" y="257129.53941952455" max_dur="00:00:00" >
+                        </activity>
+                        <leg mode="bus" dep_time="14:45:00" trav_time="00:14:00">
+                                <attributes>
+                                        <attribute name="routingMode" class="java.lang.String">rail</attribute>
+                                </attributes>
+                                <route type="default_pt" start_link="5177011476836422541_5177011476836422541" end_link="5177011578203780053_5177011578203780053" trav_time="00:14:00" distance="1089.297654735279">{"transitRouteId":"46103_0","boardingTime":"14:52:00","transitLineId":"46103","accessFacilityId":"0500CCITY528","egressFacilityId":"0500CCITY321"}</route>
+                        </leg>
+                        <activity type="pt interaction" link="5177011578203780053_5177011578203780053" x="545399.8929396417" y="257943.37673075608" max_dur="00:00:00" >
+                        </activity>
+                        <leg mode="walk" dep_time="14:59:00" trav_time="00:07:00">
+                                <attributes>
+                                        <attribute name="routingMode" class="java.lang.String">rail</attribute>
+                                </attributes>
+                                <route type="generic" start_link="5177011578203780053_5177011578203780053" end_link="417585" trav_time="00:07:00" distance="350.2865895646185"></route>
+                        </leg>
+                        <activity type="work" link="417585" facility="f_auto_494" x="545271.0" y="258180.0" start_time="13:45:00" end_time="21:43:02" >
+                        </activity>
+                        <leg mode="walk" dep_time="21:43:02" trav_time="17:17:30">
+                                <attributes>
+                                        <attribute name="routingMode" class="java.lang.String">rail</attribute>
+                                </attributes>
+                                <route type="generic" start_link="417585" end_link="5176971422848555195_5176971422678725439" trav_time="17:17:30" distance="51875.661858910295"></route>
+                        </leg>
+                        <activity type="home" link="5176971422848555195_5176971422678725439" facility="f_auto_5287" x="584480.0" y="265597.0" start_time="22:15:00" end_time="24:07:03" >
+                        </activity>
+                </plan>
+
+        </person>
+```
+
+```
+Error routing plan for agent 106656
+The problematic plan is null
+The problematic plan is [score=undefined][nof_acts_legs=7][type=null][personId=106656]
+```
+```xml
+        <person id="106656">
+                <attributes>
+                        <attribute name="age" class="java.lang.Integer">54</attribute>
+                        <attribute name="age_group" class="java.lang.String">50 to 59</attribute>
+                        <attribute name="area_type" class="java.lang.String">rural</attribute>
+                        <attribute name="carAvail" class="java.lang.Boolean">true</attribute>
+                        <attribute name="car_avail" class="java.lang.String">yes</attribute>
+                        <attribute name="car_competition" class="java.lang.Double">1.0</attribute>
+                        <attribute name="disabled" class="java.lang.String">no</attribute>
+                        <attribute name="ev" class="java.lang.Boolean">false</attribute>
+                        <attribute name="gender" class="java.lang.String">male</attribute>
+                        <attribute name="hasBike" class="java.lang.Boolean">true</attribute>
+                        <attribute name="hasCar" class="java.lang.Boolean">true</attribute>
+                        <attribute name="hasDisability" class="java.lang.Boolean">false</attribute>
+                        <attribute name="hasLicence" class="java.lang.Boolean">true</attribute>
+                        <attribute name="hcounty" class="java.lang.String">Suffolk</attribute>
+                        <attribute name="hhincome" class="java.lang.String">medium</attribute>
+                        <attribute name="hholdnumchildren" class="java.lang.Integer">2</attribute>
+                        <attribute name="hhsize" class="java.lang.Integer">4</attribute>
+                        <attribute name="hid" class="java.lang.String">106656</attribute>
+                        <attribute name="hid_old" class="java.lang.String">2006009260_7</attribute>
+                        <attribute name="householdid" class="java.lang.Integer">2006009260</attribute>
+                        <attribute name="hzone" class="java.lang.String">E02006229</attribute>
+                        <attribute name="indincome" class="java.lang.String">low</attribute>
+                        <attribute name="individualid" class="java.lang.Integer">2006022136</attribute>
+                        <attribute name="intermodalBike" class="java.lang.String">yes</attribute>
+                        <attribute name="intermodalCar" class="java.lang.String">yes</attribute>
+                        <attribute name="intermodalPassenger" class="java.lang.String">no</attribute>
+                        <attribute name="intermodalTaxi" class="java.lang.String">yes</attribute>
+                        <attribute name="marital_status" class="java.lang.String">married</attribute>
+                        <attribute name="region" class="java.lang.String">East of England</attribute>
+                        <attribute name="seasontickettype" class="java.lang.String">other</attribute>
+                        <attribute name="sex" class="java.lang.String">m</attribute>
+                        <attribute name="subpopulation" class="java.lang.String">medium</attribute>
+                        <attribute name="surveyyear" class="java.lang.Integer">2006</attribute>
+                        <attribute name="vehicles" class="org.matsim.vehicles.PersonVehicles">{"car":"106656","taxi":"106656_taxi","car_passenger":"106656_car_passenger"}</attribute>
+                        <attribute name="workstatus" class="java.lang.String">full-time</attribute>
+                </attributes>
+                <plan score="150.71178913965176" selected="no">
+                        <activity type="home" link="5176980547372196967_5176980550095014727" facility="f_auto_19125" x="586499.0" y="246549.0" start_time="00:00:00" end_time="10:28:00" >
+                        </activity>
+                        <leg mode="car" dep_time="10:28:00" trav_time="00:18:28">
+                                <attributes>
+                                        <attribute name="routingMode" class="java.lang.String">car</attribute>
+                                </attributes>
+                                <route type="links" start_link="5176980547372196967_5176980550095014727" end_link="5176971741277727863_5176971741659784981" trav_time="00:18:28" distance="20761.067909516" vehicleRefId="null">5176980547372196967_5176980550095014727 5176980550095014727_5176980550092474555 5176980550092474555_5176980550092086249 568213 490141 281314 5176980723378447539_5176980723247839255 246892 5176980722975253219_5176980722386530563 282593 416032 5176980706784673533_5176980707182857833 398690 439553 585810 398074 43650 326296 213591 252095 471083 491216 91838 193939 550316 5176979305021912187_5176979305131857375 603774 588381 5176979195776822355_5176979195777722855 21551 156879 583787 287490 551879 5176978779116777199_5176978779128804231 512618 253784 5176978720783650437_5176978720341453745 5176978720341453745_5176978717830843381 5176978717830843381_5176978717977742037 476975 430134 353123 188345 316485 344043 612388 251084 5176978654358268531_5176978654358602329 232582 5176972821864324957_5176972821869618193 156211 49292 501283 368948 346606 437980 125857 319010 507265 306015 5176972894324164917_5176972523524374329 627215 5176972523196455301_5176972522421494983 508507 186995 174087 345930 5176972503160839915_5176972503221302419 5176972503221302419_5176972456966770231 251182 5176972441047809397_5176972441128663439 124624 5176972433734010305_5176972432212189681 603300 5176972431923588405_5176971701759856261 5176971701759856261_5176971701822774873 76896 579246 5176971702985041941_5176971702987790479 598664 41169 625535 5176971703170502679_5176971703165203813 123778 5176971706100072663_5176971706499144429 5176971706499144429_5176971706453229565 5176971706453229565_5176971706432951471 252695 5176971707120419305_5176971707262174163 5176971707262174163_5176971707384702831 5176971707384702831_5176971707361614315 5176971707361614315_5176971683187197809 406969 337817 198169 5176971682852182903_5176971682907408325 343097 498391 567350 363572 5176971679222041181_5176971679218512717 55828 550469 91960 501338 463030 415415 448245 620346 5176971724591834687_5176971724592380649 5176971724592380649_5176971724703679907 148730 5176971724700722331_5176971724711964771 5176971724711964771_5176971724687346919 493303 5176971726082629801_5176971726080961375 5176971726080961375_5176971726171863147 628705 238062 529408 592424 490248 304820 251655 5176971729334606037_5176971729347682217 531454 5176971729237121859_5176971729643317991 5176971729643317991_5176971718215106641 5176971718215106641_5176971741277727863 5176971741277727863_5176971741659784981</route>
+                        </leg>
+                        <activity type="shop" link="5176971741277727863_5176971741659784981" facility="f_auto_3052" x="585973.0" y="264540.0" start_time="10:44:00" end_time="11:02:00" >
+                        </activity>
+                        <leg mode="car" dep_time="11:02:00" trav_time="00:03:39">
+                                <attributes>
+                                        <attribute name="routingMode" class="java.lang.String">car</attribute>
+                                </attributes>
+                                <route type="links" start_link="5176971741277727863_5176971741659784981" end_link="5176973176231468937_5176973176244935583" trav_time="00:03:39" distance="2709.800648078889" vehicleRefId="null">5176971741277727863_5176971741659784981 5176971741659784981_5176971741277727863 5176971741277727863_5176971718215106641 5176971718215106641_5176971729643317991 5176971729643317991_5176971729237121859 32650 5176971729347682217_5176971729334606037 44122 61851 300736 554296 78527 531571 323179 5176971726171863147_5176971726080961375 630737 5176971724711964771_5176971724700722331 182009 5176971724703679907_5176971724592380649 5176971724592380649_5176971724591834687 143341 26785 325883 134617 2763 146668 544556 5176971680597679929_5176971680619306729 113344 563134 542642 5176971681735506617_5176971681734028625 94549 246597 5176971683187197809_5176971707361614315 5176971707361614315_5176971707384702831 5176971707384702831_5176971707262174163 5176971707262174163_5176971707120419305 480609 5176971706432951471_5176971706453229565 5176971706453229565_5176971706499144429 5176971706499144429_5176971706100072663 489664 5176971703165203813_5176971703170502679 5176971703170502679_5176971703124389725 557262 93875 420215 321186 129291 614988 5176971702617341701_5176971702529042143 432689 396662 556889 558070 507876 459729 290838 358719 37654 5176973176231468937_5176973176244935583</route>
+                        </leg>
+                        <activity type="other" link="5176973176231468937_5176973176244935583" facility="f_auto_3640" x="585797.0" y="262729.0" start_time="11:07:00" end_time="14:48:00" >
+                        </activity>
+                        <leg mode="car" dep_time="14:48:00" trav_time="00:16:48">
+                                <attributes>
+                                        <attribute name="routingMode" class="java.lang.String">car</attribute>
+                                </attributes>
+                                <route type="links" start_link="5176973176231468937_5176973176244935583" end_link="5176980547372196967_5176980550095014727" trav_time="00:16:48" distance="19609.726361424488" vehicleRefId="null">5176973176231468937_5176973176244935583 5176973176244935583_5176973176231468937 538801 390015 96704 218118 567296 456584 358685 294944 554621 5176971696638932979_5176971696628990567 513726 353661 348788 420215 5176971702987790479_5176971702985041941 542867 13000 296388 5176971701822774873_5176971701759856261 5176971701759856261_5176972431923588405 595651 5176972432212189681_5176972433734010305 155300 5176972441128663439_5176972441047809397 599690 517697
+2456966770231_5176972503221302419 5176972503221302419_5176972503160839915 493098 491942 326190 91228 5176972522421494983_5176972523196455301 521019 5176972523524374329_5176972894324164917 216742 181714 521015 632073 236136 61481 298400 598901 356881 424720 5176972821869618193_5176972821864324957 239773 5176978654358602329_5176978654358268531 409983 452943 405859 27061 288388 480353 74890 341219 5176978717977742037_5176978717830843381 5176978717830843381_5176978720341453745 5176978720341453745_5176978720783650437 66943 559804 5176978779128804231_5176978779116777199 266208 303702 321840 280110 379427 5176979195777722855_5176979195776822355 338198 318894 5176979305131857375_5176979305021912187 485227 432620 366196 122305 360896 392634 303552 387063 551604 395279 632195 394217 463090 5176980707182857833_5176980706784673533 522064 22993 5176980722386530563_5176980722975253219 591258 5176980723247839255_5176980723378447539 44403 623650 575193 5176980550092086249_5176980550092474555 5176980550092474555_5176980550095014727 5176980550095014727_5176980547372196967 5176980547372196967_5176980550095014727</route>
+                        </leg>
+                        <activity type="home" link="5176980547372196967_5176980550095014727" facility="f_auto_19125" x="586499.0" y="246549.0" start_time="15:15:00" end_time="24:00:00" >
+                        </activity>
+                </plan>
+
+                <plan score="-174.69179409349144" selected="yes">
+                        <activity type="home" link="5176980547372196967_5176980550095014727" facility="f_auto_19125" x="586499.0" y="246549.0" start_time="00:00:00" end_time="10:28:00" >
+                        </activity>
+                        <leg mode="walk" dep_time="10:28:00" trav_time="00:00:29">
+                                <attributes>
+                                        <attribute name="routingMode" class="java.lang.String">rail</attribute>
+                                </attributes>
+                                <route type="generic" start_link="5176980547372196967_5176980550095014727" end_link="5176980550095014727_5176980550095014727" trav_time="00:00:29" distance="24.508945955231585"></route>
+                        </leg>
+                        <activity type="pt interaction" link="5176980550095014727_5176980550095014727" x="586510.0529568413" y="246557.85261155193" max_dur="00:00:00" >
+                        </activity>
+                        <leg mode="walk" dep_time="10:28:29" trav_time="00:00:01">
+                                <attributes>
+                                        <attribute name="routingMode" class="java.lang.String">rail</attribute>
+                                </attributes>
+                                <route type="generic" start_link="5176980550095014727_5176980550095014727" end_link="5176980550095014727_5176980550095014727" trav_time="00:00:01" distance="0.0"></route>
+                        </leg>
+                        <activity type="pt interaction" link="5176980550095014727_5176980550095014727" x="586506.0123527828" y="246566.50039572024" max_dur="00:00:00" >
+                        </activity>
+                        <leg mode="bus" dep_time="10:28:30" trav_time="02:10:30">
+                                <attributes>
+                                        <attribute name="routingMode" class="java.lang.String">rail</attribute>
+                                </attributes>
+                                <route type="default_pt" start_link="5176980550095014727_5176980550095014727" end_link="5176981723945701739_5176981723945701739" trav_time="02:10:30" distance="8211.69615332553">{"transitRouteId":"16053_1","boardingTime":"12:27:20","transitLineId":"16053","accessFacilityId":"390010157","egressFacilityId":"390G10229"}</route>
+                        </leg>
+                        <activity type="pt interaction" link="5176981723945701739_5176981723945701739" x="587484.1355733429" y="241231.54179517739" max_dur="00:00:00" >
+                        </activity>
+                        <leg mode="walk" dep_time="12:39:00" trav_time="00:00:00">
+                                <attributes>
+                                        <attribute name="routingMode" class="java.lang.String">rail</attribute>
+                                </attributes>
+                                <route type="generic" start_link="5176981723945701739_5176981723945701739" end_link="5176981723945701739_5176981723945701739" trav_time="00:00:00" distance="0.0"></route>
+                        </leg>
+                        <activity type="pt interaction" link="5176981723945701739_5176981723945701739" x="587484.1355733429" y="241231.54179517739" max_dur="00:00:00" >
+                        </activity>
+                        <leg mode="bus" dep_time="12:39:01" trav_time="01:20:59">
+                                <attributes>
+                                        <attribute name="routingMode" class="java.lang.String">rail</attribute>
+                                </attributes>
+                                <route type="default_pt" start_link="5176981723945701739_5176981723945701739" end_link="5176971627666261419_5176971627666261419" trav_time="01:20:59" distance="38008.476906595104">{"transitRouteId":"31289_0","boardingTime":"13:00:00","transitLineId":"31289","accessFacilityId":"390G10229","egressFacilityId":"390050876"}</route>
+                        </leg>
+                        <activity type="pt interaction" link="5176971627666261419_5176971627666261419" x="585175.9298012826" y="264316.01510483475" max_dur="00:00:00" >
+                        </activity>
+                        <leg mode="walk" dep_time="14:00:00" trav_time="00:12:42">
+                                <attributes>
+                                        <attribute name="routingMode" class="java.lang.String">rail</attribute>
+                                </attributes>
+                                <route type="generic" start_link="5176971627666261419_5176971627666261419" end_link="5176971725613457087_5176971725613457087" trav_time="00:12:42" distance="635.0"></route>
+                        </leg>
+                        <activity type="pt interaction" link="5176971725613457087_5176971725613457087" x="585651.6538349463" y="264352.95547463984" max_dur="00:00:00" >
+                        </activity>
+                        <leg mode="walk" dep_time="14:12:42" trav_time="00:09:18">
+                                <attributes>
+                                        <attribute name="routingMode" class="java.lang.String">rail</attribute>
+                                </attributes>
+                                <route type="generic" start_link="5176971725613457087_5176971725613457087" end_link="5176971741277727863_5176971741659784981" trav_time="00:09:18" distance="465.2266123071701"></route>
+                        </leg>
+                        <activity type="shop" link="5176971741277727863_5176971741659784981" facility="f_auto_3052" x="585973.0" y="264540.0" start_time="10:44:00" end_time="11:02:00" >
+                        </activity>
+                        <leg mode="walk" dep_time="11:02:00" trav_time="00:47:18">
+                                <attributes>
+                                        <attribute name="routingMode" class="java.lang.String">rail</attribute>
+                                </attributes>
+                                <route type="generic" start_link="5176971741277727863_5176971741659784981" end_link="5176973176231468937_5176973176244935583" trav_time="00:47:18" distance="2365.391707519074"></route>
+                        </leg>
+                        <activity type="other" link="5176973176231468937_5176973176244935583" facility="f_auto_3640" x="585797.0" y="262729.0" start_time="11:07:00" end_time="14:48:00" >
+                        </activity>
+                        <leg mode="car" dep_time="14:48:00" trav_time="00:06:12">
+                                <attributes>
+                                        <attribute name="routingMode" class="java.lang.String">rail</attribute>
+                                </attributes>
+                                <route type="links" start_link="5176973176231468937_5176973176244935583" end_link="351882" trav_time="00:06:12" distance="3980.709925552379" vehicleRefId="null">5176973176231468937_5176973176244935583 5176973176244935583_5176973176231468937 538801 390015 96704 218118 5176971693109358891_5176971693062169271 549169 498886 238528 82506 314604 434532 357034 5176971673831087679_5176971673816753561 5176971673816753561_5176971673914680415 5176971673914680415_5176971673941725167 5176971673941725167_5176971674106668353 5176971674106668353_5176971674099643953 91944 282508 237622 5176971675681325729_5176971675678624033 68821 5176971675704033793_5176971675706327425 262062 5176971636658826097_5176971636658048039 23299 617290 5176971639046934039_5176971639061442719 570810 325784 301791 253004 444992 5176971614713702391_5176971614736160173 5176971614736160173_5176971614754731811 5176971614754731811_5176971614088669701 175293 616957 634050 154479 5176971619607718013_5176971619616954679 571773 512385 93226 5176971620373952531_5176971620488895985 5176971620488895985_5176971620530051299 5176971620530051299_5176971621169311015 85127 355092 485209 77717 5176971620856238905_5176971781650859901 246813 351882</route>
+                        </leg>
+                        <activity type="pt interaction" link="351882" x="584873.589101083" y="265219.2209167288" max_dur="00:00:00" >
+                        </activity>
+                        <leg mode="walk" dep_time="14:54:12" trav_time="00:00:00">
+                                <attributes>
+                                        <attribute name="routingMode" class="java.lang.String">rail</attribute>
+                                </attributes>
+                                <route type="generic" start_link="351882" end_link="5176971782047279209_5176971782047279209" trav_time="00:00:00" distance="0.0"></route>
+                        </leg>
+                        <activity type="pt interaction" link="5176971782047279209_5176971782047279209" x="585301.8659321591" y="265201.775893673" max_dur="00:00:00" >
+                        </activity>
+                        <leg mode="walk" dep_time="14:54:12" trav_time="00:04:35">
+                                <attributes>
+                                        <attribute name="routingMode" class="java.lang.String">rail</attribute>
+                                </attributes>
+                                <route type="generic" start_link="5176971782047279209_5176971782047279209" end_link="5176971785393766433_5176971785393766433" trav_time="00:04:35" distance="230.0"></route>
+                        </leg>
+                        <activity type="pt interaction" link="5176971785393766433_5176971785393766433" x="585296.908028936" y="265377.86864908243" max_dur="00:00:00" >
+                        </activity>
+                        <leg mode="bus" dep_time="14:58:47" trav_time="00:29:13">
+                                <attributes>
+                                        <attribute name="routingMode" class="java.lang.String">rail</attribute>
+                                </attributes>
+                                <route type="default_pt" start_link="5176971785393766433_5176971785393766433" end_link="5176971612828285077_5176971612828285077" trav_time="00:29:13" distance="7158.785775111365">{"transitRouteId":"6757_0","boardingTime":"15:04:40","transitLineId":"6757","accessFacilityId":"390050806","egressFacilityId":"390050871"}</route>
+                        </leg>
+                        <activity type="pt interaction" link="5176971612828285077_5176971612828285077" x="584776.9502975785" y="264502.8709783093" max_dur="00:00:00" >
+                        </activity>
+                        <leg mode="walk" dep_time="15:28:00" trav_time="00:11:30">
+                                <attributes>
+                                        <attribute name="routingMode" class="java.lang.String">rail</attribute>
+                                </attributes>
+                                <route type="generic" start_link="5176971612828285077_5176971612828285077" end_link="5176971610368624159_5176971610368624159" trav_time="00:11:30" distance="579.0"></route>
+                        </leg>
+                        <activity type="pt interaction" link="5176971610368624159_5176971610368624159" x="584794.9089341155" y="264947.84872200113" max_dur="00:00:00" >
+                        </activity>
+                        <leg mode="bus" dep_time="15:39:35" trav_time="00:45:23">
+                                <attributes>
+                                        <attribute name="routingMode" class="java.lang.String">rail</attribute>
+                                </attributes>
+                                <route type="default_pt" start_link="5176971610368624159_5176971610368624159" end_link="5176980722984262763_5176980722984262763" trav_time="00:45:23" distance="22416.49197484107">{"transitRouteId":"31013_0","boardingTime":"15:45:00","transitLineId":"31013","accessFacilityId":"390051024","egressFacilityId":"390010648"}</route>
+                        </leg>
+                        <activity type="pt interaction" link="5176980722984262763_5176980722984262763" x="586790.023249241" y="246960.76919718873" max_dur="00:00:00" >
+                        </activity>
+                        <leg mode="walk" dep_time="16:24:58" trav_time="00:12:39">
+                                <attributes>
+                                        <attribute name="routingMode" class="java.lang.String">rail</attribute>
+                                </attributes>
+                                <route type="generic" start_link="5176980722984262763_5176980722984262763" end_link="5176980550095014727_5176980550095014727" trav_time="00:12:39" distance="632.0"></route>
+                        </leg>
+                        <activity type="pt interaction" link="5176980550095014727_5176980550095014727" x="586510.0529568413" y="246557.85261155193" max_dur="00:00:00" >
+                        </activity>
+                        <leg mode="walk" dep_time="16:37:37" trav_time="00:00:29">
+                                <attributes>
+                                        <attribute name="routingMode" class="java.lang.String">rail</attribute>
+                                </attributes>
+                                <route type="generic" start_link="5176980550095014727_5176980550095014727" end_link="5176980547372196967_5176980550095014727" trav_time="00:00:29" distance="24.508945955231585"></route>
+                        </leg>
+                        <activity type="home" link="5176980547372196967_5176980550095014727" facility="f_auto_19125" x="586499.0" y="246549.0" start_time="15:15:00" end_time="24:00:00" >
+                        </activity>
+                </plan>
+
+        </person>
+```
+
+```
+Error routing plan for agent 108953
+The problematic plan is null
+The problematic plan is [score=undefined][nof_acts_legs=5][type=null][personId=108953]
+```
+```xml
+      <person id="108953">
+                <attributes>
+                        <attribute name="age" class="java.lang.Integer">34</attribute>
+                        <attribute name="age_group" class="java.lang.String">30 to 39</attribute>
+                        <attribute name="area_type" class="java.lang.String">urban</attribute>
+                        <attribute name="carAvail" class="java.lang.Boolean">true</attribute>
+                        <attribute name="car_avail" class="java.lang.String">yes</attribute>
+                        <attribute name="car_competition" class="java.lang.Double">2.0</attribute>
+                        <attribute name="disabled" class="java.lang.String">no</attribute>
+                        <attribute name="ev" class="java.lang.Boolean">false</attribute>
+                        <attribute name="gender" class="java.lang.String">male</attribute>
+                        <attribute name="hasBike" class="java.lang.Boolean">true</attribute>
+                        <attribute name="hasCar" class="java.lang.Boolean">true</attribute>
+                        <attribute name="hasDisability" class="java.lang.Boolean">false</attribute>
+                        <attribute name="hasLicence" class="java.lang.Boolean">true</attribute>
+                        <attribute name="hcounty" class="java.lang.String">Suffolk</attribute>
+                        <attribute name="hhincome" class="java.lang.String">high</attribute>
+                        <attribute name="hholdnumchildren" class="java.lang.Integer">0</attribute>
+                        <attribute name="hhsize" class="java.lang.Integer">2</attribute>
+                        <attribute name="hid" class="java.lang.String">108953</attribute>
+                        <attribute name="hid_old" class="java.lang.String">2007001330_2</attribute>
+                        <attribute name="householdid" class="java.lang.Integer">2007001330</attribute>
+                        <attribute name="hzone" class="java.lang.String">E02006277</attribute>
+                        <attribute name="indincome" class="java.lang.String">medium</attribute>
+                        <attribute name="individualid" class="java.lang.Integer">2007003176</attribute>
+                        <attribute name="intermodalBike" class="java.lang.String">yes</attribute>
+                        <attribute name="intermodalCar" class="java.lang.String">yes</attribute>
+                        <attribute name="intermodalPassenger" class="java.lang.String">no</attribute>
+                        <attribute name="intermodalTaxi" class="java.lang.String">yes</attribute>
+                        <attribute name="marital_status" class="java.lang.String">married</attribute>
+                        <attribute name="region" class="java.lang.String">East of England</attribute>
+                        <attribute name="seasontickettype" class="java.lang.String">season_ticket</attribute>
+                        <attribute name="sex" class="java.lang.String">m</attribute>
+                        <attribute name="subpopulation" class="java.lang.String">high</attribute>
+                        <attribute name="surveyyear" class="java.lang.Integer">2007</attribute>
+                        <attribute name="vehicles" class="org.matsim.vehicles.PersonVehicles">{"car":"108953","taxi":"108953_taxi","car_passenger":"108953_car_passenger"}</attribute>
+                        <attribute name="workstatus" class="java.lang.String">full-time</attribute>
+                </attributes>
+                <plan score="219.30483944025386" selected="no">
+                        <activity type="home" link="5176972412007611595_5176972412159172221" facility="f_auto_3596" x="587058.0" y="263703.0" start_time="00:00:00" end_time="07:50:00" >
+                        </activity>
+                        <leg mode="car" dep_time="07:50:00" trav_time="00:00:43">
+                                <attributes>
+                                        <attribute name="routingMode" class="java.lang.String">car</attribute>
+                                </attributes>
+                                <route type="links" start_link="5176972412007611595_5176972412159172221" end_link="5176972322351857303_5176972322891286597" trav_time="00:0
+0:43" distance="670.9840580289804" vehicleRefId="null">5176972412007611595_5176972412159172221 5176972412159172221_5176972412007611595 485623 5176972319128107751_517697231
+8470344371 5176972318470344371_5176972318424877323 5176972318424877323_5176972318401530301 5176972318401530301_5176972320061073363 5176972320061073363_5176972320062781433
+5176972320062781433_5176972320671039309 33835 256889 5176972322351857303_5176972322891286597</route>
+                        </leg>
+                        <activity type="work" link="5176972322351857303_5176972322891286597" facility="f_auto_1337" x="587580.0" y="263932.0" start_time="09:15:00" end_tim
+e="17:30:00" >
+                        </activity>
+                        <leg mode="car" dep_time="17:30:00" trav_time="00:00:47">
+                                <attributes>
+                                        <attribute name="routingMode" class="java.lang.String">car</attribute>
+                                </attributes>
+                                <route type="links" start_link="5176972322351857303_5176972322891286597" end_link="5176972412007611595_5176972412159172221" trav_time="00:0
+0:47" distance="670.9840570394069" vehicleRefId="null">5176972322351857303_5176972322891286597 5176972322891286597_5176972322351857303 412948 313200 5176972320671039309_51
+76972320062781433 5176972320062781433_5176972320061073363 5176972320061073363_5176972318470344371 5176972318470344371_5176972319128107751 624634 5176972412007611595_517697
+2412159172221</route>
+                        </leg>
+                        <activity type="home" link="5176972412007611595_5176972412159172221" facility="f_auto_3596" x="587058.0" y="263703.0" start_time="19:00:00" end_tim
+e="24:00:00" >
+                        </activity>
+                </plan>
+
+                <plan score="223.92776380502244" selected="yes">
+                        <activity type="home" link="5176972412007611595_5176972412159172221" facility="f_auto_3596" x="587058.0" y="263703.0" start_time="00:00:00" end_tim
+e="07:50:00" >
+                        </activity>
+                        <leg mode="walk" dep_time="07:50:00" trav_time="00:14:49">
+                                <attributes>
+                                        <attribute name="routingMode" class="java.lang.String">tram</attribute>
+                                </attributes>
+                                <route type="generic" start_link="5176972412007611595_5176972412159172221" end_link="5176972322351857303_5176972322891286597" trav_time="00:14:49" distance="741.0285082235365"></route>
+                        </leg>
+                        <activity type="work" link="5176972322351857303_5176972322891286597" facility="f_auto_1337" x="587580.0" y="263932.0" start_time="09:15:00" end_time="17:30:00" >
+                        </activity>
+                        <leg mode="walk" dep_time="17:30:00" trav_time="00:14:49">
+                                <attributes>
+                                        <attribute name="routingMode" class="java.lang.String">tram</attribute>
+                                </attributes>
+                                <route type="generic" start_link="5176972322351857303_5176972322891286597" end_link="5176972412007611595_5176972412159172221" trav_time="00:14:49" distance="741.0285082235365"></route>
+                        </leg>
+                        <activity type="home" link="5176972412007611595_5176972412159172221" facility="f_auto_3596" x="587058.0" y="263703.0" start_time="19:00:00" end_time="24:00:00" >
+                        </activity>
+                </plan>
+
+        </person>
+```
+
+
+- Is this relevant?
+```
+2024-08-19T21:14:37,009  WARN PreProcessEuclidean:60 There are links with stored length smaller than their Euclidean distance in this network. Thus, A* cannot guarantee to calculate the least-cost paths between two nodes.
+```
+
+- Amended the cutter to catch all plan routing errors, continue through all plans, then summarise the failed plans and fail.
+There are multiple worker threads, and each one has some problematic plans:
+```
+!!! 23 plans had errors (there were 105 good plans)
+
+[score=undefined][nof_acts_legs=19][type=null][personId=101246]=java.lang.NullPointerException: Cannot invoke "org.matsim.pt.transitSchedule.api.TransitStopFacility.getCoord()" because "nearestStop" is null,
+[score=undefined][nof_acts_legs=7][type=null][personId=102136]=java.lang.NullPointerException: Cannot invoke "org.matsim.pt.transitSchedule.api.TransitStopFacility.getCoord()" because "nearestStop" is null,
+[score=undefined][nof_acts_legs=7][type=null][personId=103320]=java.lang.NullPointerException: Cannot invoke "org.matsim.pt.transitSchedule.api.TransitStopFacility.getCoord()" because "nearestStop" is null,
+[score=undefined][nof_acts_legs=9][type=null][personId=103157]=java.lang.NullPointerException: Cannot invoke "org.matsim.pt.transitSchedule.api.TransitStopFacility.getCoord()" because "nearestStop" is null,
+[score=undefined][nof_acts_legs=11][type=null][personId=100417]=java.lang.NullPointerException: Cannot invoke "org.matsim.pt.transitSchedule.api.TransitStopFacility.getCoord()" because "nearestStop" is null,
+[score=undefined][nof_acts_legs=3][type=null][personId=102035]=java.lang.NullPointerException: Cannot invoke "org.matsim.pt.transitSchedule.api.TransitStopFacility.getCoord()" because "nearestStop" is null,
+[score=undefined][nof_acts_legs=5][type=null][personId=100416]=java.lang.NullPointerException: Cannot invoke "org.matsim.pt.transitSchedule.api.TransitStopFacility.getCoord()" because "nearestStop" is null,
+[score=undefined][nof_acts_legs=7][type=null][personId=102646]=java.lang.NullPointerException: Cannot invoke "org.matsim.pt.transitSchedule.api.TransitStopFacility.getCoord()" because "nearestStop" is null,
+[score=undefined][nof_acts_legs=5][type=null][personId=103317]=java.lang.NullPointerException: Cannot invoke "org.matsim.pt.transitSchedule.api.TransitStopFacility.getCoord()" because "nearestStop" is null,
+[score=undefined][nof_acts_legs=3][type=null][personId=102552]=java.lang.NullPointerException: Cannot invoke "org.matsim.pt.transitSchedule.api.TransitStopFacility.getCoord()" because "nearestStop" is null,
+[score=undefined][nof_acts_legs=7][type=null][personId=100477]=java.lang.NullPointerException: Cannot invoke "org.matsim.pt.transitSchedule.api.TransitStopFacility.getCoord()" because "nearestStop" is null,
+[score=undefined][nof_acts_legs=7][type=null][personId=102646]=java.lang.NullPointerException: Cannot invoke "org.matsim.pt.transitSchedule.api.TransitStopFacility.getCoord()" because "nearestStop" is null,
+[score=undefined][nof_acts_legs=3][type=null][personId=10077]=java.lang.NullPointerException: Cannot invoke "org.matsim.pt.transitSchedule.api.TransitStopFacility.getCoord()" because "nearestStop" is null,
+[score=undefined][nof_acts_legs=7][type=null][personId=101681]=java.lang.NullPointerException: Cannot invoke "org.matsim.pt.transitSchedule.api.TransitStopFacility.getCoord()" because "nearestStop" is null,
+[score=undefined][nof_acts_legs=5][type=null][personId=101037]=java.lang.NullPointerException: Cannot invoke "org.matsim.pt.transitSchedule.api.TransitStopFacility.getCoord()" because "nearestStop" is null,
+[score=undefined][nof_acts_legs=15][type=null][personId=101244]=java.lang.NullPointerException: Cannot invoke "org.matsim.pt.transitSchedule.api.TransitStopFacility.getCoord()" because "nearestStop" is null,
+[score=undefined][nof_acts_legs=7][type=null][personId=100818]=java.lang.NullPointerException: Cannot invoke "org.matsim.pt.transitSchedule.api.TransitStopFacility.getCoord()" because "nearestStop" is null,
+[score=undefined][nof_acts_legs=11][type=null][personId=10081]=java.lang.NullPointerException: Cannot invoke "org.matsim.pt.transitSchedule.api.TransitStopFacility.getCoord()" because "nearestStop" is null,
+[score=undefined][nof_acts_legs=11][type=null][personId=100417]=java.lang.NullPointerException: Cannot invoke "org.matsim.pt.transitSchedule.api.TransitStopFacility.getCoord()" because "nearestStop" is null,
+[score=undefined][nof_acts_legs=3][type=null][personId=102880]=java.lang.NullPointerException: Cannot invoke "org.matsim.pt.transitSchedule.api.TransitStopFacility.getCoord()" because "nearestStop" is null,
+[score=undefined][nof_acts_legs=7][type=null][personId=1025]=java.lang.NullPointerException: Cannot invoke "org.matsim.pt.transitSchedule.api.TransitStopFacility.getCoord()" because "nearestStop" is null,
+[score=undefined][nof_acts_legs=3][type=null][personId=101681]=java.lang.NullPointerException: Cannot invoke "org.matsim.pt.transitSchedule.api.TransitStopFacility.getCoord()" because "nearestStop" is null,
+[score=undefined][nof_acts_legs=5][type=null][personId=100416]=java.lang.NullPointerException: Cannot invoke "org.matsim.pt.transitSchedule.api.TransitStopFacility.getCoord()" because "nearestStop" is null
+``` 
+
+```
+!!! 15 plans had errors (there were 113 good plans)
+
+[score=undefined][nof_acts_legs=5][type=null][personId=105162]=java.lang.NullPointerException: Cannot invoke "org.matsim.pt.transitSchedule.api.TransitStopFacility.getCoord()" because "nearestStop" is null,
+[score=undefined][nof_acts_legs=7][type=null][personId=103660]=java.lang.NullPointerException: Cannot invoke "org.matsim.pt.transitSchedule.api.TransitStopFacility.getCoord()" because "nearestStop" is null,
+[score=undefined][nof_acts_legs=7][type=null][personId=105566]=java.lang.NullPointerException: Cannot invoke "org.matsim.pt.transitSchedule.api.TransitStopFacility.getCoord()" because "nearestStop" is null,
+[score=undefined][nof_acts_legs=3][type=null][personId=105971]=java.lang.NullPointerException: Cannot invoke "org.matsim.pt.transitSchedule.api.TransitStopFacility.getCoord()" because "nearestStop" is null,
+[score=undefined][nof_acts_legs=3][type=null][personId=104300]=java.lang.NullPointerException: Cannot invoke "org.matsim.pt.transitSchedule.api.TransitStopFacility.getCoord()" because "nearestStop" is null,
+[score=undefined][nof_acts_legs=7][type=null][personId=10393]=java.lang.NullPointerException: Cannot invoke "org.matsim.pt.transitSchedule.api.TransitStopFacility.getCoord()" because "nearestStop" is null,
+[score=undefined][nof_acts_legs=9][type=null][personId=104992]=java.lang.NullPointerException: Cannot invoke "org.matsim.pt.transitSchedule.api.TransitStopFacility.getCoord()" because "nearestStop" is null,
+[score=undefined][nof_acts_legs=3][type=null][personId=106586]=java.lang.NullPointerException: Cannot invoke "org.matsim.pt.transitSchedule.api.TransitStopFacility.getCoord()" because "nearestStop" is null,
+[score=undefined][nof_acts_legs=7][type=null][personId=103660]=java.lang.NullPointerException: Cannot invoke "org.matsim.pt.transitSchedule.api.TransitStopFacility.getCoord()" because "nearestStop" is null,
+[score=undefined][nof_acts_legs=5][type=null][personId=104409]=java.lang.NullPointerException: Cannot invoke "org.matsim.pt.transitSchedule.api.TransitStopFacility.getCoord()" because "nearestStop" is null,
+[score=undefined][nof_acts_legs=15][type=null][personId=104511]=java.lang.NullPointerException: Cannot invoke "org.matsim.pt.transitSchedule.api.TransitStopFacility.getCoord()" because "nearestStop" is null,
+[score=undefined][nof_acts_legs=5][type=null][personId=105120]=java.lang.NullPointerException: Cannot invoke "org.matsim.pt.transitSchedule.api.TransitStopFacility.getCoord()" because "nearestStop" is null,
+[score=undefined][nof_acts_legs=9][type=null][personId=10624]=java.lang.NullPointerException: Cannot invoke "org.matsim.pt.transitSchedule.api.TransitStopFacility.getCoord()" because "nearestStop" is null,
+[score=undefined][nof_acts_legs=9][type=null][personId=10624]=java.lang.NullPointerException: Cannot invoke "org.matsim.pt.transitSchedule.api.TransitStopFacility.getCoord()" because "nearestStop" is null,
+[score=undefined][nof_acts_legs=7][type=null][personId=105077]=java.lang.NullPointerException: Cannot invoke "org.matsim.pt.transitSchedule.api.TransitStopFacility.getCoord()" because "nearestStop" is null
+```
+
+```
+!!! 19 plans had errors (there were 112 good plans)
+
+[score=undefined][nof_acts_legs=19][type=null][personId=108072]=java.lang.NullPointerException: Cannot invoke "org.matsim.pt.transitSchedule.api.TransitStopFacility.getCoord()" because "nearestStop" is null,
+[score=undefined][nof_acts_legs=3][type=null][personId=108130]=java.lang.NullPointerException: Cannot invoke "org.matsim.pt.transitSchedule.api.TransitStopFacility.getCoord()" because "nearestStop" is null,
+[score=undefined][nof_acts_legs=5][type=null][personId=107669]=java.lang.NullPointerException: Cannot invoke "org.matsim.pt.transitSchedule.api.TransitStopFacility.getCoord()" because "nearestStop" is null,
+[score=undefined][nof_acts_legs=3][type=null][personId=108017]=java.lang.NullPointerException: Cannot invoke "org.matsim.pt.transitSchedule.api.TransitStopFacility.getCoord()" because "nearestStop" is null,
+[score=undefined][nof_acts_legs=7][type=null][personId=107285]=java.lang.NullPointerException: Cannot invoke "org.matsim.pt.transitSchedule.api.TransitStopFacility.getCoord()" because "nearestStop" is null,
+[score=undefined][nof_acts_legs=7][type=null][personId=106656]=java.lang.NullPointerException: Cannot invoke "org.matsim.pt.transitSchedule.api.TransitStopFacility.getCoord()" because "nearestStop" is null,
+[score=undefined][nof_acts_legs=3][type=null][personId=106659]=java.lang.NullPointerException: Cannot invoke "org.matsim.pt.transitSchedule.api.TransitStopFacility.getCoord()" because "nearestStop" is null,
+[score=undefined][nof_acts_legs=7][type=null][personId=107135]=java.lang.NullPointerException: Cannot invoke "org.matsim.pt.transitSchedule.api.TransitStopFacility.getCoord()" because "nearestStop" is null,
+[score=undefined][nof_acts_legs=5][type=null][personId=108172]=java.lang.NullPointerException: Cannot invoke "org.matsim.pt.transitSchedule.api.TransitStopFacility.getCoord()" because "nearestStop" is null,
+[score=undefined][nof_acts_legs=3][type=null][personId=107796]=java.lang.NullPointerException: Cannot invoke "org.matsim.pt.transitSchedule.api.TransitStopFacility.getCoord()" because "nearestStop" is null,
+[score=undefined][nof_acts_legs=5][type=null][personId=108184]=java.lang.NullPointerException: Cannot invoke "org.matsim.pt.transitSchedule.api.TransitStopFacility.getCoord()" because "nearestStop" is null,
+[score=undefined][nof_acts_legs=3][type=null][personId=108319]=java.lang.NullPointerException: Cannot invoke "org.matsim.pt.transitSchedule.api.TransitStopFacility.getCoord()" because "nearestStop" is null,
+[score=undefined][nof_acts_legs=7][type=null][personId=107346]=java.lang.NullPointerException: Cannot invoke "org.matsim.pt.transitSchedule.api.TransitStopFacility.getCoord()" because "nearestStop" is null,
+[score=undefined][nof_acts_legs=3][type=null][personId=107421]=java.lang.NullPointerException: Cannot invoke "org.matsim.pt.transitSchedule.api.TransitStopFacility.getCoord()" because "nearestStop" is null,
+[score=undefined][nof_acts_legs=3][type=null][personId=107301]=java.lang.NullPointerException: Cannot invoke "org.matsim.pt.transitSchedule.api.TransitStopFacility.getCoord()" because "nearestStop" is null,
+[score=undefined][nof_acts_legs=5][type=null][personId=108169]=java.lang.NullPointerException: Cannot invoke "org.matsim.pt.transitSchedule.api.TransitStopFacility.getCoord()" because "nearestStop" is null,
+[score=undefined][nof_acts_legs=3][type=null][personId=107285]=java.lang.NullPointerException: Cannot invoke "org.matsim.pt.transitSchedule.api.TransitStopFacility.getCoord()" because "nearestStop" is null,
+[score=undefined][nof_acts_legs=5][type=null][personId=107352]=java.lang.NullPointerException: Cannot invoke "org.matsim.pt.transitSchedule.api.TransitStopFacility.getCoord()" because "nearestStop" is null,
+[score=undefined][nof_acts_legs=3][type=null][personId=106658]=java.lang.NullPointerException: Cannot invoke "org.matsim.pt.transitSchedule.api.TransitStopFacility.getCoord()" because "nearestStop" is null
+```
+
+```
+!!! 25 plans had errors (there were 114 good plans)
+
+[score=undefined][nof_acts_legs=3][type=null][personId=110891]=java.lang.NullPointerException: Cannot invoke "org.matsim.pt.transitSchedule.api.TransitStopFacility.getCoord()" because "nearestStop" is null,
+[score=undefined][nof_acts_legs=11][type=null][personId=111003]=java.lang.NullPointerException: Cannot invoke "org.matsim.pt.transitSchedule.api.TransitStopFacility.getCoord()" because "nearestStop" is null,
+[score=undefined][nof_acts_legs=5][type=null][personId=109482]=java.lang.NullPointerException: Cannot invoke "org.matsim.pt.transitSchedule.api.TransitStopFacility.getCoord()" because "nearestStop" is null,
+[score=undefined][nof_acts_legs=3][type=null][personId=109473]=java.lang.NullPointerException: Cannot invoke "org.matsim.pt.transitSchedule.api.TransitStopFacility.getCoord()" because "nearestStop" is null,
+[score=undefined][nof_acts_legs=5][type=null][personId=108953]=java.lang.NullPointerException: Cannot invoke "org.matsim.pt.transitSchedule.api.TransitStopFacility.getCoord()" because "nearestStop" is null,
+[score=undefined][nof_acts_legs=9][type=null][personId=110123]=java.lang.NullPointerException: Cannot invoke "org.matsim.pt.transitSchedule.api.TransitStopFacility.getCoord()" because "nearestStop" is null,
+[score=undefined][nof_acts_legs=3][type=null][personId=111002]=java.lang.NullPointerException: Cannot invoke "org.matsim.pt.transitSchedule.api.TransitStopFacility.getCoord()" because "nearestStop" is null,
+[score=undefined][nof_acts_legs=3][type=null][personId=109010]=java.lang.NullPointerException: Cannot invoke "org.matsim.pt.transitSchedule.api.TransitStopFacility.getCoord()" because "nearestStop" is null,
+[score=undefined][nof_acts_legs=5][type=null][personId=109472]=java.lang.NullPointerException: Cannot invoke "org.matsim.pt.transitSchedule.api.TransitStopFacility.getCoord()" because "nearestStop" is null,
+[score=undefined][nof_acts_legs=7][type=null][personId=109094]=java.lang.NullPointerException: Cannot invoke "org.matsim.pt.transitSchedule.api.TransitStopFacility.getCoord()" because "nearestStop" is null,
+[score=undefined][nof_acts_legs=3][type=null][personId=109335]=java.lang.NullPointerException: Cannot invoke "org.matsim.pt.transitSchedule.api.TransitStopFacility.getCoord()" because "nearestStop" is null,
+[score=undefined][nof_acts_legs=11][type=null][personId=109145]=java.lang.NullPointerException: Cannot invoke "org.matsim.pt.transitSchedule.api.TransitStopFacility.getCoord()" because "nearestStop" is null,
+[score=undefined][nof_acts_legs=3][type=null][personId=109335]=java.lang.NullPointerException: Cannot invoke "org.matsim.pt.transitSchedule.api.TransitStopFacility.getCoord()" because "nearestStop" is null,
+[score=undefined][nof_acts_legs=3][type=null][personId=110587]=java.lang.NullPointerException: Cannot invoke "org.matsim.pt.transitSchedule.api.TransitStopFacility.getCoord()" because "nearestStop" is null,
+[score=undefined][nof_acts_legs=3][type=null][personId=109682]=java.lang.NullPointerException: Cannot invoke "org.matsim.pt.transitSchedule.api.TransitStopFacility.getCoord()" because "nearestStop" is null,
+[score=undefined][nof_acts_legs=7][type=null][personId=109009]=java.lang.NullPointerException: Cannot invoke "org.matsim.pt.transitSchedule.api.TransitStopFacility.getCoord()" because "nearestStop" is null,
+[score=undefined][nof_acts_legs=9][type=null][personId=110122]=java.lang.NullPointerException: Cannot invoke "org.matsim.pt.transitSchedule.api.TransitStopFacility.getCoord()" because "nearestStop" is null,
+[score=undefined][nof_acts_legs=11][type=null][personId=111003]=java.lang.NullPointerException: Cannot invoke "org.matsim.pt.transitSchedule.api.TransitStopFacility.getCoord()" because "nearestStop" is null,
+[score=undefined][nof_acts_legs=3][type=null][personId=110587]=java.lang.NullPointerException: Cannot invoke "org.matsim.pt.transitSchedule.api.TransitStopFacility.getCoord()" because "nearestStop" is null,
+[score=undefined][nof_acts_legs=5][type=null][personId=109482]=java.lang.NullPointerException: Cannot invoke "org.matsim.pt.transitSchedule.api.TransitStopFacility.getCoord()" because "nearestStop" is null,
+[score=undefined][nof_acts_legs=9][type=null][personId=110122]=java.lang.NullPointerException: Cannot invoke "org.matsim.pt.transitSchedule.api.TransitStopFacility.getCoord()" because "nearestStop" is null,
+[score=undefined][nof_acts_legs=7][type=null][personId=109336]=java.lang.NullPointerException: Cannot invoke "org.matsim.pt.transitSchedule.api.TransitStopFacility.getCoord()" because "nearestStop" is null,
+[score=undefined][nof_acts_legs=3][type=null][personId=109473]=java.lang.NullPointerException: Cannot invoke "org.matsim.pt.transitSchedule.api.TransitStopFacility.getCoord()" because "nearestStop" is null,
+[score=undefined][nof_acts_legs=5][type=null][personId=109472]=java.lang.NullPointerException: Cannot invoke "org.matsim.pt.transitSchedule.api.TransitStopFacility.getCoord()" because "nearestStop" is null,
+[score=undefined][nof_acts_legs=3][type=null][personId=110603]=java.lang.NullPointerException: Cannot invoke "org.matsim.pt.transitSchedule.api.TransitStopFacility.getCoord()" because "nearestStop" is null
+```
+
+Michael also caught all the exceptions from routing and the validator, but print the validator errors.
+
+```
+2024-08-27T15:47:49,855 ERROR ScenarioValidator:140 Person 99747 has car leg without a route
+2024-08-27T15:47:49,855 ERROR ScenarioValidator:140 Person 99773 has rail leg without a route
+2024-08-27T15:47:49,855 ERROR ScenarioValidator:140 Person 99800 has walk leg without a route
+2024-08-27T15:47:49,855 ERROR ScenarioValidator:140 Person 99852 has walk leg without a route
+2024-08-27T15:47:49,855 ERROR ScenarioValidator:140 Person 99852 has walk leg without a route
+2024-08-27T15:47:49,855 ERROR ScenarioValidator:140 Person 99852 has outside leg without a route
+2024-08-27T15:47:49,855 ERROR ScenarioValidator:140 Person 99852 has walk leg without a route
+2024-08-27T15:47:49,855 ERROR ScenarioValidator:140 Person 99852 has walk leg without a route
+2024-08-27T15:47:49,855 ERROR ScenarioValidator:140 Person 99852 has walk leg without a route
+2024-08-27T15:47:49,855 ERROR ScenarioValidator:140 Person 99852 has walk leg without a route
+2024-08-27T15:47:49,855 ERROR ScenarioValidator:140 Person 99852 has outside leg without a route
+2024-08-27T15:47:49,855 ERROR ScenarioValidator:140 Person 99852 has walk leg without a route
+2024-08-27T15:47:49,855 ERROR ScenarioValidator:140 Person 99852 has walk leg without a route
+```
+The error occurred because some leg of an agent’s trip do not have a valid route according to [validation code](https://github.com/eqasim-org/eqasim-java/blob/develop/core/src/main/java/org/eqasim/core/scenario/validation/ScenarioValidator.java#L139C7-L140).  So simulation could not determine how those agents were supposed to travel between activities for those legs.
+
+Potential Causes of the Errors:
+- Incorrect plans or misconfigured modes: Some agents’ legs appear “incorrect” after the population is trimmed.
+
+- Missing or misconfigured networks: The network somehow disconnected or for a particular mode (car, rail, walk, etc.) might be missing.
+
+- Incorrect transit schedule: There may be issues with the transit schedule input.
+
+
+## Test the simulations using cutter outputs
+Michael helped to worte cutter entire scenario outputs and the outputs can be found on TE EFS at `/mnt/efs/analysis/ys/matsim_cutter/te-10pc-outputs-ignoring-errors`.
+
+When I tested the scenarios by rerunning the simulations with cut outputs based on the following command 
+
+The command to run the simulation: 
+```
+java -cp target/columbus-2.1.0-jar-with-dependencies.jar com.arup.cm.RunArupMatsim /mnt/efs/analysis/ys/matsim_cutter/te-10pc-outputs-ignoring-errors/matsim_config_TE_cutting_validation_with_intermodal.xml
+``` 
+
+It failed with similar errors: 
+```
+024-08-28T14:29:28,700 ERROR ParallelPersonAlgorithmUtils$ExceptionHandler:164 Thread PersonPrepareForSim.0 died with exception while handling events.
+java.lang.NullPointerException: Cannot invoke "org.matsim.pt.transitSchedule.api.TransitStopFacility.getCoord()" because "nearestStop" is null
+        at ch.sbb.matsim.routing.pt.raptor.DefaultRaptorStopFinder.addInitialStopsForParamSet(DefaultRaptorStopFinder.java:175) ~[columbus-2.1.0-jar-with-dependencies.jar:2.1.0]
+        at ch.sbb.matsim.routing.pt.raptor.DefaultRaptorStopFinder.findIntermodalStops(DefaultRaptorStopFinder.java:131) ~[columbus-2.1.0-jar-with-dependencies.jar:2.1.0]
+        at ch.sbb.matsim.routing.pt.raptor.DefaultRaptorStopFinder.findAccessStops(DefaultRaptorStopFinder.java:83) ~[columbus-2.1.0-jar-with-dependencies.jar:2.1.0]
+        at ch.sbb.matsim.routing.pt.raptor.DefaultRaptorStopFinder.findStops(DefaultRaptorStopFinder.java:71) ~[columbus-2.1.0-jar-with-dependencies.jar:2.1.0]
+        at ch.sbb.matsim.routing.pt.raptor.SwissRailRaptor.findAccessStops(SwissRailRaptor.java:252) ~[columbus-2.1.0-jar-with-dependencies.jar:2.1.0]
+        at ch.sbb.matsim.routing.pt.raptor.SwissRailRaptor.calcRoute(SwissRailRaptor.java:74) ~[columbus-2.1.0-jar-with-dependencies.jar:2.1.0]
+        at ch.sbb.matsim.routing.pt.raptor.SwissRailRaptorRoutingModule.calcRoute(SwissRailRaptorRoutingModule.java:58) ~[columbus-2.1.0-jar-with-dependencies.jar:2.1.0]
+        at org.matsim.core.router.TripRouter.calcRoute(TripRouter.java:182) ~[columbus-2.1.0-jar-with-dependencies.jar:2.1.0]
+        at org.matsim.core.router.PlanRouter.run(PlanRouter.java:101) ~[columbus-2.1.0-jar-with-dependencies.jar:2.1.0]
+        at org.matsim.core.population.algorithms.PersonPrepareForSim.run(PersonPrepareForSim.java:219) ~[columbus-2.1.0-jar-with-dependencies.jar:2.1.0]
+        at org.matsim.core.population.algorithms.ParallelPersonAlgorithmUtils$PersonAlgoThread.run(ParallelPersonAlgorithmUtils.java:145) ~[columbus-2.1.0-jar-with-dependencies.jar:2.1.0]
+        at java.lang.Thread.run(Thread.java:840) ~[?:?]
+```
+
+When I did the spot check for the `agent 99852` in the cut population, I found in the plan activities,  the Leg looks a bit weird.
+
+Here is the part of content for the leg, do you know should the legs normally have `routingMode` and `trav_time` in the leg attributes or it’s optional?
+
+```
+<plan selected="yes">
+        <activity type="outside" link="217523" facility="outside_107" x="581674.3013465618" y="266268.765120827" end_time="12:54:02" >
+        </activity>
+        <leg mode="walk">
+        </leg>
+        <activity type="education" link="5176971604409504091_5176971605843912959" facility="f_auto_833" x="584455.0" y="264501.0" start_time="07:40:00" end_time="12:30:00" >
+        </activity>
+```
+
+I did a simple test with trimmed agent plans, I only left the top 5 agents in the cut `TE_cutter_population.xml` which has more “complete” plans with `routingMode `attribute in their legs. The test simulation can successfully run to end.
+
+
+I did another two tests to run the sims with adding  `agent 99852`  plans into the 5 agents test population input.
+
+When the `agent 99852` has "weird" plans without `routingMode` between legs (The original plans we got from the cutting process), the test simulation failed with NEP error.
+
+```xml
+<plan selected="yes">
+        <activity type="outside" link="217523" facility="outside_107" x="581674.3013465618" y="266268.765120827" end_time="12:54:02" >
+        </activity>
+        <leg mode="walk">
+        </leg>
+        <activity type="education" link="5176971604409504091_5176971605843912959" facility="f_auto_833" x="584455.0" y="264501.0" start_time="07:40:00" end_time="12:30:00" >
+        </activity>
+        <leg mode="walk">
+        </leg>
+        <activity type="outside" link="217523" facility="outside_107" x="581674.3013465618" y="266268.765120827" end_time="13:15:00" >
+        </activity>
+        <leg mode="outside">
+        </leg>
+        <activity type="outside" link="217523" facility="outside_107" x="581674.3013465618" y="266268.765120827" end_time="18:49:02" >
+        </activity>
+        <leg mode="walk">
+        </leg>
+        <activity type="education" link="5176971604409504091_5176971605843912959" facility="f_auto_833" x="584455.0" y="264501.0" start_time="13:30:00" end_time="14:20:00" >
+        </activity>
+        <leg mode="walk">
+        </leg>
+        <activity type="outside" link="217523" facility="outside_107" x="581674.3013465618" y="266268.765120827" >
+        </activity>
+</plan>
+```
+
+When I manually added the `routingMode` into the agents' plans, 
+
+```xml
+<attributes>
+	<attribute name="routingMode" class="java.lang.String">walk</attribute>
+</attributes>
+```
+between the legs into the plans, the test simulation can run to the end.
+
+
+The original plans of the `agent 99852` from the population,
+```xml
+<plan score="-574.0437376231156" selected="yes">
+        <activity type="home" link="66637" facility="f_auto_5689" x="571705.0" y="273772.0" start_time="00:00:00" end_time="07:26:12" >
+        </activity>
+        <leg mode="walk" dep_time="07:26:12" trav_time="06:49:52">
+                <attributes>
+                        <attribute name="routingMode" class="java.lang.String">walk</attribute>
+                </attributes>
+                <route type="generic" start_link="66637" end_link="5176971604409504091_5176971605843912959" trav_time="06:49:52" distance="20493.62242967309"></route>
+        </leg>
+        <activity type="education" link="5176971604409504091_5176971605843912959" facility="f_auto_833" x="584455.0" y="264501.0" start_time="07:40:00" end_time="12:14:05" >
+        </activity>
+        <leg mode="walk" dep_time="12:14:05" trav_time="06:49:52">
+                <attributes>
+                        <attribute name="routingMode" class="java.lang.String">walk</attribute>
+                </attributes>
+                <route type="generic" start_link="5176971604409504091_5176971605843912959" end_link="66637" trav_time="06:49:52" distance="20493.62242967309"></route>
+        </leg>
+        <activity type="home" link="66637" facility="f_auto_5689" x="571705.0" y="273772.0" start_time="12:45:00" end_time="12:59:27" >
+        </activity>
+        <leg mode="walk" dep_time="12:59:27" trav_time="06:49:52">
+                <attributes>
+                        <attribute name="routingMode" class="java.lang.String">walk</attribute>
+                </attributes>
+                <route type="generic" start_link="66637" end_link="5176971604409504091_5176971605843912959" trav_time="06:49:52" distance="20493.62242967309"></route>
+        </leg>
+        <activity type="education" link="5176971604409504091_5176971605843912959" facility="f_auto_833" x="584455.0" y="264501.0" start_time="13:30:00" end_time="14:31:16" >
+        </activity>
+        <leg mode="walk" dep_time="14:31:16" trav_time="06:49:52">
+                <attributes>
+                        <attribute name="routingMode" class="java.lang.String">walk</attribute>
+                </attributes>
+                <route type="generic" start_link="5176971604409504091_5176971605843912959" end_link="66637" trav_time="06:49:52" distance="20493.62242967309"></route>
+                                        </leg>
+        <activity type="home" link="66637" facility="f_auto_5689" x="571705.0" y="273772.0" start_time="14:40:00" end_time="23:45:58" >
+        </activity>
+</plan>
+
+</person>
+```
+It seems cutter somehow didn’t deal with `agent 99852` and other agents correctly.
+
+
+### Validate the connectivity of the network
+I have used the `networkX` package to validate connectivity based on the script at `/mnt/efs/analysis/ys/matsim_cutter/network_validation.py`. The network doesn’t have any dead end nodes or isolated node and some nodes are disconnected.
+
+
+
+### Checking the output trainsit schedule
+For the cutter output `transit_schedule.xml` at 
+`/mnt/efs/analysis/ys/matsim_cutter/te-10pc-outputs-ignoring-errors/TE_cutter_transit_schedule.xml`, it seems all of the stop facilities have been updated the `bikeAccessible` and `carAccessible` attribute which maybe not the reason induce the error but incorrectly.
+
+```xml
+<stopFacility id="390GBURY1" x="585132.9173118277" y="264535.6685015094" linkRefId="5176971626509406753_5176971626509406753" name="Bury St Edmunds" isBlocking="false">
+                <attributes>
+                        <attribute name="bikeAccessible" class="java.lang.String">True</attribute>
+                        <attribute name="carAccessible" class="java.lang.String">True</attribute>
+                </attributes>
+
+        </stopFacility>
+```
+Before the cutting, the stop id `390GBURY1` which could not be accessible for bike and car since it doesn’t have these attributes:
+```xml
+<stopFacility id="390GBURY1" x="585132.9173118277" y="264535.6685015094" linkRefId="5176971626509406753_5176971626509406753" name="Bury St Edmunds" isBlocking="false"/>
+```
+
+### Progress of debugging the missing `walk` mode parameters when rerun the simulations with post cutting inputs.
+
+When I validate the simulation by rerunning using the inputs after cutting, the cutter works without intermodal setting in the matsim config for 0.01% simulation inputs.
+
+It failed with the following error when tried the same process for 10% .
+
+```
+2024-08-06T15:30:33,240 ERROR ParallelEventsManager$ExceptionHandler:414 Thread SingleHandlerEventsManager: class org.matsim.core.scoring.ScoringFunctionsForPopulation died with exception while handling events.
+java.lang.RuntimeException: just encountered mode for which no scoring parameters are defined: walk
+	at org.matsim.core.scoring.functions.CharyparNagelLegScoring.calcLegScore(CharyparNagelLegScoring.java:113) ~[columbus-2.1.0-jar-with-dependencies.jar:2.1.0]
+	at org.matsim.core.scoring.functions.CharyparNagelLegScoring.handleLeg(CharyparNagelLegScoring.java:191) ~[columbus-2.1.0-jar-with-dependencies.jar:2.1.0]
+	at org.matsim.core.scoring.SumScoringFunction.handleLeg(SumScoringFunction.java:114) ~[columbus-2.1.0-jar-with-dependencies.jar:2.1.0]
+	at org.matsim.core.scoring.ScoringFunctionsForPopulation.handleLeg(ScoringFunctionsForPopulation.java:226) ~[columbus-2.1.0-jar-with-dependencies.jar:2.1.0]
+	at org.matsim.core.scoring.EventsToLegs.handleEvent(EventsToLegs.java:353) ~[columbus-2.1.0-jar-with-dependencies.jar:2.1.0]
+	at org.matsim.core.scoring.ScoringFunctionsForPopulation.handleEvent(ScoringFunctionsForPopulation.java:176) ~[columbus-2.1.0-jar-with-dependencies.jar:2.1.0]
+	at org.matsim.core.events.SingleHandlerEventsManager.callHandlerFast(SingleHandlerEventsManager.java:298) ~[columbus-2.1.0-jar-with-dependencies.jar:2.1.0]
+	at org.matsim.core.events.SingleHandlerEventsManager.computeEvent(SingleHandlerEventsManager.java:229) ~[columbus-2.1.0-jar-with-dependencies.jar:2.1.0]
+	at org.matsim.core.events.SingleHandlerEventsManager.processEvent(SingleHandlerEventsManager.java:182) ~[columbus-2.1.0-jar-with-dependencies.jar:2.1.0]
+	at org.matsim.core.events.ParallelEventsManager$ProcessEventsRunnable.run(ParallelEventsManager.java:381) ~[columbus-2.1.0-jar-with-dependencies.jar:2.1.0]
+```
+
+The errors pointed a transport mode walk in the population plans that hasn't been defined in the scoring parameters of the planCalcScore module in the MATSim config([code](https://github.com/matsim-org/matsim-libs/blob/master/matsim/src/main/java/org/matsim/core/scoring/functions/CharyparNagelLegScoring.java#L131)).
+
+I have checked the matsim config scoring module, the walk mode parameters have been added to each supopulation expect the freight subpopulation, e.g lgv, hgv which only requires the car mode for delivery.
+
+When I added the `walk` mode parameter for the freight to rerun, it threw another error:
+
+```
+2024-09-09T13:56:28,336  INFO Realm:325 Hermes running at 09:00:00
+2024-09-09T13:56:28,378  INFO Realm:325 Hermes running at 10:00:00
+2024-09-09T13:56:28,365 ERROR ParallelEventsManager$ExceptionHandler:414 Thread SingleHandlerEventsManager: class org.matsim.core.scoring.ScoringFunctionsForPopulation died with exception while handling events.
+java.lang.NullPointerException: Cannot read field "marginalUtilityOfTraveling_s" because the return value of "java.util.Map.get(Object)" is null
+	at org.matsim.core.scoring.functions.CharyparNagelLegScoring.handleEvent(CharyparNagelLegScoring.java:168) ~[columbus-2.1.0-jar-with-dependencies.jar:2.1.0]
+	at org.matsim.core.scoring.SumScoringFunction.handleEvent(SumScoringFunction.java:149) ~[columbus-2.1.0-jar-with-dependencies.jar:2.1.0]
+	at org.matsim.core.scoring.ScoringFunctionsForPopulation.handleEvent(ScoringFunctionsForPopulation.java:135) ~[columbus-2.1.0-jar-with-dependencies.jar:2.1.0]
+	at org.matsim.core.events.SingleHandlerEventsManager.callHandlerFast(SingleHandlerEventsManager.java:298) ~[columbus-2.1.0-jar-with-dependencies.jar:2.1.0]
+	at org.matsim.core.events.SingleHandlerEventsManager.computeEvent(SingleHandlerEventsManager.java:229) ~[columbus-2.1.0-jar-with-dependencies.jar:2.1.0]
+	at org.matsim.core.events.SingleHandlerEventsManager.processEvent(SingleHandlerEventsManager.java:182) ~[columbus-2.1.0-jar-with-dependencies.jar:2.1.0]
+	at org.matsim.core.events.ParallelEventsManager$ProcessEventsRunnable.run(ParallelEventsManager.java:381) ~[columbus-2.1.0-jar-with-dependencies.jar:2.1.0]
+
+```
+
+I have checked the freight subpopulation and it only used `car` leg.
+
+The current solution is to remove freight population, the simulations using post-cutting inputs can successfully rerun to the end.
+
+More investigation can be potential carried out on why the error induced in the freight subpopulation. 
+

--- a/docs/cutting-scenarios-CML/matsim_configs_example/matsim_config_TE_cutting_validation_no_intermodal_no_freight.xml
+++ b/docs/cutting-scenarios-CML/matsim_configs_example/matsim_config_TE_cutting_validation_no_intermodal_no_freight.xml
@@ -1,0 +1,3166 @@
+<?xml version="1.0" ?>
+<!DOCTYPE config SYSTEM "http://www.matsim.org/files/dtd/config_v2.dtd">
+<config>
+  <module name="global">
+    <param name="randomSeed" value="4711"/>
+    <param name="coordinateSystem" value="EPSG:27700"/>
+    <param name="numberOfThreads" value="96"/>
+  </module>
+  <module name="network">
+    <param name="inputNetworkFile" value="TE_cutter_network.xml.gz"/>
+  </module>
+  <module name="plans">
+    <param name="inputPlansFile" value="modified_remove_freight_TE_cutter_population_v1.xml"/>
+  </module>
+  <module name="vehicles">
+    <param name="vehiclesFile" value="TE_cutter_vehicles.xml.gz"/>
+  </module>
+  <module name="planscalcroute">
+    <param name="networkModes" value="car,car_passenger,taxi"/>
+    <parameterset type="teleportedModeParameters">
+      <param name="beelineDistanceFactor" value="1.3"/>
+      <param name="mode" value="bike"/>
+      <param name="teleportedModeFreespeedFactor" value="null"/>
+      <param name="teleportedModeSpeed" value="4.166666666666667"/>
+    </parameterset>
+    <parameterset type="teleportedModeParameters">
+      <param name="beelineDistanceFactor" value="1.3"/>
+      <param name="mode" value="walk"/>
+      <param name="teleportedModeFreespeedFactor" value="null"/>
+      <param name="teleportedModeSpeed" value="0.8333333333333333"/>
+    </parameterset>
+    <parameterset type="teleportedModeParameters">
+      <param name="beelineDistanceFactor" value="1.3"/>
+      <param name="mode" value="non_network_walk"/>
+      <param name="teleportedModeFreespeedFactor" value="null"/>
+      <param name="teleportedModeSpeed" value="0.8333333333333333"/>
+    </parameterset>
+  </module>
+  <module name="transit">
+    <param name="useTransit" value="true"/>
+    <param name="transitScheduleFile" value="TE_cutter_transit_schedule.xml.gz"/>
+    <param name="vehiclesFile" value="TE_cutter_transit_vehicles.xml.gz"/>
+    <param name="transitModes" value="bus,rail,ferry,subway,tram,pt,outside"/>
+  </module>
+  <module name="swissRailRaptor">
+    <param name="useModeMappingForPassengers" value="true"/>
+    <!-- <param name="useIntermodalAccessEgress" value="true"/>
+    <param name="intermodalAccessEgressModeSelection" value="RandomSelectOneModePerRoutingRequestAndDirection"/>
+    <parameterset type="intermodalAccessEgress">
+      <param name="mode" value="walk"/>
+      <param name="initialSearchRadius" value="500"/>
+      <param name="maxRadius" value="2000"/>
+    </parameterset>
+    <parameterset type="intermodalAccessEgress">
+      <param name="mode" value="bike"/>
+      <param name="initialSearchRadius" value="2000"/>
+      <param name="maxRadius" value="5000"/>
+      <param name="personFilterAttribute" value="intermodalBike"/>
+      <param name="personFilterValue" value="yes"/>
+      <param name="stopFilterAttribute" value="bikeAccessible"/>
+      <param name="stopFilterValue" value="true"/>
+    </parameterset>
+    <parameterset type="intermodalAccessEgress">
+      <param name="mode" value="car"/>
+      <param name="initialSearchRadius" value="5000"/>
+      <param name="searchExtensionRadius" value="1000.0"/>
+      <param name="maxRadius" value="10000"/>
+      <param name="linkIdAttribute" value="accessLinkId_car"/>
+      <param name="personFilterAttribute" value="intermodalCar"/>
+      <param name="personFilterValue" value="yes"/>
+      <param name="stopFilterAttribute" value="carAccessible"/>
+      <param name="stopFilterValue" value="true"/>
+    </parameterset>
+    <parameterset type="intermodalAccessEgress">
+      <param name="mode" value="taxi"/>
+      <param name="initialSearchRadius" value="5000"/>
+      <param name="searchExtensionRadius" value="1000.0"/>
+      <param name="maxRadius" value="10000"/>
+      <param name="linkIdAttribute" value="accessLinkId_car"/>
+      <param name="personFilterAttribute" value="intermodalTaxi"/>
+      <param name="personFilterValue" value="yes"/>
+      <param name="stopFilterAttribute" value="carAccessible"/>
+      <param name="stopFilterValue" value="true"/>
+    </parameterset>
+    <parameterset type="intermodalAccessEgress">
+      <param name="mode" value="car_passenger"/>
+      <param name="initialSearchRadius" value="5000"/>
+      <param name="searchExtensionRadius" value="1000.0"/>
+      <param name="maxRadius" value="10000"/>
+      <param name="linkIdAttribute" value="accessLinkId_car"/>
+      <param name="personFilterAttribute" value="intermodalPassenger"/>
+      <param name="personFilterValue" value="yes"/>
+      <param name="stopFilterAttribute" value="carAccessible"/>
+      <param name="stopFilterValue" value="true"/>
+    </parameterset> -->
+    <parameterset type="modeMapping">
+      <param name="routeMode" value="bus"/>
+      <param name="passengerMode" value="bus"/>
+    </parameterset>
+    <parameterset type="modeMapping">
+      <param name="routeMode" value="rail"/>
+      <param name="passengerMode" value="rail"/>
+    </parameterset>
+    <parameterset type="modeMapping">
+      <param name="routeMode" value="ferry"/>
+      <param name="passengerMode" value="ferry"/>
+    </parameterset>
+    <parameterset type="modeMapping">
+      <param name="routeMode" value="subway"/>
+      <param name="passengerMode" value="subway"/>
+    </parameterset>
+    <parameterset type="modeMapping">
+      <param name="routeMode" value="tram"/>
+      <param name="passengerMode" value="tram"/>
+    </parameterset>
+  </module>
+  <module name="transitRouter">
+    <param name="additionalTransferTime" value="1.0"/>
+    <param name="extensionRadius" value="2000.0"/>
+    <param name="maxBeelineWalkConnectionDistance" value="500.0"/>
+    <param name="searchRadius" value="2000.0"/>
+  </module>
+  <module name="TimeAllocationMutator">
+    <param name="mutationRange" value="1000.0"/>
+  </module>
+  <module name="ArupReplanning">
+    <param name="maximumBikeTourDistance_m" value="45000"/>
+    <param name="maximumWalkTourDistance_m" value="12500"/>
+    <param name="minimumTimeMutationStep_s" value="300"/>
+  </module>
+  	<module name="facilities" >
+      <!-- This defines how facilities should be created. Possible values: none fromFile setInScenario onePerActivityLinkInPlansFile onePerActivityLinkInPlansFileExceptWhenCoordinatesAreGiven onePerActivityLocationInPlansFile  -->
+      <!-- <param name="facilitiesSource" value="onePerActivityLocationInPlansFile" /> -->
+	<param name="facilitiesSource" value="onePerActivityLinkInPlansFile" />
+	<!-- <param name="facilitiesSource" value="fromFile" />
+	  <param name="inputFacilitiesFile" value="output_facilities.xml.gz" /> -->
+    </module>
+  <module name="controler">
+    <param name="createGraphs" value="true"/>
+    <param name="outputDirectory" value="/mnt/efs/analysis/ys/matsim_cutter/output_no_intermodal_20240909_10pct/simulation_validation_20240912_no_freight_v1"/>
+    <param name="firstIteration" value="0"/>
+    <param name="lastIteration" value="10"/>
+    <param name="routingAlgorithmType" value="FastAStarLandmarks"/>
+    <param name="eventsFileFormat" value="xml"/>
+    <param name="writeEventsInterval" value="10"/>
+    <param name="writePlansInterval" value="10"/>
+    <param name="mobsim" value="hermes"/>
+    <param name="snapshotFormat" value=""/>
+    <param name="overwriteFiles" value="deleteDirectoryIfExists"/>
+  </module>
+  <module name="subtourModeChoice">
+    <param name="considerCarAvailability" value="true"/>
+    <param name="chainBasedModes" value="car,bike"/>
+    <param name="modes" value="bus,bike,walk,rail,car,ferry,subway,tram,car_passenger,taxi"/>
+  </module>
+  <module name="parallelEventHandling">
+    <param name="estimatedNumberOfEvents" value="null"/>
+    <param name="eventsQueueSize" value="270000000"/>
+    <param name="numberOfThreads" value="96"/>
+    <param name="oneThreadPerHandler" value="true"/>
+    <param name="synchronizeOnSimSteps" value="true"/>
+  </module>
+  <module name="hermes">
+    <param name="endTime" value="32:00:00"/>
+    <param name="flowCapacityFactor" value="0.1"/>
+    <param name="mainMode" value="car,taxi"/>
+    <param name="storageCapacityFactor" value="0.1"/>
+    <param name="stuckTime" value="30"/>
+    <param name="useDeterministicPt" value="true"/>
+  </module>
+  <module name="SBBPt">
+    <param name="deterministicServiceModes" value="rail,ferry,subway,tram"/>
+    <param name="createLinkEventsInterval" value="50"/>
+  </module>
+  <module name="planCalcScore">
+    <param name="BrainExpBeta" value="1.0"/>
+    <param name="writeExperiencedPlans" value="true"/>
+    <parameterset type="scoringParameters">
+      <param name="earlyDeparture" value="-0.0"/>
+      <param name="lateArrival" value="0"/>
+      <param name="marginalUtilityOfMoney" value="1"/>
+      <param name="performing" value="10"/>
+      <param name="subpopulation" value="default"/>
+      <param name="utilityOfLineSwitch" value="-0.5"/>
+      <param name="waiting" value="-0.0"/>
+      <param name="waitingPt" value="0"/>
+      <parameterset type="activityParams">
+        <param name="activityType" value="outside"/>
+        <param name="priority" value="1"/>
+        <param name="typicalDuration" value="12:00:00"/>
+        <param name="minimalDuration" value="08:00:00"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="home"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="1:00:00"/>
+        <param name="typicalDuration" value="10:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="work"/>
+        <param name="openingTime" value="7:00:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="6:00:00"/>
+        <param name="typicalDuration" value="9:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="delivery"/>
+        <param name="openingTime" value="06:00:00"/>
+        <param name="closingTime" value="20:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="1:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="depot"/>
+        <param name="openingTime" value="0:00:00"/>
+        <param name="closingTime" value="23:59:59"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="4:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="education"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="17:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="6:00:00"/>
+        <param name="typicalDuration" value="6:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="other"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:10:00"/>
+        <param name="typicalDuration" value="0:30:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="shop"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="0:30:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="visit"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="2:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="medical"/>
+        <param name="openingTime" value="09:00:00"/>
+        <param name="closingTime" value="18:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="1:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="business"/>
+        <param name="openingTime" value="07:30:00"/>
+        <param name="closingTime" value="20:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="1:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_home"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_work"/>
+        <param name="openingTime" value="7:00:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_business"/>
+        <param name="openingTime" value="7:00:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_education"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="17:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_other"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+        <parameterset type="activityParams">
+        <param name="activityType" value="escort_shop"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="17:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+    
+ 
+      <parameterset type="modeParams">
+        <param name="mode" value="outside"/>
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.0004"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0.0"/>
+        <param name="mode" value="car"/>
+        <param name="monetaryDistanceRate" value="-0.00009"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0.0"/>
+        <param name="mode" value="car_passenger"/>
+        <param name="monetaryDistanceRate" value="-0.00009"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0.0"/>
+        <param name="mode" value="taxi"/>
+        <param name="monetaryDistanceRate" value="-0.001"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-1"/>
+        <param name="dailyMonetaryConstant" value="0"/>
+        <param name="dailyUtilityConstant" value="0.0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="-0.0015"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="0"/>
+        <param name="mode" value="bike"/>
+        <param name="monetaryDistanceRate" value="-0.0"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="-0.0005"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="0"/>
+        <param name="mode" value="walk"/>
+        <param name="monetaryDistanceRate" value="0.0"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="pt"/>
+        <param name="constant" value="-10000.0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="0"/>
+        <param name="monetaryDistanceRate" value="-0.000"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="bus"/>
+        <param name="constant" value="-3"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-2"/>
+        <param name="monetaryDistanceRate" value="-0.0002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="rail"/>
+        <param name="constant" value="2"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.0002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="ferry"/>
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.001"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="subway"/>
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.0002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="tram"/>
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.0004"/>
+      </parameterset>
+    </parameterset>
+
+    <parameterset type="scoringParameters">
+      <param name="earlyDeparture" value="-0.0"/>
+      <param name="lateArrival" value="0"/>
+      <param name="marginalUtilityOfMoney" value="2"/>
+      <param name="performing" value="10"/>
+      <param name="subpopulation" value="low"/>
+      <param name="utilityOfLineSwitch" value="-0.5"/>
+      <param name="waiting" value="-0.0"/>
+      <param name="waitingPt" value="0"/>
+      <parameterset type="activityParams">
+        <param name="activityType" value="outside"/>
+        <param name="priority" value="1"/>
+        <param name="typicalDuration" value="12:00:00"/>
+        <param name="minimalDuration" value="08:00:00"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="home"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="1:00:00"/>
+        <param name="typicalDuration" value="10:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="work"/>
+        <param name="openingTime" value="7:00:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="6:00:00"/>
+        <param name="typicalDuration" value="9:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="education"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="17:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="6:00:00"/>
+        <param name="typicalDuration" value="6:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="other"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:10:00"/>
+        <param name="typicalDuration" value="0:30:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="shop"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="0:30:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="visit"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="2:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="medical"/>
+        <param name="openingTime" value="09:00:00"/>
+        <param name="closingTime" value="18:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="1:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="business"/>
+        <param name="openingTime" value="07:30:00"/>
+        <param name="closingTime" value="20:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="1:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_home"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_work"/>
+        <param name="openingTime" value="7:00:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_business"/>
+        <param name="openingTime" value="7:00:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_education"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="17:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_other"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+        <parameterset type="activityParams">
+        <param name="activityType" value="escort_shop"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="17:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      
+ 
+
+      <parameterset type="modeParams">
+        <param name="mode" value="outside"/>
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.0004"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0.0"/>
+        <param name="mode" value="car"/>
+        <param name="monetaryDistanceRate" value="-0.00009"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0.0"/>
+        <param name="mode" value="car_passenger"/>
+        <param name="monetaryDistanceRate" value="-0.0002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0.0"/>
+        <param name="mode" value="taxi"/>
+        <param name="monetaryDistanceRate" value="-0.002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-1"/>
+        <param name="dailyMonetaryConstant" value="0"/>
+        <param name="dailyUtilityConstant" value="0.0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="-0.0015"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="0"/>
+        <param name="mode" value="bike"/>
+        <param name="monetaryDistanceRate" value="-0.0"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="-0.0005"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="0"/>
+        <param name="mode" value="walk"/>
+        <param name="monetaryDistanceRate" value="0.0"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="pt"/>
+        <param name="constant" value="-10000.0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="0"/>
+        <param name="monetaryDistanceRate" value="-0.000"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="bus"/>
+        <param name="constant" value="-3"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-2"/>
+        <param name="monetaryDistanceRate" value="-0.0002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="rail"/>
+        <param name="constant" value="2"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.0002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="ferry"/>
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.001"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="subway"/>
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.0002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="tram"/>
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.0004"/>
+      </parameterset>
+ 
+    </parameterset>
+    <parameterset type="scoringParameters">
+      <param name="earlyDeparture" value="-0.0"/>
+      <param name="lateArrival" value="0"/>
+      <param name="marginalUtilityOfMoney" value="1"/>
+      <param name="performing" value="10"/>
+      <param name="subpopulation" value="medium"/>
+      <param name="utilityOfLineSwitch" value="-0.5"/>
+      <param name="waiting" value="-0.0"/>
+      <param name="waitingPt" value="0"/>
+      <parameterset type="activityParams">
+        <param name="activityType" value="outside"/>
+        <param name="priority" value="1"/>
+        <param name="typicalDuration" value="12:00:00"/>
+        <param name="minimalDuration" value="08:00:00"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="home"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="1:00:00"/>
+        <param name="typicalDuration" value="10:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="work"/>
+        <param name="openingTime" value="7:00:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="6:00:00"/>
+        <param name="typicalDuration" value="9:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="education"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="17:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="6:00:00"/>
+        <param name="typicalDuration" value="6:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="other"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:10:00"/>
+        <param name="typicalDuration" value="0:30:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="shop"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="0:30:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="visit"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="2:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="medical"/>
+        <param name="openingTime" value="09:00:00"/>
+        <param name="closingTime" value="18:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="1:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="business"/>
+        <param name="openingTime" value="07:30:00"/>
+        <param name="closingTime" value="20:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="1:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_home"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_work"/>
+        <param name="openingTime" value="7:00:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_business"/>
+        <param name="openingTime" value="7:00:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_education"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="17:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_other"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+        <parameterset type="activityParams">
+        <param name="activityType" value="escort_shop"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="17:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      
+ 
+
+      
+
+      <parameterset type="modeParams">
+        <param name="mode" value="outside"/>
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.0004"/>
+      </parameterset>      
+      <parameterset type="modeParams">
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0.0"/>
+        <param name="mode" value="car"/>
+        <param name="monetaryDistanceRate" value="-0.0002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0.0"/>
+        <param name="mode" value="car_passenger"/>
+        <param name="monetaryDistanceRate" value="-0.0002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0.0"/>
+        <param name="mode" value="taxi"/>
+        <param name="monetaryDistanceRate" value="-0.002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-1"/>
+        <param name="dailyMonetaryConstant" value="0"/>
+        <param name="dailyUtilityConstant" value="0.0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="-0.0015"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="0"/>
+        <param name="mode" value="bike"/>
+        <param name="monetaryDistanceRate" value="-0.0"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="-0.0005"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="0"/>
+        <param name="mode" value="walk"/>
+        <param name="monetaryDistanceRate" value="0.0"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="pt"/>
+        <param name="constant" value="-10000.0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="0"/>
+        <param name="monetaryDistanceRate" value="-0.000"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="bus"/>
+        <param name="constant" value="-3"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-2"/>
+        <param name="monetaryDistanceRate" value="-0.0002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="rail"/>
+        <param name="constant" value="2"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.0002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="ferry"/>
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.001"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="subway"/>
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.0002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="tram"/>
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.0004"/>
+      </parameterset>
+ 
+    </parameterset>
+    <parameterset type="scoringParameters">
+      <param name="earlyDeparture" value="-0.0"/>
+      <param name="lateArrival" value="0"/>
+      <param name="marginalUtilityOfMoney" value="0.5"/>
+      <param name="performing" value="10"/>
+      <param name="subpopulation" value="high"/>
+      <param name="utilityOfLineSwitch" value="-0.5"/>
+      <param name="waiting" value="-0.0"/>
+      <param name="waitingPt" value="0"/>
+      <parameterset type="activityParams">
+        <param name="activityType" value="outside"/>
+        <param name="priority" value="1"/>
+        <param name="typicalDuration" value="12:00:00"/>
+        <param name="minimalDuration" value="08:00:00"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="home"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="1:00:00"/>
+        <param name="typicalDuration" value="10:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="work"/>
+        <param name="openingTime" value="7:00:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="6:00:00"/>
+        <param name="typicalDuration" value="9:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="education"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="17:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="6:00:00"/>
+        <param name="typicalDuration" value="6:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="other"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:10:00"/>
+        <param name="typicalDuration" value="0:30:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="shop"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="0:30:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="visit"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="2:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="medical"/>
+        <param name="openingTime" value="09:00:00"/>
+        <param name="closingTime" value="18:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="1:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="business"/>
+        <param name="openingTime" value="07:30:00"/>
+        <param name="closingTime" value="20:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="1:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_home"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_work"/>
+        <param name="openingTime" value="7:00:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_business"/>
+        <param name="openingTime" value="7:00:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_education"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="17:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_other"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+        <parameterset type="activityParams">
+        <param name="activityType" value="escort_shop"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="17:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      
+ 
+
+      
+
+      <parameterset type="modeParams">
+        <param name="mode" value="outside"/>
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.0004"/>
+      </parameterset>      
+      <parameterset type="modeParams">
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0.0"/>
+        <param name="mode" value="car"/>
+        <param name="monetaryDistanceRate" value="-0.0002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0.0"/>
+        <param name="mode" value="car_passenger"/>
+        <param name="monetaryDistanceRate" value="-0.0002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0.0"/>
+        <param name="mode" value="taxi"/>
+        <param name="monetaryDistanceRate" value="-0.002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-1"/>
+        <param name="dailyMonetaryConstant" value="0"/>
+        <param name="dailyUtilityConstant" value="0.0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="-0.0015"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="0"/>
+        <param name="mode" value="bike"/>
+        <param name="monetaryDistanceRate" value="-0.0"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="-0.0005"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="0"/>
+        <param name="mode" value="walk"/>
+        <param name="monetaryDistanceRate" value="0.0"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="pt"/>
+        <param name="constant" value="-10000.0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="0"/>
+        <param name="monetaryDistanceRate" value="-0.000"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="bus"/>
+        <param name="constant" value="-3"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-2"/>
+        <param name="monetaryDistanceRate" value="-0.0002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="rail"/>
+        <param name="constant" value="2"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.0002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="ferry"/>
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.001"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="subway"/>
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.0002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="tram"/>
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.0004"/>
+      </parameterset>
+ 
+    </parameterset>
+    <parameterset type="scoringParameters">
+      <param name="earlyDeparture" value="-0.0"/>
+      <param name="lateArrival" value="0"/>
+      <param name="marginalUtilityOfMoney" value="2"/>
+      <param name="performing" value="10"/>
+      <param name="subpopulation" value="ev_low"/>
+      <param name="utilityOfLineSwitch" value="-0.5"/>
+      <param name="waiting" value="-0.0"/>
+      <param name="waitingPt" value="0"/>
+      <parameterset type="activityParams">
+        <param name="activityType" value="outside"/>
+        <param name="priority" value="1"/>
+        <param name="typicalDuration" value="12:00:00"/>
+        <param name="minimalDuration" value="08:00:00"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="home"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="1:00:00"/>
+        <param name="typicalDuration" value="10:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="work"/>
+        <param name="openingTime" value="7:00:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="6:00:00"/>
+        <param name="typicalDuration" value="9:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="education"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="17:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="6:00:00"/>
+        <param name="typicalDuration" value="6:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="other"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:10:00"/>
+        <param name="typicalDuration" value="0:30:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="shop"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="0:30:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="visit"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="2:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="medical"/>
+        <param name="openingTime" value="09:00:00"/>
+        <param name="closingTime" value="18:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="1:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="business"/>
+        <param name="openingTime" value="07:30:00"/>
+        <param name="closingTime" value="20:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="1:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_home"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_work"/>
+        <param name="openingTime" value="7:00:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_business"/>
+        <param name="openingTime" value="7:00:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_education"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="17:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_other"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+        <parameterset type="activityParams">
+        <param name="activityType" value="escort_shop"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="17:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      
+ 
+
+      
+
+      <parameterset type="modeParams">
+        <param name="mode" value="outside"/>
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.0004"/>
+      </parameterset>      
+      <parameterset type="modeParams">
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0.0"/>
+        <param name="mode" value="car"/>
+        <param name="monetaryDistanceRate" value="-5e-05"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0.0"/>
+        <param name="mode" value="car_passenger"/>
+        <param name="monetaryDistanceRate" value="-5e-05"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0.0"/>
+        <param name="mode" value="taxi"/>
+        <param name="monetaryDistanceRate" value="-0.002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-1"/>
+        <param name="dailyMonetaryConstant" value="0"/>
+        <param name="dailyUtilityConstant" value="0.0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="-0.0015"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="0"/>
+        <param name="mode" value="bike"/>
+        <param name="monetaryDistanceRate" value="-0.0"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="-0.0005"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="0"/>
+        <param name="mode" value="walk"/>
+        <param name="monetaryDistanceRate" value="0.0"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="pt"/>
+        <param name="constant" value="-10000.0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="0"/>
+        <param name="monetaryDistanceRate" value="-0.000"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="bus"/>
+        <param name="constant" value="-3"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-2"/>
+        <param name="monetaryDistanceRate" value="-0.0002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="rail"/>
+        <param name="constant" value="2"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.0002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="ferry"/>
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.001"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="subway"/>
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.0002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="tram"/>
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.0004"/>
+      </parameterset>
+ 
+    </parameterset>
+    <parameterset type="scoringParameters">
+      <param name="earlyDeparture" value="-0.0"/>
+      <param name="lateArrival" value="0"/>
+      <param name="marginalUtilityOfMoney" value="1"/>
+      <param name="performing" value="10"/>
+      <param name="subpopulation" value="ev_medium"/>
+      <param name="utilityOfLineSwitch" value="-0.5"/>
+      <param name="waiting" value="-0.0"/>
+      <param name="waitingPt" value="0"/>
+      <parameterset type="activityParams">
+        <param name="activityType" value="outside"/>
+        <param name="priority" value="1"/>
+        <param name="typicalDuration" value="12:00:00"/>
+        <param name="minimalDuration" value="08:00:00"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="home"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="1:00:00"/>
+        <param name="typicalDuration" value="10:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="work"/>
+        <param name="openingTime" value="7:00:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="6:00:00"/>
+        <param name="typicalDuration" value="9:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="education"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="17:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="6:00:00"/>
+        <param name="typicalDuration" value="6:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="other"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:10:00"/>
+        <param name="typicalDuration" value="0:30:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="shop"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="0:30:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="visit"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="2:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="medical"/>
+        <param name="openingTime" value="09:00:00"/>
+        <param name="closingTime" value="18:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="1:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="business"/>
+        <param name="openingTime" value="07:30:00"/>
+        <param name="closingTime" value="20:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="1:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_home"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_work"/>
+        <param name="openingTime" value="7:00:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_business"/>
+        <param name="openingTime" value="7:00:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_education"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="17:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_other"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+        <parameterset type="activityParams">
+        <param name="activityType" value="escort_shop"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="17:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      
+ 
+
+      
+
+      <parameterset type="modeParams">
+        <param name="mode" value="outside"/>
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.0004"/>
+      </parameterset>      
+      <parameterset type="modeParams">
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0.0"/>
+        <param name="mode" value="car"/>
+        <param name="monetaryDistanceRate" value="-5e-05"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0.0"/>
+        <param name="mode" value="car_passenger"/>
+        <param name="monetaryDistanceRate" value="-5e-05"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0.0"/>
+        <param name="mode" value="taxi"/>
+        <param name="monetaryDistanceRate" value="-0.002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-1"/>
+        <param name="dailyMonetaryConstant" value="0"/>
+        <param name="dailyUtilityConstant" value="0.0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="-0.0015"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="0"/>
+        <param name="mode" value="bike"/>
+        <param name="monetaryDistanceRate" value="-0.0"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="-0.0005"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="0"/>
+        <param name="mode" value="walk"/>
+        <param name="monetaryDistanceRate" value="0.0"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="pt"/>
+        <param name="constant" value="-10000.0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="0"/>
+        <param name="monetaryDistanceRate" value="-0.000"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="bus"/>
+        <param name="constant" value="-3"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-2"/>
+        <param name="monetaryDistanceRate" value="-0.0002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="rail"/>
+        <param name="constant" value="2"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.0002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="ferry"/>
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.001"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="subway"/>
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.0002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="tram"/>
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.0004"/>
+      </parameterset>
+ 
+    </parameterset>
+    <parameterset type="scoringParameters">
+      <param name="earlyDeparture" value="-0.0"/>
+      <param name="lateArrival" value="0"/>
+      <param name="marginalUtilityOfMoney" value="0.5"/>
+      <param name="performing" value="10"/>
+      <param name="subpopulation" value="ev_high"/>
+      <param name="utilityOfLineSwitch" value="-0.5"/>
+      <param name="waiting" value="-0.0"/>
+      <param name="waitingPt" value="0"/>
+      <parameterset type="activityParams">
+        <param name="activityType" value="outside"/>
+        <param name="priority" value="1"/>
+        <param name="typicalDuration" value="12:00:00"/>
+        <param name="minimalDuration" value="08:00:00"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="home"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="1:00:00"/>
+        <param name="typicalDuration" value="10:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="work"/>
+        <param name="openingTime" value="7:00:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="6:00:00"/>
+        <param name="typicalDuration" value="9:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="education"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="17:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="6:00:00"/>
+        <param name="typicalDuration" value="6:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="other"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:10:00"/>
+        <param name="typicalDuration" value="0:30:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="shop"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="0:30:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="visit"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="2:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="medical"/>
+        <param name="openingTime" value="09:00:00"/>
+        <param name="closingTime" value="18:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="1:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="business"/>
+        <param name="openingTime" value="07:30:00"/>
+        <param name="closingTime" value="20:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="1:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_home"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_work"/>
+        <param name="openingTime" value="7:00:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_business"/>
+        <param name="openingTime" value="7:00:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_education"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="17:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_other"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+        <parameterset type="activityParams">
+        <param name="activityType" value="escort_shop"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="17:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="outside"/>
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.0004"/>
+      </parameterset>      
+      <parameterset type="modeParams">
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0.0"/>
+        <param name="mode" value="car"/>
+        <param name="monetaryDistanceRate" value="-5e-05"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0.0"/>
+        <param name="mode" value="car_passenger"/>
+        <param name="monetaryDistanceRate" value="-5e-05"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0.0"/>
+        <param name="mode" value="taxi"/>
+        <param name="monetaryDistanceRate" value="-0.002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-1"/>
+        <param name="dailyMonetaryConstant" value="0"/>
+        <param name="dailyUtilityConstant" value="0.0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="-0.0015"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="0"/>
+        <param name="mode" value="bike"/>
+        <param name="monetaryDistanceRate" value="-0.0"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="-0.0005"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="0"/>
+        <param name="mode" value="walk"/>
+        <param name="monetaryDistanceRate" value="0.0"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="pt"/>
+        <param name="constant" value="-10000.0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="0"/>
+        <param name="monetaryDistanceRate" value="-0.000"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="bus"/>
+        <param name="constant" value="-3"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-2"/>
+        <param name="monetaryDistanceRate" value="-0.0002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="rail"/>
+        <param name="constant" value="2"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.0002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="ferry"/>
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.001"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="subway"/>
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.0002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="tram"/>
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.0004"/>
+      </parameterset>
+    </parameterset>
+    <parameterset type="scoringParameters">
+      <param name="earlyDeparture" value="-0.0"/>
+      <param name="lateArrival" value="0"/>
+      <param name="marginalUtilityOfMoney" value="1"/>
+      <param name="performing" value="17.3"/>
+      <param name="subpopulation" value="lgv"/>
+      <param name="utilityOfLineSwitch" value="-0.5"/>
+      <param name="waiting" value="-0.0"/>
+      <param name="waitingPt" value="0"/>
+      <parameterset type="activityParams">
+        <param name="activityType" value="outside"/>
+        <param name="priority" value="1"/>
+        <param name="typicalDuration" value="12:00:00"/>
+        <param name="minimalDuration" value="08:00:00"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="delivery"/>
+        <param name="openingTime" value="06:00:00"/>
+        <param name="closingTime" value="20:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="1:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="depot"/>
+        <param name="openingTime" value="0:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="4:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="outside"/>
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.0004"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0.0"/>
+        <param name="mode" value="car"/>
+        <param name="monetaryDistanceRate" value="-0.0003"/>
+      </parameterset>
+      <!-- <parameterset type="modeParams">
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="-0.0005"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="0"/>
+        <param name="mode" value="walk"/>
+        <param name="monetaryDistanceRate" value="0.0"/>
+      </parameterset> -->
+    </parameterset>
+    <parameterset type="scoringParameters">
+      <param name="earlyDeparture" value="-0.0"/>
+      <param name="lateArrival" value="0"/>
+      <param name="marginalUtilityOfMoney" value="1"/>
+      <param name="performing" value="17.3"/>
+      <param name="subpopulation" value="lgv_ev"/>
+      <param name="utilityOfLineSwitch" value="-0.5"/>
+      <param name="waiting" value="-0.0"/>
+      <param name="waitingPt" value="0"/>
+      <parameterset type="activityParams">
+        <param name="activityType" value="outside"/>
+        <param name="priority" value="1"/>
+        <param name="typicalDuration" value="12:00:00"/>
+        <param name="minimalDuration" value="08:00:00"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="delivery"/>
+        <param name="openingTime" value="06:00:00"/>
+        <param name="closingTime" value="20:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="1:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="depot"/>
+        <param name="openingTime" value="0:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="4:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="outside"/>
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.0004"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0.0"/>
+        <param name="mode" value="car"/>
+        <param name="monetaryDistanceRate" value="-0.0001"/>
+      </parameterset>
+      <!-- <parameterset type="modeParams">
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="-0.0005"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="0"/>
+        <param name="mode" value="walk"/>
+        <param name="monetaryDistanceRate" value="0.0"/>
+      </parameterset> -->
+    </parameterset>
+    <parameterset type="scoringParameters">
+      <param name="earlyDeparture" value="-0.0"/>
+      <param name="lateArrival" value="0"/>
+      <param name="marginalUtilityOfMoney" value="1"/>
+      <param name="performing" value="40"/>
+      <param name="subpopulation" value="hgv"/>
+      <param name="utilityOfLineSwitch" value="-0.5"/>
+      <param name="waiting" value="-0.0"/>
+      <param name="waitingPt" value="0"/>
+      <parameterset type="activityParams">
+        <param name="activityType" value="outside"/>
+        <param name="priority" value="1"/>
+        <param name="typicalDuration" value="12:00:00"/>
+        <param name="minimalDuration" value="08:00:00"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="delivery"/>
+        <param name="openingTime" value="06:00:00"/>
+        <param name="closingTime" value="20:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="1:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="depot"/>
+        <param name="openingTime" value="0:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="4:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="outside"/>
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.0004"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0.0"/>
+        <param name="mode" value="car"/>
+        <param name="monetaryDistanceRate" value="-0.0006"/>
+      </parameterset>
+      <!-- <parameterset type="modeParams">
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="-0.0005"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="0"/>
+        <param name="mode" value="walk"/>
+        <param name="monetaryDistanceRate" value="0.0"/>
+      </parameterset> -->
+    </parameterset>
+    <parameterset type="scoringParameters">
+      <param name="earlyDeparture" value="-0.0"/>
+      <param name="lateArrival" value="0"/>
+      <param name="marginalUtilityOfMoney" value="1"/>
+      <param name="performing" value="10"/>
+      <param name="subpopulation" value="airport"/>
+      <param name="utilityOfLineSwitch" value="-0.5"/>
+      <param name="waiting" value="-0.0"/>
+      <param name="waitingPt" value="0"/>
+      <parameterset type="activityParams">
+        <param name="activityType" value="outside"/>
+        <param name="priority" value="1"/>
+        <param name="typicalDuration" value="12:00:00"/>
+        <param name="minimalDuration" value="08:00:00"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="home"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="1:00:00"/>
+        <param name="typicalDuration" value="10:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="work"/>
+        <param name="openingTime" value="7:00:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="6:00:00"/>
+        <param name="typicalDuration" value="9:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="education"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="17:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="6:00:00"/>
+        <param name="typicalDuration" value="6:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="other"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:10:00"/>
+        <param name="typicalDuration" value="0:30:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="shop"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="0:30:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="visit"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="2:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="medical"/>
+        <param name="openingTime" value="09:00:00"/>
+        <param name="closingTime" value="18:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="1:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="business"/>
+        <param name="openingTime" value="07:30:00"/>
+        <param name="closingTime" value="20:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="1:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_home"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_work"/>
+        <param name="openingTime" value="7:00:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_business"/>
+        <param name="openingTime" value="7:00:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_education"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="17:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_other"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+        <parameterset type="activityParams">
+        <param name="activityType" value="escort_shop"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="17:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="outside"/>
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.0004"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0.0"/>
+        <param name="mode" value="car"/>
+        <param name="monetaryDistanceRate" value="-0.0002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0.0"/>
+        <param name="mode" value="car_passenger"/>
+        <param name="monetaryDistanceRate" value="-0.0002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0.0"/>
+        <param name="mode" value="taxi"/>
+        <param name="monetaryDistanceRate" value="-0.002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-1"/>
+        <param name="dailyMonetaryConstant" value="0"/>
+        <param name="dailyUtilityConstant" value="0.0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="-0.0015"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="0"/>
+        <param name="mode" value="bike"/>
+        <param name="monetaryDistanceRate" value="-0.0"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="-0.0005"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="0"/>
+        <param name="mode" value="walk"/>
+        <param name="monetaryDistanceRate" value="0.0"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="pt"/>
+        <param name="constant" value="-10000.0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="0"/>
+        <param name="monetaryDistanceRate" value="-0.000"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="bus"/>
+        <param name="constant" value="-3"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-2"/>
+        <param name="monetaryDistanceRate" value="-0.0002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="rail"/>
+        <param name="constant" value="2"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.0002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="ferry"/>
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.001"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="subway"/>
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.0002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="tram"/>
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.0004"/>
+      </parameterset>
+    </parameterset>
+    <parameterset type="scoringParameters">
+      <param name="earlyDeparture" value="-0.0"/>
+      <param name="lateArrival" value="0"/>
+      <param name="marginalUtilityOfMoney" value="1"/>
+      <param name="performing" value="10"/>
+      <param name="subpopulation" value="ev_airport"/>
+      <param name="utilityOfLineSwitch" value="-0.5"/>
+      <param name="waiting" value="-0.0"/>
+      <param name="waitingPt" value="0"/>
+      <parameterset type="activityParams">
+        <param name="activityType" value="outside"/>
+        <param name="priority" value="1"/>
+        <param name="typicalDuration" value="12:00:00"/>
+        <param name="minimalDuration" value="08:00:00"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="home"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="1:00:00"/>
+        <param name="typicalDuration" value="10:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="work"/>
+        <param name="openingTime" value="7:00:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="6:00:00"/>
+        <param name="typicalDuration" value="9:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="education"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="17:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="6:00:00"/>
+        <param name="typicalDuration" value="6:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="other"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:10:00"/>
+        <param name="typicalDuration" value="0:30:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="shop"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="0:30:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="visit"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="2:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="medical"/>
+        <param name="openingTime" value="09:00:00"/>
+        <param name="closingTime" value="18:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="1:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="business"/>
+        <param name="openingTime" value="07:30:00"/>
+        <param name="closingTime" value="20:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="1:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_home"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_work"/>
+        <param name="openingTime" value="7:00:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_business"/>
+        <param name="openingTime" value="7:00:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_education"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="17:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_other"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+        <parameterset type="activityParams">
+        <param name="activityType" value="escort_shop"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="17:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="outside"/>
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.0004"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0.0"/>
+        <param name="mode" value="car"/>
+        <param name="monetaryDistanceRate" value="-5e-05"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0.0"/>
+        <param name="mode" value="car_passenger"/>
+        <param name="monetaryDistanceRate" value="-5e-05"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0.0"/>
+        <param name="mode" value="taxi"/>
+        <param name="monetaryDistanceRate" value="-0.002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-1"/>
+        <param name="dailyMonetaryConstant" value="0"/>
+        <param name="dailyUtilityConstant" value="0.0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="-0.0015"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="0"/>
+        <param name="mode" value="bike"/>
+        <param name="monetaryDistanceRate" value="-0.0"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="-0.0005"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="0"/>
+        <param name="mode" value="walk"/>
+        <param name="monetaryDistanceRate" value="0.0"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="pt"/>
+        <param name="constant" value="-10000.0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="0"/>
+        <param name="monetaryDistanceRate" value="-0.000"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="bus"/>
+        <param name="constant" value="-3"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-2"/>
+        <param name="monetaryDistanceRate" value="-0.0002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="rail"/>
+        <param name="constant" value="2"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.0002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="ferry"/>
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.001"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="subway"/>
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.0002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="tram"/>
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.0004"/>
+      </parameterset>
+ 
+    </parameterset>
+
+  </module>
+  <module name="strategy">
+    <param name="fractionOfIterationsToDisableInnovation" value="0.8"/>
+    <param name="maxAgentPlanMemorySize" value="5"/>
+    <param name="planSelectorForRemoval" value="WorstPlanSelector"/>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="ReRoute"/>
+      <param name="subpopulation" value="default"/>
+      <param name="weight" value="0.1"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="SubtourModeChoice"/>
+      <param name="subpopulation" value="default"/>
+      <param name="weight" value="0.1"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="TimeAllocationMutator_ReRoute"/>
+      <param name="subpopulation" value="default"/>
+      <param name="weight" value="0.1"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="ChangeExpBeta"/>
+      <param name="subpopulation" value="default"/>
+      <param name="weight" value="0.7"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="ReRoute"/>
+      <param name="subpopulation" value="low"/>
+      <param name="weight" value="0.1"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="SubtourModeChoice"/>
+      <param name="subpopulation" value="low"/>
+      <param name="weight" value="0.1"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="TimeAllocationMutator_ReRoute"/>
+      <param name="subpopulation" value="low"/>
+      <param name="weight" value="0.1"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="ChangeExpBeta"/>
+      <param name="subpopulation" value="low"/>
+      <param name="weight" value="0.7"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="ReRoute"/>
+      <param name="subpopulation" value="medium"/>
+      <param name="weight" value="0.1"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="SubtourModeChoice"/>
+      <param name="subpopulation" value="medium"/>
+      <param name="weight" value="0.1"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="TimeAllocationMutator_ReRoute"/>
+      <param name="subpopulation" value="medium"/>
+      <param name="weight" value="0.1"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="ChangeExpBeta"/>
+      <param name="subpopulation" value="medium"/>
+      <param name="weight" value="0.7"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="ReRoute"/>
+      <param name="subpopulation" value="high"/>
+      <param name="weight" value="0.1"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="SubtourModeChoice"/>
+      <param name="subpopulation" value="high"/>
+      <param name="weight" value="0.1"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="TimeAllocationMutator_ReRoute"/>
+      <param name="subpopulation" value="high"/>
+      <param name="weight" value="0.1"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="ChangeExpBeta"/>
+      <param name="subpopulation" value="high"/>
+      <param name="weight" value="0.7"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="ReRoute"/>
+      <param name="subpopulation" value="ev_low"/>
+      <param name="weight" value="0.1"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="SubtourModeChoice"/>
+      <param name="subpopulation" value="ev_low"/>
+      <param name="weight" value="0.1"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="TimeAllocationMutator_ReRoute"/>
+      <param name="subpopulation" value="ev_low"/>
+      <param name="weight" value="0.1"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="ChangeExpBeta"/>
+      <param name="subpopulation" value="ev_low"/>
+      <param name="weight" value="0.7"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="ReRoute"/>
+      <param name="subpopulation" value="ev_medium"/>
+      <param name="weight" value="0.1"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="SubtourModeChoice"/>
+      <param name="subpopulation" value="ev_medium"/>
+      <param name="weight" value="0.1"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="TimeAllocationMutator_ReRoute"/>
+      <param name="subpopulation" value="ev_medium"/>
+      <param name="weight" value="0.1"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="ChangeExpBeta"/>
+      <param name="subpopulation" value="ev_medium"/>
+      <param name="weight" value="0.7"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="ReRoute"/>
+      <param name="subpopulation" value="ev_high"/>
+      <param name="weight" value="0.1"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="SubtourModeChoice"/>
+      <param name="subpopulation" value="ev_high"/>
+      <param name="weight" value="0.1"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="TimeAllocationMutator_ReRoute"/>
+      <param name="subpopulation" value="ev_high"/>
+      <param name="weight" value="0.1"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="ChangeExpBeta"/>
+      <param name="subpopulation" value="ev_high"/>
+      <param name="weight" value="0.7"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="ReRoute"/>
+      <param name="subpopulation" value="lgv"/>
+      <param name="weight" value="0.1"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="TimeAllocationMutator_ReRoute"/>
+      <param name="subpopulation" value="lgv"/>
+      <param name="weight" value="0.2"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="ChangeExpBeta"/>
+      <param name="subpopulation" value="lgv"/>
+      <param name="weight" value="0.7"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="ReRoute"/>
+      <param name="subpopulation" value="lgv_ev"/>
+      <param name="weight" value="0.1"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="TimeAllocationMutator_ReRoute"/>
+      <param name="subpopulation" value="lgv_ev"/>
+      <param name="weight" value="0.2"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="ChangeExpBeta"/>
+      <param name="subpopulation" value="lgv_ev"/>
+      <param name="weight" value="0.7"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="ReRoute"/>
+      <param name="subpopulation" value="hgv"/>
+      <param name="weight" value="0.1"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="TimeAllocationMutator_ReRoute"/>
+      <param name="subpopulation" value="hgv"/>
+      <param name="weight" value="0.2"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="ChangeExpBeta"/>
+      <param name="subpopulation" value="hgv"/>
+      <param name="weight" value="0.7"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="ReRoute"/>
+      <param name="subpopulation" value="airport"/>
+      <param name="weight" value="0.1"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="SubtourModeChoice"/>
+      <param name="subpopulation" value="airport"/>
+      <param name="weight" value="0.1"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="TimeAllocationMutator_ReRoute"/>
+      <param name="subpopulation" value="airport"/>
+      <param name="weight" value="0.1"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="ChangeExpBeta"/>
+      <param name="subpopulation" value="airport"/>
+      <param name="weight" value="0.7"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="ReRoute"/>
+      <param name="subpopulation" value="ev_airport"/>
+      <param name="weight" value="0.1"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="SubtourModeChoice"/>
+      <param name="subpopulation" value="ev_airport"/>
+      <param name="weight" value="0.1"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="TimeAllocationMutator_ReRoute"/>
+      <param name="subpopulation" value="ev_airport"/>
+      <param name="weight" value="0.1"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="ChangeExpBeta"/>
+      <param name="subpopulation" value="ev_airport"/>
+      <param name="weight" value="0.7"/>
+    </parameterset>
+  </module>
+</config>

--- a/docs/cutting-scenarios-CML/matsim_configs_example/matsim_config_cutter_no_intermodal_bike.xml
+++ b/docs/cutting-scenarios-CML/matsim_configs_example/matsim_config_cutter_no_intermodal_bike.xml
@@ -1,0 +1,2962 @@
+<?xml version="1.0" ?>
+<!DOCTYPE config SYSTEM "http://www.matsim.org/files/dtd/config_v2.dtd">
+<config>
+  <module name="global">
+    <param name="randomSeed" value="4711"/>
+    <param name="coordinateSystem" value="EPSG:27700"/>
+    <param name="numberOfThreads" value="4"/>
+  </module>
+  <module name="network">
+    <param name="inputNetworkFile" value="output_network.xml.gz"/>
+  </module>
+  <module name="plans">
+    <param name="inputPlansFile" value="output_plans.xml.gz"/>
+  </module>
+  <module name="vehicles">
+    <param name="vehiclesFile" value="output_vehicles.xml.gz"/>
+  </module>
+  <module name="planscalcroute">
+    <param name="networkModes" value="car,car_passenger,taxi"/>
+    <parameterset type="teleportedModeParameters">
+		<param name="beelineDistanceFactor" value="1.3"/>
+		<param name="mode" value="outside"/>
+		<param name="teleportedModeFreespeedFactor" value="null"/>
+		<param name="teleportedModeSpeed" value="4.166666666666667"/>
+		</parameterset>
+    <parameterset type="teleportedModeParameters">
+      <param name="beelineDistanceFactor" value="1.3"/>
+      <param name="mode" value="bike"/>
+      <param name="teleportedModeFreespeedFactor" value="null"/>
+      <param name="teleportedModeSpeed" value="4.166666666666667"/>
+    </parameterset>
+    <parameterset type="teleportedModeParameters">
+      <param name="beelineDistanceFactor" value="1.3"/>
+      <param name="mode" value="walk"/>
+      <param name="teleportedModeFreespeedFactor" value="null"/>
+      <param name="teleportedModeSpeed" value="0.8333333333333333"/>
+    </parameterset>
+    <parameterset type="teleportedModeParameters">
+      <param name="beelineDistanceFactor" value="1.3"/>
+      <param name="mode" value="non_network_walk"/>
+      <param name="teleportedModeFreespeedFactor" value="null"/>
+      <param name="teleportedModeSpeed" value="0.8333333333333333"/>
+    </parameterset>
+  </module>
+  <module name="transit">
+    <param name="useTransit" value="true"/>
+    <param name="transitScheduleFile" value="output_transitSchedule.xml.gz"/>
+    <param name="vehiclesFile" value="output_transitVehicles.xml.gz"/>
+    <param name="transitModes" value="bus,rail,ferry,subway,tram"/>
+  </module>
+  <module name="swissRailRaptor">
+    <param name="useModeMappingForPassengers" value="true"/>
+    <!-- <param name="useIntermodalAccessEgress" value="true"/>
+    <param name="intermodalAccessEgressModeSelection" value="RandomSelectOneModePerRoutingRequestAndDirection"/>
+    <parameterset type="intermodalAccessEgress">
+      <param name="mode" value="walk"/>
+      <param name="initialSearchRadius" value="5000"/>
+      <param name="maxRadius" value="2000"/>
+    </parameterset>
+    <parameterset type="intermodalAccessEgress">
+      <param name="mode" value="bike"/>
+      <param name="initialSearchRadius" value="5000"/>
+      <param name="maxRadius" value="10000"/>
+      <param name="personFilterAttribute" value="intermodalBike"/>
+      <param name="personFilterValue" value="yes"/>
+      <param name="stopFilterAttribute" value="bikeAccessible"/>
+      <param name="stopFilterValue" value="true"/>
+    </parameterset>
+    <parameterset type="intermodalAccessEgress">
+      <param name="mode" value="car"/>
+      <param name="initialSearchRadius" value="5000"/>
+      <param name="searchExtensionRadius" value="1000.0"/>
+      <param name="maxRadius" value="10000"/>
+      <param name="linkIdAttribute" value="accessLinkId_car"/>
+      <param name="personFilterAttribute" value="intermodalCar"/>
+      <param name="personFilterValue" value="yes"/>
+      <param name="stopFilterAttribute" value="carAccessible"/>
+      <param name="stopFilterValue" value="true"/>
+    </parameterset>
+    <parameterset type="intermodalAccessEgress">
+      <param name="mode" value="taxi"/>
+      <param name="initialSearchRadius" value="5000"/>
+      <param name="searchExtensionRadius" value="1000.0"/>
+      <param name="maxRadius" value="10000"/>
+      <param name="linkIdAttribute" value="accessLinkId_car"/>
+      <param name="personFilterAttribute" value="intermodalTaxi"/>
+      <param name="personFilterValue" value="yes"/>
+      <param name="stopFilterAttribute" value="carAccessible"/>
+      <param name="stopFilterValue" value="true"/>
+    </parameterset>
+    <parameterset type="intermodalAccessEgress">
+      <param name="mode" value="car_passenger"/>
+      <param name="initialSearchRadius" value="5000"/>
+      <param name="searchExtensionRadius" value="1000.0"/>
+      <param name="maxRadius" value="10000"/>
+      <param name="linkIdAttribute" value="accessLinkId_car"/>
+      <param name="personFilterAttribute" value="intermodalPassenger"/>
+      <param name="personFilterValue" value="yes"/>
+      <param name="stopFilterAttribute" value="carAccessible"/>
+      <param name="stopFilterValue" value="true"/>
+    </parameterset> -->
+    <parameterset type="modeMapping">
+      <param name="routeMode" value="bus"/>
+      <param name="passengerMode" value="bus"/>
+    </parameterset>
+    <parameterset type="modeMapping">
+      <param name="routeMode" value="rail"/>
+      <param name="passengerMode" value="rail"/>
+    </parameterset>
+    <parameterset type="modeMapping">
+      <param name="routeMode" value="ferry"/>
+      <param name="passengerMode" value="ferry"/>
+    </parameterset>
+    <parameterset type="modeMapping">
+      <param name="routeMode" value="subway"/>
+      <param name="passengerMode" value="subway"/>
+    </parameterset>
+    <parameterset type="modeMapping">
+      <param name="routeMode" value="tram"/>
+      <param name="passengerMode" value="tram"/>
+    </parameterset>
+  </module>
+  <module name="transitRouter">
+    <param name="additionalTransferTime" value="1.0"/>
+    <param name="extensionRadius" value="2000.0"/>
+    <param name="maxBeelineWalkConnectionDistance" value="500.0"/>
+    <param name="searchRadius" value="2000.0"/>
+  </module>
+  <module name="TimeAllocationMutator">
+    <param name="mutationRange" value="1000.0"/>
+  </module>
+  <module name="ArupReplanning">
+    <param name="maximumBikeTourDistance_m" value="45000"/>
+    <param name="maximumWalkTourDistance_m" value="12500"/>
+    <param name="minimumTimeMutationStep_s" value="300"/>
+  </module>
+  	<module name="facilities" >
+      <!-- This defines how facilities should be created. Possible values: none fromFile setInScenario onePerActivityLinkInPlansFile onePerActivityLinkInPlansFileExceptWhenCoordinatesAreGiven onePerActivityLocationInPlansFile  -->
+      <!-- <param name="facilitiesSource" value="onePerActivityLocationInPlansFile" /> -->
+	<!-- <param name="facilitiesSource" value="onePerActivityLinkInPlansFile" /> -->
+	<param name="facilitiesSource" value="fromFile" />
+	  <param name="inputFacilitiesFile" value="output_facilities.xml.gz" />
+    </module>
+  <module name="controler">
+    <param name="createGraphs" value="true"/>
+    <param name="outputDirectory" value="/mnt/efs/analysis/ys/matsim_cutter/input_files_locations_facilities_10pc_20240807/output_no_intermodal_bike_20240830_10pct"/>
+    <param name="firstIteration" value="0"/>
+    <param name="lastIteration" value="2"/>
+    <!-- <param name="routingAlgorithmType" value="FastAStarLandmarks"/> -->
+    <param name="eventsFileFormat" value="xml"/>
+    <param name="writeEventsInterval" value="2"/>
+    <param name="writePlansInterval" value="2"/>
+    <param name="mobsim" value="hermes"/>
+    <param name="snapshotFormat" value=""/>
+    <param name="overwriteFiles" value="deleteDirectoryIfExists"/>
+  </module>
+  <module name="subtourModeChoice">
+    <param name="considerCarAvailability" value="true"/>
+    <param name="chainBasedModes" value="car,bike"/>
+    <param name="modes" value="bus,bike,walk,rail,car,ferry,subway,tram,car_passenger,taxi"/>
+  </module>
+  <module name="parallelEventHandling">
+    <param name="estimatedNumberOfEvents" value="null"/>
+    <param name="eventsQueueSize" value="270000000"/>
+    <param name="numberOfThreads" value="4"/>
+    <param name="oneThreadPerHandler" value="true"/>
+    <param name="synchronizeOnSimSteps" value="true"/>
+  </module>
+  <module name="hermes">
+    <param name="endTime" value="32:00:00"/>
+    <param name="flowCapacityFactor" value="0.1"/>
+    <param name="mainMode" value="car,taxi"/>
+    <param name="storageCapacityFactor" value="0.1"/>
+    <param name="stuckTime" value="30"/>
+    <param name="useDeterministicPt" value="true"/>
+  </module>
+  <module name="SBBPt">
+    <param name="deterministicServiceModes" value="rail,ferry,subway,tram"/>
+    <param name="createLinkEventsInterval" value="50"/>
+  </module>
+  <module name="planCalcScore">
+    <param name="BrainExpBeta" value="1.0"/>
+    <param name="writeExperiencedPlans" value="true"/>
+    <parameterset type="scoringParameters">
+      <param name="earlyDeparture" value="-0.0"/>
+      <param name="lateArrival" value="0"/>
+      <param name="marginalUtilityOfMoney" value="1"/>
+      <param name="performing" value="10"/>
+      <param name="subpopulation" value="default"/>
+      <param name="utilityOfLineSwitch" value="-0.5"/>
+      <param name="waiting" value="-0.0"/>
+      <param name="waitingPt" value="0"/>
+      <parameterset type="activityParams">
+        <param name="activityType" value="home"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="1:00:00"/>
+        <param name="typicalDuration" value="10:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="work"/>
+        <param name="openingTime" value="7:00:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="6:00:00"/>
+        <param name="typicalDuration" value="9:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="delivery"/>
+        <param name="openingTime" value="06:00:00"/>
+        <param name="closingTime" value="20:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="1:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="depot"/>
+        <param name="openingTime" value="0:00:00"/>
+        <param name="closingTime" value="23:59:59"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="4:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="education"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="17:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="6:00:00"/>
+        <param name="typicalDuration" value="6:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="other"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:10:00"/>
+        <param name="typicalDuration" value="0:30:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="shop"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="0:30:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="visit"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="2:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="medical"/>
+        <param name="openingTime" value="09:00:00"/>
+        <param name="closingTime" value="18:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="1:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="business"/>
+        <param name="openingTime" value="07:30:00"/>
+        <param name="closingTime" value="20:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="1:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_home"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_work"/>
+        <param name="openingTime" value="7:00:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_business"/>
+        <param name="openingTime" value="7:00:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_education"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="17:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_other"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_shop"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="17:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0.0"/>
+        <param name="mode" value="car"/>
+        <param name="monetaryDistanceRate" value="-0.00009"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0.0"/>
+        <param name="mode" value="car_passenger"/>
+        <param name="monetaryDistanceRate" value="-0.00009"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0.0"/>
+        <param name="mode" value="taxi"/>
+        <param name="monetaryDistanceRate" value="-0.001"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-1"/>
+        <param name="dailyMonetaryConstant" value="0"/>
+        <param name="dailyUtilityConstant" value="0.0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="-0.0015"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="0"/>
+        <param name="mode" value="bike"/>
+        <param name="monetaryDistanceRate" value="-0.0"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="-0.0005"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="0"/>
+        <param name="mode" value="walk"/>
+        <param name="monetaryDistanceRate" value="0.0"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="pt"/>
+        <param name="constant" value="-10000.0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="0"/>
+        <param name="monetaryDistanceRate" value="-0.000"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="bus"/>
+        <param name="constant" value="-3"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-2"/>
+        <param name="monetaryDistanceRate" value="-0.0002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="rail"/>
+        <param name="constant" value="2"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.0002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="ferry"/>
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.001"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="subway"/>
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.0002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="tram"/>
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.0004"/>
+      </parameterset>
+    </parameterset>
+    <parameterset type="scoringParameters">
+      <param name="earlyDeparture" value="-0.0"/>
+      <param name="lateArrival" value="0"/>
+      <param name="marginalUtilityOfMoney" value="2"/>
+      <param name="performing" value="10"/>
+      <param name="subpopulation" value="low"/>
+      <param name="utilityOfLineSwitch" value="-0.5"/>
+      <param name="waiting" value="-0.0"/>
+      <param name="waitingPt" value="0"/>
+      <parameterset type="activityParams">
+        <param name="activityType" value="home"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="1:00:00"/>
+        <param name="typicalDuration" value="10:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="work"/>
+        <param name="openingTime" value="7:00:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="6:00:00"/>
+        <param name="typicalDuration" value="9:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="education"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="17:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="6:00:00"/>
+        <param name="typicalDuration" value="6:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="other"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:10:00"/>
+        <param name="typicalDuration" value="0:30:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="shop"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="0:30:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="visit"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="2:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="medical"/>
+        <param name="openingTime" value="09:00:00"/>
+        <param name="closingTime" value="18:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="1:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="business"/>
+        <param name="openingTime" value="07:30:00"/>
+        <param name="closingTime" value="20:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="1:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_home"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_work"/>
+        <param name="openingTime" value="7:00:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_business"/>
+        <param name="openingTime" value="7:00:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_education"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="17:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_other"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_shop"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="17:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0.0"/>
+        <param name="mode" value="car"/>
+        <param name="monetaryDistanceRate" value="-0.0002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0.0"/>
+        <param name="mode" value="car_passenger"/>
+        <param name="monetaryDistanceRate" value="-0.0002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0.0"/>
+        <param name="mode" value="taxi"/>
+        <param name="monetaryDistanceRate" value="-0.002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-1"/>
+        <param name="dailyMonetaryConstant" value="0"/>
+        <param name="dailyUtilityConstant" value="0.0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="-0.0015"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="0"/>
+        <param name="mode" value="bike"/>
+        <param name="monetaryDistanceRate" value="-0.0"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="-0.0005"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="0"/>
+        <param name="mode" value="walk"/>
+        <param name="monetaryDistanceRate" value="0.0"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="pt"/>
+        <param name="constant" value="-10000.0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="0"/>
+        <param name="monetaryDistanceRate" value="-0.000"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="bus"/>
+        <param name="constant" value="-3"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-2"/>
+        <param name="monetaryDistanceRate" value="-0.0002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="rail"/>
+        <param name="constant" value="2"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.0002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="ferry"/>
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.001"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="subway"/>
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.0002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="tram"/>
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.0004"/>
+      </parameterset>
+    </parameterset>
+    <parameterset type="scoringParameters">
+      <param name="earlyDeparture" value="-0.0"/>
+      <param name="lateArrival" value="0"/>
+      <param name="marginalUtilityOfMoney" value="1"/>
+      <param name="performing" value="10"/>
+      <param name="subpopulation" value="medium"/>
+      <param name="utilityOfLineSwitch" value="-0.5"/>
+      <param name="waiting" value="-0.0"/>
+      <param name="waitingPt" value="0"/>
+      <parameterset type="activityParams">
+        <param name="activityType" value="home"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="1:00:00"/>
+        <param name="typicalDuration" value="10:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="work"/>
+        <param name="openingTime" value="7:00:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="6:00:00"/>
+        <param name="typicalDuration" value="9:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="education"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="17:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="6:00:00"/>
+        <param name="typicalDuration" value="6:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="other"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:10:00"/>
+        <param name="typicalDuration" value="0:30:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="shop"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="0:30:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="visit"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="2:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="medical"/>
+        <param name="openingTime" value="09:00:00"/>
+        <param name="closingTime" value="18:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="1:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="business"/>
+        <param name="openingTime" value="07:30:00"/>
+        <param name="closingTime" value="20:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="1:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_home"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_work"/>
+        <param name="openingTime" value="7:00:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_business"/>
+        <param name="openingTime" value="7:00:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_education"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="17:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_other"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_shop"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="17:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0.0"/>
+        <param name="mode" value="car"/>
+        <param name="monetaryDistanceRate" value="-0.0002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0.0"/>
+        <param name="mode" value="car_passenger"/>
+        <param name="monetaryDistanceRate" value="-0.0002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0.0"/>
+        <param name="mode" value="taxi"/>
+        <param name="monetaryDistanceRate" value="-0.002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-1"/>
+        <param name="dailyMonetaryConstant" value="0"/>
+        <param name="dailyUtilityConstant" value="0.0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="-0.0015"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="0"/>
+        <param name="mode" value="bike"/>
+        <param name="monetaryDistanceRate" value="-0.0"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="-0.0005"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="0"/>
+        <param name="mode" value="walk"/>
+        <param name="monetaryDistanceRate" value="0.0"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="pt"/>
+        <param name="constant" value="-10000.0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="0"/>
+        <param name="monetaryDistanceRate" value="-0.000"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="bus"/>
+        <param name="constant" value="-3"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-2"/>
+        <param name="monetaryDistanceRate" value="-0.0002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="rail"/>
+        <param name="constant" value="2"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.0002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="ferry"/>
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.001"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="subway"/>
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.0002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="tram"/>
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.0004"/>
+      </parameterset>
+    </parameterset>
+    <parameterset type="scoringParameters">
+      <param name="earlyDeparture" value="-0.0"/>
+      <param name="lateArrival" value="0"/>
+      <param name="marginalUtilityOfMoney" value="0.5"/>
+      <param name="performing" value="10"/>
+      <param name="subpopulation" value="high"/>
+      <param name="utilityOfLineSwitch" value="-0.5"/>
+      <param name="waiting" value="-0.0"/>
+      <param name="waitingPt" value="0"/>
+      <parameterset type="activityParams">
+        <param name="activityType" value="home"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="1:00:00"/>
+        <param name="typicalDuration" value="10:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="work"/>
+        <param name="openingTime" value="7:00:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="6:00:00"/>
+        <param name="typicalDuration" value="9:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="education"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="17:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="6:00:00"/>
+        <param name="typicalDuration" value="6:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="other"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:10:00"/>
+        <param name="typicalDuration" value="0:30:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="shop"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="0:30:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="visit"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="2:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="medical"/>
+        <param name="openingTime" value="09:00:00"/>
+        <param name="closingTime" value="18:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="1:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="business"/>
+        <param name="openingTime" value="07:30:00"/>
+        <param name="closingTime" value="20:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="1:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_home"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_work"/>
+        <param name="openingTime" value="7:00:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_business"/>
+        <param name="openingTime" value="7:00:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_education"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="17:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_other"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_shop"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="17:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0.0"/>
+        <param name="mode" value="car"/>
+        <param name="monetaryDistanceRate" value="-0.0002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0.0"/>
+        <param name="mode" value="car_passenger"/>
+        <param name="monetaryDistanceRate" value="-0.0002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0.0"/>
+        <param name="mode" value="taxi"/>
+        <param name="monetaryDistanceRate" value="-0.002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-1"/>
+        <param name="dailyMonetaryConstant" value="0"/>
+        <param name="dailyUtilityConstant" value="0.0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="-0.0015"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="0"/>
+        <param name="mode" value="bike"/>
+        <param name="monetaryDistanceRate" value="-0.0"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="-0.0005"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="0"/>
+        <param name="mode" value="walk"/>
+        <param name="monetaryDistanceRate" value="0.0"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="pt"/>
+        <param name="constant" value="-10000.0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="0"/>
+        <param name="monetaryDistanceRate" value="-0.000"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="bus"/>
+        <param name="constant" value="-3"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-2"/>
+        <param name="monetaryDistanceRate" value="-0.0002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="rail"/>
+        <param name="constant" value="2"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.0002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="ferry"/>
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.001"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="subway"/>
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.0002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="tram"/>
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.0004"/>
+      </parameterset>
+    </parameterset>
+    <parameterset type="scoringParameters">
+      <param name="earlyDeparture" value="-0.0"/>
+      <param name="lateArrival" value="0"/>
+      <param name="marginalUtilityOfMoney" value="2"/>
+      <param name="performing" value="10"/>
+      <param name="subpopulation" value="ev_low"/>
+      <param name="utilityOfLineSwitch" value="-0.5"/>
+      <param name="waiting" value="-0.0"/>
+      <param name="waitingPt" value="0"/>
+      <parameterset type="activityParams">
+        <param name="activityType" value="home"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="1:00:00"/>
+        <param name="typicalDuration" value="10:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="work"/>
+        <param name="openingTime" value="7:00:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="6:00:00"/>
+        <param name="typicalDuration" value="9:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="education"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="17:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="6:00:00"/>
+        <param name="typicalDuration" value="6:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="other"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:10:00"/>
+        <param name="typicalDuration" value="0:30:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="shop"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="0:30:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="visit"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="2:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="medical"/>
+        <param name="openingTime" value="09:00:00"/>
+        <param name="closingTime" value="18:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="1:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="business"/>
+        <param name="openingTime" value="07:30:00"/>
+        <param name="closingTime" value="20:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="1:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_home"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_work"/>
+        <param name="openingTime" value="7:00:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_business"/>
+        <param name="openingTime" value="7:00:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_education"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="17:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_other"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_shop"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="17:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0.0"/>
+        <param name="mode" value="car"/>
+        <param name="monetaryDistanceRate" value="-5e-05"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0.0"/>
+        <param name="mode" value="car_passenger"/>
+        <param name="monetaryDistanceRate" value="-5e-05"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0.0"/>
+        <param name="mode" value="taxi"/>
+        <param name="monetaryDistanceRate" value="-0.002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-1"/>
+        <param name="dailyMonetaryConstant" value="0"/>
+        <param name="dailyUtilityConstant" value="0.0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="-0.0015"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="0"/>
+        <param name="mode" value="bike"/>
+        <param name="monetaryDistanceRate" value="-0.0"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="-0.0005"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="0"/>
+        <param name="mode" value="walk"/>
+        <param name="monetaryDistanceRate" value="0.0"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="pt"/>
+        <param name="constant" value="-10000.0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="0"/>
+        <param name="monetaryDistanceRate" value="-0.000"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="bus"/>
+        <param name="constant" value="-3"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-2"/>
+        <param name="monetaryDistanceRate" value="-0.0002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="rail"/>
+        <param name="constant" value="2"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.0002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="ferry"/>
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.001"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="subway"/>
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.0002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="tram"/>
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.0004"/>
+      </parameterset>
+    </parameterset>
+    <parameterset type="scoringParameters">
+      <param name="earlyDeparture" value="-0.0"/>
+      <param name="lateArrival" value="0"/>
+      <param name="marginalUtilityOfMoney" value="1"/>
+      <param name="performing" value="10"/>
+      <param name="subpopulation" value="ev_medium"/>
+      <param name="utilityOfLineSwitch" value="-0.5"/>
+      <param name="waiting" value="-0.0"/>
+      <param name="waitingPt" value="0"/>
+      <parameterset type="activityParams">
+        <param name="activityType" value="home"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="1:00:00"/>
+        <param name="typicalDuration" value="10:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="work"/>
+        <param name="openingTime" value="7:00:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="6:00:00"/>
+        <param name="typicalDuration" value="9:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="education"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="17:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="6:00:00"/>
+        <param name="typicalDuration" value="6:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="other"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:10:00"/>
+        <param name="typicalDuration" value="0:30:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="shop"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="0:30:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="visit"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="2:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="medical"/>
+        <param name="openingTime" value="09:00:00"/>
+        <param name="closingTime" value="18:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="1:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="business"/>
+        <param name="openingTime" value="07:30:00"/>
+        <param name="closingTime" value="20:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="1:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_home"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_work"/>
+        <param name="openingTime" value="7:00:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_business"/>
+        <param name="openingTime" value="7:00:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_education"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="17:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_other"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_shop"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="17:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0.0"/>
+        <param name="mode" value="car"/>
+        <param name="monetaryDistanceRate" value="-5e-05"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0.0"/>
+        <param name="mode" value="car_passenger"/>
+        <param name="monetaryDistanceRate" value="-5e-05"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0.0"/>
+        <param name="mode" value="taxi"/>
+        <param name="monetaryDistanceRate" value="-0.002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-1"/>
+        <param name="dailyMonetaryConstant" value="0"/>
+        <param name="dailyUtilityConstant" value="0.0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="-0.0015"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="0"/>
+        <param name="mode" value="bike"/>
+        <param name="monetaryDistanceRate" value="-0.0"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="-0.0005"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="0"/>
+        <param name="mode" value="walk"/>
+        <param name="monetaryDistanceRate" value="0.0"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="pt"/>
+        <param name="constant" value="-10000.0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="0"/>
+        <param name="monetaryDistanceRate" value="-0.000"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="bus"/>
+        <param name="constant" value="-3"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-2"/>
+        <param name="monetaryDistanceRate" value="-0.0002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="rail"/>
+        <param name="constant" value="2"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.0002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="ferry"/>
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.001"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="subway"/>
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.0002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="tram"/>
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.0004"/>
+      </parameterset>
+    </parameterset>
+    <parameterset type="scoringParameters">
+      <param name="earlyDeparture" value="-0.0"/>
+      <param name="lateArrival" value="0"/>
+      <param name="marginalUtilityOfMoney" value="0.5"/>
+      <param name="performing" value="10"/>
+      <param name="subpopulation" value="ev_high"/>
+      <param name="utilityOfLineSwitch" value="-0.5"/>
+      <param name="waiting" value="-0.0"/>
+      <param name="waitingPt" value="0"/>
+      <parameterset type="activityParams">
+        <param name="activityType" value="home"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="1:00:00"/>
+        <param name="typicalDuration" value="10:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="work"/>
+        <param name="openingTime" value="7:00:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="6:00:00"/>
+        <param name="typicalDuration" value="9:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="education"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="17:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="6:00:00"/>
+        <param name="typicalDuration" value="6:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="other"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:10:00"/>
+        <param name="typicalDuration" value="0:30:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="shop"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="0:30:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="visit"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="2:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="medical"/>
+        <param name="openingTime" value="09:00:00"/>
+        <param name="closingTime" value="18:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="1:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="business"/>
+        <param name="openingTime" value="07:30:00"/>
+        <param name="closingTime" value="20:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="1:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_home"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_work"/>
+        <param name="openingTime" value="7:00:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_business"/>
+        <param name="openingTime" value="7:00:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_education"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="17:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_other"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_shop"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="17:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0.0"/>
+        <param name="mode" value="car"/>
+        <param name="monetaryDistanceRate" value="-5e-05"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0.0"/>
+        <param name="mode" value="car_passenger"/>
+        <param name="monetaryDistanceRate" value="-5e-05"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0.0"/>
+        <param name="mode" value="taxi"/>
+        <param name="monetaryDistanceRate" value="-0.002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-1"/>
+        <param name="dailyMonetaryConstant" value="0"/>
+        <param name="dailyUtilityConstant" value="0.0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="-0.0015"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="0"/>
+        <param name="mode" value="bike"/>
+        <param name="monetaryDistanceRate" value="-0.0"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="-0.0005"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="0"/>
+        <param name="mode" value="walk"/>
+        <param name="monetaryDistanceRate" value="0.0"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="pt"/>
+        <param name="constant" value="-10000.0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="0"/>
+        <param name="monetaryDistanceRate" value="-0.000"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="bus"/>
+        <param name="constant" value="-3"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-2"/>
+        <param name="monetaryDistanceRate" value="-0.0002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="rail"/>
+        <param name="constant" value="2"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.0002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="ferry"/>
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.001"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="subway"/>
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.0002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="tram"/>
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.0004"/>
+      </parameterset>
+    </parameterset>
+    <parameterset type="scoringParameters">
+      <param name="earlyDeparture" value="-0.0"/>
+      <param name="lateArrival" value="0"/>
+      <param name="marginalUtilityOfMoney" value="1"/>
+      <param name="performing" value="17.3"/>
+      <param name="subpopulation" value="lgv"/>
+      <param name="utilityOfLineSwitch" value="-0.5"/>
+      <param name="waiting" value="-0.0"/>
+      <param name="waitingPt" value="0"/>
+      <parameterset type="activityParams">
+        <param name="activityType" value="delivery"/>
+        <param name="openingTime" value="06:00:00"/>
+        <param name="closingTime" value="20:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="1:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="depot"/>
+        <param name="openingTime" value="0:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="4:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0.0"/>
+        <param name="mode" value="car"/>
+        <param name="monetaryDistanceRate" value="-0.0003"/>
+      </parameterset>
+    </parameterset>
+    <parameterset type="scoringParameters">
+      <param name="earlyDeparture" value="-0.0"/>
+      <param name="lateArrival" value="0"/>
+      <param name="marginalUtilityOfMoney" value="1"/>
+      <param name="performing" value="17.3"/>
+      <param name="subpopulation" value="lgv_ev"/>
+      <param name="utilityOfLineSwitch" value="-0.5"/>
+      <param name="waiting" value="-0.0"/>
+      <param name="waitingPt" value="0"/>
+      <parameterset type="activityParams">
+        <param name="activityType" value="delivery"/>
+        <param name="openingTime" value="06:00:00"/>
+        <param name="closingTime" value="20:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="1:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="depot"/>
+        <param name="openingTime" value="0:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="4:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0.0"/>
+        <param name="mode" value="car"/>
+        <param name="monetaryDistanceRate" value="-0.0001"/>
+      </parameterset>
+    </parameterset>
+    <parameterset type="scoringParameters">
+      <param name="earlyDeparture" value="-0.0"/>
+      <param name="lateArrival" value="0"/>
+      <param name="marginalUtilityOfMoney" value="1"/>
+      <param name="performing" value="40"/>
+      <param name="subpopulation" value="hgv"/>
+      <param name="utilityOfLineSwitch" value="-0.5"/>
+      <param name="waiting" value="-0.0"/>
+      <param name="waitingPt" value="0"/>
+      <parameterset type="activityParams">
+        <param name="activityType" value="delivery"/>
+        <param name="openingTime" value="06:00:00"/>
+        <param name="closingTime" value="20:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="1:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="depot"/>
+        <param name="openingTime" value="0:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="4:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0.0"/>
+        <param name="mode" value="car"/>
+        <param name="monetaryDistanceRate" value="-0.0006"/>
+      </parameterset>
+    </parameterset>
+    <parameterset type="scoringParameters">
+      <param name="earlyDeparture" value="-0.0"/>
+      <param name="lateArrival" value="0"/>
+      <param name="marginalUtilityOfMoney" value="1"/>
+      <param name="performing" value="10"/>
+      <param name="subpopulation" value="airport"/>
+      <param name="utilityOfLineSwitch" value="-0.5"/>
+      <param name="waiting" value="-0.0"/>
+      <param name="waitingPt" value="0"/>
+      <parameterset type="activityParams">
+        <param name="activityType" value="home"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="1:00:00"/>
+        <param name="typicalDuration" value="10:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="work"/>
+        <param name="openingTime" value="7:00:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="6:00:00"/>
+        <param name="typicalDuration" value="9:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="education"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="17:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="6:00:00"/>
+        <param name="typicalDuration" value="6:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="other"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:10:00"/>
+        <param name="typicalDuration" value="0:30:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="shop"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="0:30:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="visit"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="2:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="medical"/>
+        <param name="openingTime" value="09:00:00"/>
+        <param name="closingTime" value="18:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="1:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="business"/>
+        <param name="openingTime" value="07:30:00"/>
+        <param name="closingTime" value="20:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="1:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_home"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_work"/>
+        <param name="openingTime" value="7:00:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_business"/>
+        <param name="openingTime" value="7:00:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_education"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="17:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_other"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_shop"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="17:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0.0"/>
+        <param name="mode" value="car"/>
+        <param name="monetaryDistanceRate" value="-0.0002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0.0"/>
+        <param name="mode" value="car_passenger"/>
+        <param name="monetaryDistanceRate" value="-0.0002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0.0"/>
+        <param name="mode" value="taxi"/>
+        <param name="monetaryDistanceRate" value="-0.002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-1"/>
+        <param name="dailyMonetaryConstant" value="0"/>
+        <param name="dailyUtilityConstant" value="0.0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="-0.0015"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="0"/>
+        <param name="mode" value="bike"/>
+        <param name="monetaryDistanceRate" value="-0.0"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="-0.0005"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="0"/>
+        <param name="mode" value="walk"/>
+        <param name="monetaryDistanceRate" value="0.0"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="pt"/>
+        <param name="constant" value="-10000.0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="0"/>
+        <param name="monetaryDistanceRate" value="-0.000"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="bus"/>
+        <param name="constant" value="-3"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-2"/>
+        <param name="monetaryDistanceRate" value="-0.0002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="rail"/>
+        <param name="constant" value="2"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.0002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="ferry"/>
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.001"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="subway"/>
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.0002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="tram"/>
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.0004"/>
+      </parameterset>
+    </parameterset>
+    <parameterset type="scoringParameters">
+      <param name="earlyDeparture" value="-0.0"/>
+      <param name="lateArrival" value="0"/>
+      <param name="marginalUtilityOfMoney" value="1"/>
+      <param name="performing" value="10"/>
+      <param name="subpopulation" value="ev_airport"/>
+      <param name="utilityOfLineSwitch" value="-0.5"/>
+      <param name="waiting" value="-0.0"/>
+      <param name="waitingPt" value="0"/>
+      <parameterset type="activityParams">
+        <param name="activityType" value="home"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="1:00:00"/>
+        <param name="typicalDuration" value="10:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="work"/>
+        <param name="openingTime" value="7:00:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="6:00:00"/>
+        <param name="typicalDuration" value="9:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="education"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="17:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="6:00:00"/>
+        <param name="typicalDuration" value="6:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="other"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:10:00"/>
+        <param name="typicalDuration" value="0:30:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="shop"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="0:30:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="visit"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="2:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="medical"/>
+        <param name="openingTime" value="09:00:00"/>
+        <param name="closingTime" value="18:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="1:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="business"/>
+        <param name="openingTime" value="07:30:00"/>
+        <param name="closingTime" value="20:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="1:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_home"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_work"/>
+        <param name="openingTime" value="7:00:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_business"/>
+        <param name="openingTime" value="7:00:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_education"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="17:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_other"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_shop"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="17:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0.0"/>
+        <param name="mode" value="car"/>
+        <param name="monetaryDistanceRate" value="-5e-05"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0.0"/>
+        <param name="mode" value="car_passenger"/>
+        <param name="monetaryDistanceRate" value="-5e-05"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0.0"/>
+        <param name="mode" value="taxi"/>
+        <param name="monetaryDistanceRate" value="-0.002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-1"/>
+        <param name="dailyMonetaryConstant" value="0"/>
+        <param name="dailyUtilityConstant" value="0.0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="-0.0015"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="0"/>
+        <param name="mode" value="bike"/>
+        <param name="monetaryDistanceRate" value="-0.0"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="-0.0005"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="0"/>
+        <param name="mode" value="walk"/>
+        <param name="monetaryDistanceRate" value="0.0"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="pt"/>
+        <param name="constant" value="-10000.0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="0"/>
+        <param name="monetaryDistanceRate" value="-0.000"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="bus"/>
+        <param name="constant" value="-3"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-2"/>
+        <param name="monetaryDistanceRate" value="-0.0002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="rail"/>
+        <param name="constant" value="2"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.0002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="ferry"/>
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.001"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="subway"/>
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.0002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="tram"/>
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.0004"/>
+      </parameterset>
+    </parameterset>
+  </module>
+  <module name="strategy">
+    <param name="fractionOfIterationsToDisableInnovation" value="0.8"/>
+    <param name="maxAgentPlanMemorySize" value="5"/>
+    <param name="planSelectorForRemoval" value="WorstPlanSelector"/>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="ReRoute"/>
+      <param name="subpopulation" value="default"/>
+      <param name="weight" value="0.1"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="SubtourModeChoice"/>
+      <param name="subpopulation" value="default"/>
+      <param name="weight" value="0.1"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="TimeAllocationMutator_ReRoute"/>
+      <param name="subpopulation" value="default"/>
+      <param name="weight" value="0.1"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="ChangeExpBeta"/>
+      <param name="subpopulation" value="default"/>
+      <param name="weight" value="0.7"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="ReRoute"/>
+      <param name="subpopulation" value="low"/>
+      <param name="weight" value="0.1"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="SubtourModeChoice"/>
+      <param name="subpopulation" value="low"/>
+      <param name="weight" value="0.1"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="TimeAllocationMutator_ReRoute"/>
+      <param name="subpopulation" value="low"/>
+      <param name="weight" value="0.1"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="ChangeExpBeta"/>
+      <param name="subpopulation" value="low"/>
+      <param name="weight" value="0.7"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="ReRoute"/>
+      <param name="subpopulation" value="medium"/>
+      <param name="weight" value="0.1"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="SubtourModeChoice"/>
+      <param name="subpopulation" value="medium"/>
+      <param name="weight" value="0.1"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="TimeAllocationMutator_ReRoute"/>
+      <param name="subpopulation" value="medium"/>
+      <param name="weight" value="0.1"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="ChangeExpBeta"/>
+      <param name="subpopulation" value="medium"/>
+      <param name="weight" value="0.7"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="ReRoute"/>
+      <param name="subpopulation" value="high"/>
+      <param name="weight" value="0.1"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="SubtourModeChoice"/>
+      <param name="subpopulation" value="high"/>
+      <param name="weight" value="0.1"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="TimeAllocationMutator_ReRoute"/>
+      <param name="subpopulation" value="high"/>
+      <param name="weight" value="0.1"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="ChangeExpBeta"/>
+      <param name="subpopulation" value="high"/>
+      <param name="weight" value="0.7"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="ReRoute"/>
+      <param name="subpopulation" value="ev_low"/>
+      <param name="weight" value="0.1"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="SubtourModeChoice"/>
+      <param name="subpopulation" value="ev_low"/>
+      <param name="weight" value="0.1"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="TimeAllocationMutator_ReRoute"/>
+      <param name="subpopulation" value="ev_low"/>
+      <param name="weight" value="0.1"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="ChangeExpBeta"/>
+      <param name="subpopulation" value="ev_low"/>
+      <param name="weight" value="0.7"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="ReRoute"/>
+      <param name="subpopulation" value="ev_medium"/>
+      <param name="weight" value="0.1"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="SubtourModeChoice"/>
+      <param name="subpopulation" value="ev_medium"/>
+      <param name="weight" value="0.1"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="TimeAllocationMutator_ReRoute"/>
+      <param name="subpopulation" value="ev_medium"/>
+      <param name="weight" value="0.1"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="ChangeExpBeta"/>
+      <param name="subpopulation" value="ev_medium"/>
+      <param name="weight" value="0.7"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="ReRoute"/>
+      <param name="subpopulation" value="ev_high"/>
+      <param name="weight" value="0.1"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="SubtourModeChoice"/>
+      <param name="subpopulation" value="ev_high"/>
+      <param name="weight" value="0.1"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="TimeAllocationMutator_ReRoute"/>
+      <param name="subpopulation" value="ev_high"/>
+      <param name="weight" value="0.1"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="ChangeExpBeta"/>
+      <param name="subpopulation" value="ev_high"/>
+      <param name="weight" value="0.7"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="ReRoute"/>
+      <param name="subpopulation" value="lgv"/>
+      <param name="weight" value="0.1"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="TimeAllocationMutator_ReRoute"/>
+      <param name="subpopulation" value="lgv"/>
+      <param name="weight" value="0.2"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="ChangeExpBeta"/>
+      <param name="subpopulation" value="lgv"/>
+      <param name="weight" value="0.7"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="ReRoute"/>
+      <param name="subpopulation" value="lgv_ev"/>
+      <param name="weight" value="0.1"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="TimeAllocationMutator_ReRoute"/>
+      <param name="subpopulation" value="lgv_ev"/>
+      <param name="weight" value="0.2"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="ChangeExpBeta"/>
+      <param name="subpopulation" value="lgv_ev"/>
+      <param name="weight" value="0.7"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="ReRoute"/>
+      <param name="subpopulation" value="hgv"/>
+      <param name="weight" value="0.1"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="TimeAllocationMutator_ReRoute"/>
+      <param name="subpopulation" value="hgv"/>
+      <param name="weight" value="0.2"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="ChangeExpBeta"/>
+      <param name="subpopulation" value="hgv"/>
+      <param name="weight" value="0.7"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="ReRoute"/>
+      <param name="subpopulation" value="airport"/>
+      <param name="weight" value="0.1"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="SubtourModeChoice"/>
+      <param name="subpopulation" value="airport"/>
+      <param name="weight" value="0.1"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="TimeAllocationMutator_ReRoute"/>
+      <param name="subpopulation" value="airport"/>
+      <param name="weight" value="0.1"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="ChangeExpBeta"/>
+      <param name="subpopulation" value="airport"/>
+      <param name="weight" value="0.7"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="ReRoute"/>
+      <param name="subpopulation" value="ev_airport"/>
+      <param name="weight" value="0.1"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="SubtourModeChoice"/>
+      <param name="subpopulation" value="ev_airport"/>
+      <param name="weight" value="0.1"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="TimeAllocationMutator_ReRoute"/>
+      <param name="subpopulation" value="ev_airport"/>
+      <param name="weight" value="0.1"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="ChangeExpBeta"/>
+      <param name="subpopulation" value="ev_airport"/>
+      <param name="weight" value="0.7"/>
+    </parameterset>
+  </module>
+</config>

--- a/docs/cutting-scenarios-CML/matsim_configs_example/matsim_config_generate_facilities.xml
+++ b/docs/cutting-scenarios-CML/matsim_configs_example/matsim_config_generate_facilities.xml
@@ -1,0 +1,2959 @@
+<?xml version="1.0" ?>
+<!DOCTYPE config SYSTEM "http://www.matsim.org/files/dtd/config_v2.dtd">
+<config>
+  <module name="global">
+    <param name="randomSeed" value="4711"/>
+    <param name="coordinateSystem" value="EPSG:27700"/>
+    <param name="numberOfThreads" value="96"/>
+  </module>
+  <module name="network">
+    <param name="inputNetworkFile" value="/efs/networks/network_with_access_and_0.75_freespeed_v2/osm_and_rtm_speed_and_capacity/urban_primary_trunk_squeeze_and_roundabout_fattening/network.xml"/>
+  </module>
+  <module name="plans">
+    <param name="inputPlansFile" value="/efs/population/SE_2019_v1_10pct_2019_20240702/combined/final/plans_20240731_kdtree.xml"/>
+    <!-- <param name="inputPlansFile" value="/mnt/efs/population/SE_2019_v1_1pct_2019_20231123/combined_intermodal/final/plans20240730_kdtree.xml"/> -->
+  </module>
+  <module name="vehicles">
+    <param name="vehiclesFile" value="/efs/population/SE_2019_v1_10pct_2019_20240702/combined/final/vehicles.xml"/>
+    <!-- <param name="vehiclesFile" value="/mnt/efs/population/SE_2019_v1_1pct_2019_20231123/combined_intermodal/final/vehicles.xml"/> -->
+
+  </module>
+  <module name="planscalcroute">
+    <param name="networkModes" value="car,car_passenger,taxi"/>
+    <parameterset type="teleportedModeParameters">
+      <param name="beelineDistanceFactor" value="1.3"/>
+      <param name="mode" value="bike"/>
+      <param name="teleportedModeFreespeedFactor" value="null"/>
+      <param name="teleportedModeSpeed" value="4.166666666666667"/>
+    </parameterset>
+    <parameterset type="teleportedModeParameters">
+      <param name="beelineDistanceFactor" value="1.3"/>
+      <param name="mode" value="walk"/>
+      <param name="teleportedModeFreespeedFactor" value="null"/>
+      <param name="teleportedModeSpeed" value="0.8333333333333333"/>
+    </parameterset>
+    <parameterset type="teleportedModeParameters">
+      <param name="beelineDistanceFactor" value="1.3"/>
+      <param name="mode" value="non_network_walk"/>
+      <param name="teleportedModeFreespeedFactor" value="null"/>
+      <param name="teleportedModeSpeed" value="0.8333333333333333"/>
+    </parameterset>
+  </module>
+  <module name="transit">
+    <param name="useTransit" value="true"/>
+    <param name="transitScheduleFile" value="/efs/networks/network_with_access_and_0.75_freespeed_v2/schedule.xml"/>
+    <param name="vehiclesFile" value="/efs/networks/network_with_access_and_0.75_freespeed_v2/network_with_access_and_0.75_freespeed_vehicles_10pc.xml"/>
+    <param name="transitModes" value="bus,rail,ferry,subway,tram"/>
+  </module>
+  <module name="swissRailRaptor">
+    <param name="useModeMappingForPassengers" value="true"/>
+    <param name="useIntermodalAccessEgress" value="true"/>
+    <param name="intermodalAccessEgressModeSelection" value="RandomSelectOneModePerRoutingRequestAndDirection"/>
+    <parameterset type="intermodalAccessEgress">
+      <param name="mode" value="walk"/>
+      <param name="initialSearchRadius" value="500"/>
+      <param name="maxRadius" value="2000"/>
+    </parameterset>
+    <parameterset type="intermodalAccessEgress">
+      <param name="mode" value="bike"/>
+      <param name="initialSearchRadius" value="2000"/>
+      <param name="maxRadius" value="5000"/>
+      <param name="personFilterAttribute" value="intermodalBike"/>
+      <param name="personFilterValue" value="yes"/>
+      <param name="stopFilterAttribute" value="bikeAccessible"/>
+      <param name="stopFilterValue" value="true"/>
+    </parameterset>
+    <parameterset type="intermodalAccessEgress">
+      <param name="mode" value="car"/>
+      <param name="initialSearchRadius" value="5000"/>
+      <param name="searchExtensionRadius" value="1000.0"/>
+      <param name="maxRadius" value="10000"/>
+      <param name="linkIdAttribute" value="accessLinkId_car"/>
+      <param name="personFilterAttribute" value="intermodalCar"/>
+      <param name="personFilterValue" value="yes"/>
+      <param name="stopFilterAttribute" value="carAccessible"/>
+      <param name="stopFilterValue" value="true"/>
+    </parameterset>
+    <parameterset type="intermodalAccessEgress">
+      <param name="mode" value="taxi"/>
+      <param name="initialSearchRadius" value="5000"/>
+      <param name="searchExtensionRadius" value="1000.0"/>
+      <param name="maxRadius" value="10000"/>
+      <param name="linkIdAttribute" value="accessLinkId_car"/>
+      <param name="personFilterAttribute" value="intermodalTaxi"/>
+      <param name="personFilterValue" value="yes"/>
+      <param name="stopFilterAttribute" value="carAccessible"/>
+      <param name="stopFilterValue" value="true"/>
+    </parameterset>
+    <parameterset type="intermodalAccessEgress">
+      <param name="mode" value="car_passenger"/>
+      <param name="initialSearchRadius" value="5000"/>
+      <param name="searchExtensionRadius" value="1000.0"/>
+      <param name="maxRadius" value="10000"/>
+      <param name="linkIdAttribute" value="accessLinkId_car"/>
+      <param name="personFilterAttribute" value="intermodalPassenger"/>
+      <param name="personFilterValue" value="yes"/>
+      <param name="stopFilterAttribute" value="carAccessible"/>
+      <param name="stopFilterValue" value="true"/>
+    </parameterset>
+    <parameterset type="modeMapping">
+      <param name="routeMode" value="bus"/>
+      <param name="passengerMode" value="bus"/>
+    </parameterset>
+    <parameterset type="modeMapping">
+      <param name="routeMode" value="rail"/>
+      <param name="passengerMode" value="rail"/>
+    </parameterset>
+    <parameterset type="modeMapping">
+      <param name="routeMode" value="ferry"/>
+      <param name="passengerMode" value="ferry"/>
+    </parameterset>
+    <parameterset type="modeMapping">
+      <param name="routeMode" value="subway"/>
+      <param name="passengerMode" value="subway"/>
+    </parameterset>
+    <parameterset type="modeMapping">
+      <param name="routeMode" value="tram"/>
+      <param name="passengerMode" value="tram"/>
+    </parameterset>
+  </module>
+  <module name="transitRouter">
+    <param name="additionalTransferTime" value="1.0"/>
+    <param name="extensionRadius" value="2000.0"/>
+    <param name="maxBeelineWalkConnectionDistance" value="500.0"/>
+    <param name="searchRadius" value="2000.0"/>
+  </module>
+  <module name="TimeAllocationMutator">
+    <param name="mutationRange" value="1000.0"/>
+  </module>
+  <module name="ArupReplanning">
+    <param name="maximumBikeTourDistance_m" value="45000"/>
+    <param name="maximumWalkTourDistance_m" value="12500"/>
+    <param name="minimumTimeMutationStep_s" value="300"/>
+  </module>
+  <module name="facilities" >
+      <!-- This defines how facilities should be created. Possible values: none fromFile setInScenario onePerActivityLinkInPlansFile onePerActivityLinkInPlansFileExceptWhenCoordinatesAreGiven onePerActivityLocationInPlansFile  -->
+      <!-- <param name="facilitiesSource" value="onePerActivityLocationInPlansFile" /> -->
+	<param name="facilitiesSource" value="onePerActivityLocationInPlansFile" />
+	<!-- <param name="facilitiesSource" value="fromFile" />
+	  <param name="inputFacilitiesFile" value="output_facilities.xml" /> -->
+    </module>
+  <module name="controler">
+    <param name="createGraphs" value="true"/>
+    <param name="outputDirectory" value="/efs/simulations_refresh/10pc/2019_freight_update_baseline_20240726/generate_facilities_10pct_20240909"/>
+    <param name="firstIteration" value="0"/>
+    <param name="lastIteration" value="2"/>
+    <param name="routingAlgorithmType" value="FastAStarLandmarks"/>
+    <param name="eventsFileFormat" value="xml,json"/>
+    <param name="writeEventsInterval" value="2"/>
+    <param name="writePlansInterval" value="2"/>
+    <param name="mobsim" value="hermes"/>
+    <param name="snapshotFormat" value=""/>
+    <param name="overwriteFiles" value="deleteDirectoryIfExists"/>
+  </module>
+  <module name="subtourModeChoice">
+    <param name="considerCarAvailability" value="true"/>
+    <param name="chainBasedModes" value="car,bike"/>
+    <param name="modes" value="bus,bike,walk,rail,car,ferry,subway,tram,car_passenger,taxi"/>
+  </module>
+  <module name="parallelEventHandling">
+    <param name="estimatedNumberOfEvents" value="null"/>
+    <param name="eventsQueueSize" value="270000000"/>
+    <param name="numberOfThreads" value="96"/>
+    <param name="oneThreadPerHandler" value="true"/>
+    <param name="synchronizeOnSimSteps" value="true"/>
+  </module>
+  <module name="hermes">
+    <param name="endTime" value="32:00:00"/>
+    <param name="flowCapacityFactor" value="0.1"/>
+    <param name="mainMode" value="car,taxi"/>
+    <param name="storageCapacityFactor" value="0.1"/>
+    <param name="stuckTime" value="30"/>
+    <param name="useDeterministicPt" value="true"/>
+  </module>
+  <module name="SBBPt">
+    <param name="deterministicServiceModes" value="rail,ferry,subway,tram"/>
+    <param name="createLinkEventsInterval" value="50"/>
+  </module>
+  <module name="planCalcScore">
+    <param name="BrainExpBeta" value="1.0"/>
+    <param name="writeExperiencedPlans" value="true"/>
+    <parameterset type="scoringParameters">
+      <param name="earlyDeparture" value="-0.0"/>
+      <param name="lateArrival" value="0"/>
+      <param name="marginalUtilityOfMoney" value="1"/>
+      <param name="performing" value="10"/>
+      <param name="subpopulation" value="default"/>
+      <param name="utilityOfLineSwitch" value="-0.5"/>
+      <param name="waiting" value="-0.0"/>
+      <param name="waitingPt" value="0"/>
+      <parameterset type="activityParams">
+        <param name="activityType" value="home"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="1:00:00"/>
+        <param name="typicalDuration" value="10:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="work"/>
+        <param name="openingTime" value="7:00:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="6:00:00"/>
+        <param name="typicalDuration" value="9:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="delivery"/>
+        <param name="openingTime" value="06:00:00"/>
+        <param name="closingTime" value="20:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="1:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="depot"/>
+        <param name="openingTime" value="0:00:00"/>
+        <param name="closingTime" value="23:59:59"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="4:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="education"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="17:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="6:00:00"/>
+        <param name="typicalDuration" value="6:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="other"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:10:00"/>
+        <param name="typicalDuration" value="0:30:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="shop"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="0:30:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="visit"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="2:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="medical"/>
+        <param name="openingTime" value="09:00:00"/>
+        <param name="closingTime" value="18:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="1:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="business"/>
+        <param name="openingTime" value="07:30:00"/>
+        <param name="closingTime" value="20:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="1:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_home"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_work"/>
+        <param name="openingTime" value="7:00:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_business"/>
+        <param name="openingTime" value="7:00:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_education"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="17:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_other"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_shop"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="17:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0.0"/>
+        <param name="mode" value="car"/>
+        <param name="monetaryDistanceRate" value="-0.00009"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0.0"/>
+        <param name="mode" value="car_passenger"/>
+        <param name="monetaryDistanceRate" value="-0.00009"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0.0"/>
+        <param name="mode" value="taxi"/>
+        <param name="monetaryDistanceRate" value="-0.001"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-4"/>
+        <param name="dailyMonetaryConstant" value="0"/>
+        <param name="dailyUtilityConstant" value="0.0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="-0.0015"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="0"/>
+        <param name="mode" value="bike"/>
+        <param name="monetaryDistanceRate" value="-0.0"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="-0.003"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="0"/>
+        <param name="mode" value="walk"/>
+        <param name="monetaryDistanceRate" value="0.0"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="pt"/>
+        <param name="constant" value="-10000.0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="0"/>
+        <param name="monetaryDistanceRate" value="-0.000"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="bus"/>
+        <param name="constant" value="-1"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="0"/>
+        <param name="monetaryDistanceRate" value="-0.00017"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="rail"/>
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.0002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="ferry"/>
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.001"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="subway"/>
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.0002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="tram"/>
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.0004"/>
+      </parameterset>
+    </parameterset>
+    <parameterset type="scoringParameters">
+      <param name="earlyDeparture" value="-0.0"/>
+      <param name="lateArrival" value="0"/>
+      <param name="marginalUtilityOfMoney" value="2"/>
+      <param name="performing" value="10"/>
+      <param name="subpopulation" value="low"/>
+      <param name="utilityOfLineSwitch" value="-0.5"/>
+      <param name="waiting" value="-0.0"/>
+      <param name="waitingPt" value="0"/>
+      <parameterset type="activityParams">
+        <param name="activityType" value="home"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="1:00:00"/>
+        <param name="typicalDuration" value="10:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="work"/>
+        <param name="openingTime" value="7:00:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="6:00:00"/>
+        <param name="typicalDuration" value="9:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="education"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="17:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="6:00:00"/>
+        <param name="typicalDuration" value="6:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="other"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:10:00"/>
+        <param name="typicalDuration" value="0:30:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="shop"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="0:30:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="visit"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="2:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="medical"/>
+        <param name="openingTime" value="09:00:00"/>
+        <param name="closingTime" value="18:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="1:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="business"/>
+        <param name="openingTime" value="07:30:00"/>
+        <param name="closingTime" value="20:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="1:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_home"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_work"/>
+        <param name="openingTime" value="7:00:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_business"/>
+        <param name="openingTime" value="7:00:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_education"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="17:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_other"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_shop"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="17:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0.0"/>
+        <param name="mode" value="car"/>
+        <param name="monetaryDistanceRate" value="-0.0002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0.0"/>
+        <param name="mode" value="car_passenger"/>
+        <param name="monetaryDistanceRate" value="-0.0002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0.0"/>
+        <param name="mode" value="taxi"/>
+        <param name="monetaryDistanceRate" value="-0.002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-4"/>
+        <param name="dailyMonetaryConstant" value="0"/>
+        <param name="dailyUtilityConstant" value="0.0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="-0.0015"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="0"/>
+        <param name="mode" value="bike"/>
+        <param name="monetaryDistanceRate" value="-0.0"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="-0.003"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="0"/>
+        <param name="mode" value="walk"/>
+        <param name="monetaryDistanceRate" value="0.0"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="pt"/>
+        <param name="constant" value="-10000.0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="0"/>
+        <param name="monetaryDistanceRate" value="-0.000"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="bus"/>
+        <param name="constant" value="-1"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="0"/>
+        <param name="monetaryDistanceRate" value="-0.00017"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="rail"/>
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.0002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="ferry"/>
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.001"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="subway"/>
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.0002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="tram"/>
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.0004"/>
+      </parameterset>
+    </parameterset>
+    <parameterset type="scoringParameters">
+      <param name="earlyDeparture" value="-0.0"/>
+      <param name="lateArrival" value="0"/>
+      <param name="marginalUtilityOfMoney" value="1"/>
+      <param name="performing" value="10"/>
+      <param name="subpopulation" value="medium"/>
+      <param name="utilityOfLineSwitch" value="-0.5"/>
+      <param name="waiting" value="-0.0"/>
+      <param name="waitingPt" value="0"/>
+      <parameterset type="activityParams">
+        <param name="activityType" value="home"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="1:00:00"/>
+        <param name="typicalDuration" value="10:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="work"/>
+        <param name="openingTime" value="7:00:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="6:00:00"/>
+        <param name="typicalDuration" value="9:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="education"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="17:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="6:00:00"/>
+        <param name="typicalDuration" value="6:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="other"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:10:00"/>
+        <param name="typicalDuration" value="0:30:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="shop"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="0:30:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="visit"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="2:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="medical"/>
+        <param name="openingTime" value="09:00:00"/>
+        <param name="closingTime" value="18:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="1:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="business"/>
+        <param name="openingTime" value="07:30:00"/>
+        <param name="closingTime" value="20:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="1:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_home"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_work"/>
+        <param name="openingTime" value="7:00:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_business"/>
+        <param name="openingTime" value="7:00:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_education"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="17:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_other"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_shop"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="17:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0.0"/>
+        <param name="mode" value="car"/>
+        <param name="monetaryDistanceRate" value="-0.0002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0.0"/>
+        <param name="mode" value="car_passenger"/>
+        <param name="monetaryDistanceRate" value="-0.0002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0.0"/>
+        <param name="mode" value="taxi"/>
+        <param name="monetaryDistanceRate" value="-0.002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-4"/>
+        <param name="dailyMonetaryConstant" value="0"/>
+        <param name="dailyUtilityConstant" value="0.0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="-0.0015"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="0"/>
+        <param name="mode" value="bike"/>
+        <param name="monetaryDistanceRate" value="-0.0"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="-0.003"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="0"/>
+        <param name="mode" value="walk"/>
+        <param name="monetaryDistanceRate" value="0.0"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="pt"/>
+        <param name="constant" value="-10000.0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="0"/>
+        <param name="monetaryDistanceRate" value="-0.000"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="bus"/>
+        <param name="constant" value="-1"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="0"/>
+        <param name="monetaryDistanceRate" value="-0.00017"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="rail"/>
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.0002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="ferry"/>
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.001"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="subway"/>
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.0002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="tram"/>
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.0004"/>
+      </parameterset>
+    </parameterset>
+    <parameterset type="scoringParameters">
+      <param name="earlyDeparture" value="-0.0"/>
+      <param name="lateArrival" value="0"/>
+      <param name="marginalUtilityOfMoney" value="0.5"/>
+      <param name="performing" value="10"/>
+      <param name="subpopulation" value="high"/>
+      <param name="utilityOfLineSwitch" value="-0.5"/>
+      <param name="waiting" value="-0.0"/>
+      <param name="waitingPt" value="0"/>
+      <parameterset type="activityParams">
+        <param name="activityType" value="home"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="1:00:00"/>
+        <param name="typicalDuration" value="10:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="work"/>
+        <param name="openingTime" value="7:00:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="6:00:00"/>
+        <param name="typicalDuration" value="9:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="education"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="17:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="6:00:00"/>
+        <param name="typicalDuration" value="6:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="other"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:10:00"/>
+        <param name="typicalDuration" value="0:30:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="shop"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="0:30:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="visit"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="2:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="medical"/>
+        <param name="openingTime" value="09:00:00"/>
+        <param name="closingTime" value="18:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="1:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="business"/>
+        <param name="openingTime" value="07:30:00"/>
+        <param name="closingTime" value="20:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="1:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_home"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_work"/>
+        <param name="openingTime" value="7:00:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_business"/>
+        <param name="openingTime" value="7:00:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_education"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="17:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_other"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_shop"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="17:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0.0"/>
+        <param name="mode" value="car"/>
+        <param name="monetaryDistanceRate" value="-0.0002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0.0"/>
+        <param name="mode" value="car_passenger"/>
+        <param name="monetaryDistanceRate" value="-0.0002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0.0"/>
+        <param name="mode" value="taxi"/>
+        <param name="monetaryDistanceRate" value="-0.002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-4"/>
+        <param name="dailyMonetaryConstant" value="0"/>
+        <param name="dailyUtilityConstant" value="0.0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="-0.0015"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="0"/>
+        <param name="mode" value="bike"/>
+        <param name="monetaryDistanceRate" value="-0.0"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="-0.003"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="0"/>
+        <param name="mode" value="walk"/>
+        <param name="monetaryDistanceRate" value="0.0"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="pt"/>
+        <param name="constant" value="-10000.0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="0"/>
+        <param name="monetaryDistanceRate" value="-0.000"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="bus"/>
+        <param name="constant" value="-1"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="0"/>
+        <param name="monetaryDistanceRate" value="-0.00017"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="rail"/>
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.0002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="ferry"/>
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.001"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="subway"/>
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.0002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="tram"/>
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.0004"/>
+      </parameterset>
+    </parameterset>
+    <parameterset type="scoringParameters">
+      <param name="earlyDeparture" value="-0.0"/>
+      <param name="lateArrival" value="0"/>
+      <param name="marginalUtilityOfMoney" value="2"/>
+      <param name="performing" value="10"/>
+      <param name="subpopulation" value="ev_low"/>
+      <param name="utilityOfLineSwitch" value="-0.5"/>
+      <param name="waiting" value="-0.0"/>
+      <param name="waitingPt" value="0"/>
+      <parameterset type="activityParams">
+        <param name="activityType" value="home"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="1:00:00"/>
+        <param name="typicalDuration" value="10:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="work"/>
+        <param name="openingTime" value="7:00:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="6:00:00"/>
+        <param name="typicalDuration" value="9:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="education"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="17:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="6:00:00"/>
+        <param name="typicalDuration" value="6:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="other"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:10:00"/>
+        <param name="typicalDuration" value="0:30:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="shop"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="0:30:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="visit"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="2:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="medical"/>
+        <param name="openingTime" value="09:00:00"/>
+        <param name="closingTime" value="18:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="1:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="business"/>
+        <param name="openingTime" value="07:30:00"/>
+        <param name="closingTime" value="20:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="1:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_home"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_work"/>
+        <param name="openingTime" value="7:00:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_business"/>
+        <param name="openingTime" value="7:00:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_education"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="17:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_other"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_shop"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="17:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0.0"/>
+        <param name="mode" value="car"/>
+        <param name="monetaryDistanceRate" value="-5e-05"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0.0"/>
+        <param name="mode" value="car_passenger"/>
+        <param name="monetaryDistanceRate" value="-5e-05"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0.0"/>
+        <param name="mode" value="taxi"/>
+        <param name="monetaryDistanceRate" value="-0.002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-4"/>
+        <param name="dailyMonetaryConstant" value="0"/>
+        <param name="dailyUtilityConstant" value="0.0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="-0.0015"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="0"/>
+        <param name="mode" value="bike"/>
+        <param name="monetaryDistanceRate" value="-0.0"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="-0.003"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="0"/>
+        <param name="mode" value="walk"/>
+        <param name="monetaryDistanceRate" value="0.0"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="pt"/>
+        <param name="constant" value="-10000.0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="0"/>
+        <param name="monetaryDistanceRate" value="-0.000"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="bus"/>
+        <param name="constant" value="-1"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="0"/>
+        <param name="monetaryDistanceRate" value="-0.00017"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="rail"/>
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.0002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="ferry"/>
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.001"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="subway"/>
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.0002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="tram"/>
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.0004"/>
+      </parameterset>
+    </parameterset>
+    <parameterset type="scoringParameters">
+      <param name="earlyDeparture" value="-0.0"/>
+      <param name="lateArrival" value="0"/>
+      <param name="marginalUtilityOfMoney" value="1"/>
+      <param name="performing" value="10"/>
+      <param name="subpopulation" value="ev_medium"/>
+      <param name="utilityOfLineSwitch" value="-0.5"/>
+      <param name="waiting" value="-0.0"/>
+      <param name="waitingPt" value="0"/>
+      <parameterset type="activityParams">
+        <param name="activityType" value="home"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="1:00:00"/>
+        <param name="typicalDuration" value="10:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="work"/>
+        <param name="openingTime" value="7:00:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="6:00:00"/>
+        <param name="typicalDuration" value="9:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="education"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="17:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="6:00:00"/>
+        <param name="typicalDuration" value="6:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="other"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:10:00"/>
+        <param name="typicalDuration" value="0:30:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="shop"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="0:30:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="visit"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="2:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="medical"/>
+        <param name="openingTime" value="09:00:00"/>
+        <param name="closingTime" value="18:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="1:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="business"/>
+        <param name="openingTime" value="07:30:00"/>
+        <param name="closingTime" value="20:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="1:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_home"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_work"/>
+        <param name="openingTime" value="7:00:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_business"/>
+        <param name="openingTime" value="7:00:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_education"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="17:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_other"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_shop"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="17:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0.0"/>
+        <param name="mode" value="car"/>
+        <param name="monetaryDistanceRate" value="-5e-05"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0.0"/>
+        <param name="mode" value="car_passenger"/>
+        <param name="monetaryDistanceRate" value="-5e-05"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0.0"/>
+        <param name="mode" value="taxi"/>
+        <param name="monetaryDistanceRate" value="-0.002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-4"/>
+        <param name="dailyMonetaryConstant" value="0"/>
+        <param name="dailyUtilityConstant" value="0.0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="-0.0015"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="0"/>
+        <param name="mode" value="bike"/>
+        <param name="monetaryDistanceRate" value="-0.0"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="-0.003"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="0"/>
+        <param name="mode" value="walk"/>
+        <param name="monetaryDistanceRate" value="0.0"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="pt"/>
+        <param name="constant" value="-10000.0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="0"/>
+        <param name="monetaryDistanceRate" value="-0.000"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="bus"/>
+        <param name="constant" value="-1"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="0"/>
+        <param name="monetaryDistanceRate" value="-0.00017"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="rail"/>
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.0002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="ferry"/>
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.001"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="subway"/>
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.0002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="tram"/>
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.0004"/>
+      </parameterset>
+    </parameterset>
+    <parameterset type="scoringParameters">
+      <param name="earlyDeparture" value="-0.0"/>
+      <param name="lateArrival" value="0"/>
+      <param name="marginalUtilityOfMoney" value="0.5"/>
+      <param name="performing" value="10"/>
+      <param name="subpopulation" value="ev_high"/>
+      <param name="utilityOfLineSwitch" value="-0.5"/>
+      <param name="waiting" value="-0.0"/>
+      <param name="waitingPt" value="0"/>
+      <parameterset type="activityParams">
+        <param name="activityType" value="home"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="1:00:00"/>
+        <param name="typicalDuration" value="10:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="work"/>
+        <param name="openingTime" value="7:00:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="6:00:00"/>
+        <param name="typicalDuration" value="9:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="education"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="17:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="6:00:00"/>
+        <param name="typicalDuration" value="6:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="other"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:10:00"/>
+        <param name="typicalDuration" value="0:30:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="shop"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="0:30:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="visit"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="2:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="medical"/>
+        <param name="openingTime" value="09:00:00"/>
+        <param name="closingTime" value="18:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="1:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="business"/>
+        <param name="openingTime" value="07:30:00"/>
+        <param name="closingTime" value="20:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="1:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_home"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_work"/>
+        <param name="openingTime" value="7:00:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_business"/>
+        <param name="openingTime" value="7:00:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_education"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="17:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_other"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_shop"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="17:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0.0"/>
+        <param name="mode" value="car"/>
+        <param name="monetaryDistanceRate" value="-5e-05"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0.0"/>
+        <param name="mode" value="car_passenger"/>
+        <param name="monetaryDistanceRate" value="-5e-05"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0.0"/>
+        <param name="mode" value="taxi"/>
+        <param name="monetaryDistanceRate" value="-0.002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-4"/>
+        <param name="dailyMonetaryConstant" value="0"/>
+        <param name="dailyUtilityConstant" value="0.0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="-0.0015"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="0"/>
+        <param name="mode" value="bike"/>
+        <param name="monetaryDistanceRate" value="-0.0"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="-0.003"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="0"/>
+        <param name="mode" value="walk"/>
+        <param name="monetaryDistanceRate" value="0.0"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="pt"/>
+        <param name="constant" value="-10000.0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="0"/>
+        <param name="monetaryDistanceRate" value="-0.000"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="bus"/>
+        <param name="constant" value="-1"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="0"/>
+        <param name="monetaryDistanceRate" value="-0.00017"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="rail"/>
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.0002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="ferry"/>
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.001"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="subway"/>
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.0002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="tram"/>
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.0004"/>
+      </parameterset>
+    </parameterset>
+    <parameterset type="scoringParameters">
+      <param name="earlyDeparture" value="-0.0"/>
+      <param name="lateArrival" value="0"/>
+      <param name="marginalUtilityOfMoney" value="1"/>
+      <param name="performing" value="17.3"/>
+      <param name="subpopulation" value="lgv"/>
+      <param name="utilityOfLineSwitch" value="-0.5"/>
+      <param name="waiting" value="-0.0"/>
+      <param name="waitingPt" value="0"/>
+      <parameterset type="activityParams">
+        <param name="activityType" value="delivery"/>
+        <param name="openingTime" value="06:00:00"/>
+        <param name="closingTime" value="20:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="1:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="depot"/>
+        <param name="openingTime" value="0:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="4:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0.0"/>
+        <param name="mode" value="car"/>
+        <param name="monetaryDistanceRate" value="-0.0003"/>
+      </parameterset>
+    </parameterset>
+    <parameterset type="scoringParameters">
+      <param name="earlyDeparture" value="-0.0"/>
+      <param name="lateArrival" value="0"/>
+      <param name="marginalUtilityOfMoney" value="1"/>
+      <param name="performing" value="17.3"/>
+      <param name="subpopulation" value="lgv_ev"/>
+      <param name="utilityOfLineSwitch" value="-0.5"/>
+      <param name="waiting" value="-0.0"/>
+      <param name="waitingPt" value="0"/>
+      <parameterset type="activityParams">
+        <param name="activityType" value="delivery"/>
+        <param name="openingTime" value="06:00:00"/>
+        <param name="closingTime" value="20:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="1:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="depot"/>
+        <param name="openingTime" value="0:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="4:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0.0"/>
+        <param name="mode" value="car"/>
+        <param name="monetaryDistanceRate" value="-0.0001"/>
+      </parameterset>
+    </parameterset>
+    <parameterset type="scoringParameters">
+      <param name="earlyDeparture" value="-0.0"/>
+      <param name="lateArrival" value="0"/>
+      <param name="marginalUtilityOfMoney" value="1"/>
+      <param name="performing" value="40"/>
+      <param name="subpopulation" value="hgv"/>
+      <param name="utilityOfLineSwitch" value="-0.5"/>
+      <param name="waiting" value="-0.0"/>
+      <param name="waitingPt" value="0"/>
+      <parameterset type="activityParams">
+        <param name="activityType" value="delivery"/>
+        <param name="openingTime" value="06:00:00"/>
+        <param name="closingTime" value="20:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="1:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="depot"/>
+        <param name="openingTime" value="0:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="4:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0.0"/>
+        <param name="mode" value="car"/>
+        <param name="monetaryDistanceRate" value="-0.0006"/>
+      </parameterset>
+    </parameterset>
+    <parameterset type="scoringParameters">
+      <param name="earlyDeparture" value="-0.0"/>
+      <param name="lateArrival" value="0"/>
+      <param name="marginalUtilityOfMoney" value="1"/>
+      <param name="performing" value="10"/>
+      <param name="subpopulation" value="airport"/>
+      <param name="utilityOfLineSwitch" value="-0.5"/>
+      <param name="waiting" value="-0.0"/>
+      <param name="waitingPt" value="0"/>
+      <parameterset type="activityParams">
+        <param name="activityType" value="home"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="1:00:00"/>
+        <param name="typicalDuration" value="10:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="work"/>
+        <param name="openingTime" value="7:00:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="6:00:00"/>
+        <param name="typicalDuration" value="9:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="education"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="17:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="6:00:00"/>
+        <param name="typicalDuration" value="6:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="other"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:10:00"/>
+        <param name="typicalDuration" value="0:30:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="shop"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="0:30:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="visit"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="2:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="medical"/>
+        <param name="openingTime" value="09:00:00"/>
+        <param name="closingTime" value="18:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="1:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="business"/>
+        <param name="openingTime" value="07:30:00"/>
+        <param name="closingTime" value="20:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="1:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_home"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_work"/>
+        <param name="openingTime" value="7:00:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_business"/>
+        <param name="openingTime" value="7:00:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_education"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="17:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_other"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_shop"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="17:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0.0"/>
+        <param name="mode" value="car"/>
+        <param name="monetaryDistanceRate" value="-0.0002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0.0"/>
+        <param name="mode" value="car_passenger"/>
+        <param name="monetaryDistanceRate" value="-0.0002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0.0"/>
+        <param name="mode" value="taxi"/>
+        <param name="monetaryDistanceRate" value="-0.002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-4"/>
+        <param name="dailyMonetaryConstant" value="0"/>
+        <param name="dailyUtilityConstant" value="0.0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="-0.0015"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="0"/>
+        <param name="mode" value="bike"/>
+        <param name="monetaryDistanceRate" value="-0.0"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="-0.003"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="0"/>
+        <param name="mode" value="walk"/>
+        <param name="monetaryDistanceRate" value="0.0"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="pt"/>
+        <param name="constant" value="-10000.0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="0"/>
+        <param name="monetaryDistanceRate" value="-0.000"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="bus"/>
+        <param name="constant" value="-1"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="0"/>
+        <param name="monetaryDistanceRate" value="-0.00017"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="rail"/>
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.0002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="ferry"/>
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.001"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="subway"/>
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.0002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="tram"/>
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.0004"/>
+      </parameterset>
+    </parameterset>
+    <parameterset type="scoringParameters">
+      <param name="earlyDeparture" value="-0.0"/>
+      <param name="lateArrival" value="0"/>
+      <param name="marginalUtilityOfMoney" value="1"/>
+      <param name="performing" value="10"/>
+      <param name="subpopulation" value="ev_airport"/>
+      <param name="utilityOfLineSwitch" value="-0.5"/>
+      <param name="waiting" value="-0.0"/>
+      <param name="waitingPt" value="0"/>
+      <parameterset type="activityParams">
+        <param name="activityType" value="home"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="1:00:00"/>
+        <param name="typicalDuration" value="10:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="work"/>
+        <param name="openingTime" value="7:00:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="6:00:00"/>
+        <param name="typicalDuration" value="9:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="education"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="17:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="6:00:00"/>
+        <param name="typicalDuration" value="6:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="other"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:10:00"/>
+        <param name="typicalDuration" value="0:30:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="shop"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="0:30:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="visit"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="2:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="medical"/>
+        <param name="openingTime" value="09:00:00"/>
+        <param name="closingTime" value="18:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="1:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="business"/>
+        <param name="openingTime" value="07:30:00"/>
+        <param name="closingTime" value="20:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="0:30:00"/>
+        <param name="typicalDuration" value="1:00:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_home"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_work"/>
+        <param name="openingTime" value="7:00:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_business"/>
+        <param name="openingTime" value="7:00:00"/>
+        <param name="closingTime" value="19:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_education"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="17:00:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_other"/>
+        <param name="openingTime" value="undefined"/>
+        <param name="closingTime" value="undefined"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="activityParams">
+        <param name="activityType" value="escort_shop"/>
+        <param name="openingTime" value="08:30:00"/>
+        <param name="closingTime" value="17:30:00"/>
+        <param name="earliestEndTime" value="undefined"/>
+        <param name="latestStartTime" value="undefined"/>
+        <param name="minimalDuration" value="00:05:00"/>
+        <param name="typicalDuration" value="00:05:00"/>
+        <param name="priority" value="1.0"/>
+        <param name="scoringThisActivityAtAll" value="true"/>
+        <param name="typicalDurationScoreComputation" value="relative"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0.0"/>
+        <param name="mode" value="car"/>
+        <param name="monetaryDistanceRate" value="-5e-05"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0.0"/>
+        <param name="mode" value="car_passenger"/>
+        <param name="monetaryDistanceRate" value="-5e-05"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0.0"/>
+        <param name="mode" value="taxi"/>
+        <param name="monetaryDistanceRate" value="-0.002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="-4"/>
+        <param name="dailyMonetaryConstant" value="0"/>
+        <param name="dailyUtilityConstant" value="0.0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="-0.0015"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="0"/>
+        <param name="mode" value="bike"/>
+        <param name="monetaryDistanceRate" value="-0.0"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="-0.003"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="0"/>
+        <param name="mode" value="walk"/>
+        <param name="monetaryDistanceRate" value="0.0"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="pt"/>
+        <param name="constant" value="-10000.0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="0"/>
+        <param name="monetaryDistanceRate" value="-0.000"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="bus"/>
+        <param name="constant" value="-1"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="0"/>
+        <param name="monetaryDistanceRate" value="-0.00017"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="rail"/>
+        <param name="constant" value="-5"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.0002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="ferry"/>
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.001"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="subway"/>
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.0002"/>
+      </parameterset>
+      <parameterset type="modeParams">
+        <param name="mode" value="tram"/>
+        <param name="constant" value="0"/>
+        <param name="marginalUtilityOfDistance_util_m" value="0.0"/>
+        <param name="marginalUtilityOfTraveling_util_hr" value="-0"/>
+        <param name="monetaryDistanceRate" value="-0.0004"/>
+      </parameterset>
+    </parameterset>
+  </module>
+  <module name="strategy">
+    <param name="fractionOfIterationsToDisableInnovation" value="0.8"/>
+    <param name="maxAgentPlanMemorySize" value="5"/>
+    <param name="planSelectorForRemoval" value="WorstPlanSelector"/>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="ReRoute"/>
+      <param name="subpopulation" value="default"/>
+      <param name="weight" value="0.1"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="SubtourModeChoice"/>
+      <param name="subpopulation" value="default"/>
+      <param name="weight" value="0.1"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="TimeAllocationMutator_ReRoute"/>
+      <param name="subpopulation" value="default"/>
+      <param name="weight" value="0.1"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="ChangeExpBeta"/>
+      <param name="subpopulation" value="default"/>
+      <param name="weight" value="0.7"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="ReRoute"/>
+      <param name="subpopulation" value="low"/>
+      <param name="weight" value="0.1"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="SubtourModeChoice"/>
+      <param name="subpopulation" value="low"/>
+      <param name="weight" value="0.1"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="TimeAllocationMutator_ReRoute"/>
+      <param name="subpopulation" value="low"/>
+      <param name="weight" value="0.1"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="ChangeExpBeta"/>
+      <param name="subpopulation" value="low"/>
+      <param name="weight" value="0.7"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="ReRoute"/>
+      <param name="subpopulation" value="medium"/>
+      <param name="weight" value="0.1"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="SubtourModeChoice"/>
+      <param name="subpopulation" value="medium"/>
+      <param name="weight" value="0.1"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="TimeAllocationMutator_ReRoute"/>
+      <param name="subpopulation" value="medium"/>
+      <param name="weight" value="0.1"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="ChangeExpBeta"/>
+      <param name="subpopulation" value="medium"/>
+      <param name="weight" value="0.7"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="ReRoute"/>
+      <param name="subpopulation" value="high"/>
+      <param name="weight" value="0.1"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="SubtourModeChoice"/>
+      <param name="subpopulation" value="high"/>
+      <param name="weight" value="0.1"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="TimeAllocationMutator_ReRoute"/>
+      <param name="subpopulation" value="high"/>
+      <param name="weight" value="0.1"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="ChangeExpBeta"/>
+      <param name="subpopulation" value="high"/>
+      <param name="weight" value="0.7"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="ReRoute"/>
+      <param name="subpopulation" value="ev_low"/>
+      <param name="weight" value="0.1"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="SubtourModeChoice"/>
+      <param name="subpopulation" value="ev_low"/>
+      <param name="weight" value="0.1"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="TimeAllocationMutator_ReRoute"/>
+      <param name="subpopulation" value="ev_low"/>
+      <param name="weight" value="0.1"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="ChangeExpBeta"/>
+      <param name="subpopulation" value="ev_low"/>
+      <param name="weight" value="0.7"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="ReRoute"/>
+      <param name="subpopulation" value="ev_medium"/>
+      <param name="weight" value="0.1"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="SubtourModeChoice"/>
+      <param name="subpopulation" value="ev_medium"/>
+      <param name="weight" value="0.1"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="TimeAllocationMutator_ReRoute"/>
+      <param name="subpopulation" value="ev_medium"/>
+      <param name="weight" value="0.1"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="ChangeExpBeta"/>
+      <param name="subpopulation" value="ev_medium"/>
+      <param name="weight" value="0.7"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="ReRoute"/>
+      <param name="subpopulation" value="ev_high"/>
+      <param name="weight" value="0.1"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="SubtourModeChoice"/>
+      <param name="subpopulation" value="ev_high"/>
+      <param name="weight" value="0.1"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="TimeAllocationMutator_ReRoute"/>
+      <param name="subpopulation" value="ev_high"/>
+      <param name="weight" value="0.1"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="ChangeExpBeta"/>
+      <param name="subpopulation" value="ev_high"/>
+      <param name="weight" value="0.7"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="ReRoute"/>
+      <param name="subpopulation" value="lgv"/>
+      <param name="weight" value="0.1"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="TimeAllocationMutator_ReRoute"/>
+      <param name="subpopulation" value="lgv"/>
+      <param name="weight" value="0.2"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="ChangeExpBeta"/>
+      <param name="subpopulation" value="lgv"/>
+      <param name="weight" value="0.7"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="ReRoute"/>
+      <param name="subpopulation" value="lgv_ev"/>
+      <param name="weight" value="0.1"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="TimeAllocationMutator_ReRoute"/>
+      <param name="subpopulation" value="lgv_ev"/>
+      <param name="weight" value="0.2"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="ChangeExpBeta"/>
+      <param name="subpopulation" value="lgv_ev"/>
+      <param name="weight" value="0.7"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="ReRoute"/>
+      <param name="subpopulation" value="hgv"/>
+      <param name="weight" value="0.1"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="TimeAllocationMutator_ReRoute"/>
+      <param name="subpopulation" value="hgv"/>
+      <param name="weight" value="0.2"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="ChangeExpBeta"/>
+      <param name="subpopulation" value="hgv"/>
+      <param name="weight" value="0.7"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="ReRoute"/>
+      <param name="subpopulation" value="airport"/>
+      <param name="weight" value="0.1"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="SubtourModeChoice"/>
+      <param name="subpopulation" value="airport"/>
+      <param name="weight" value="0.1"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="TimeAllocationMutator_ReRoute"/>
+      <param name="subpopulation" value="airport"/>
+      <param name="weight" value="0.1"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="ChangeExpBeta"/>
+      <param name="subpopulation" value="airport"/>
+      <param name="weight" value="0.7"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="ReRoute"/>
+      <param name="subpopulation" value="ev_airport"/>
+      <param name="weight" value="0.1"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="SubtourModeChoice"/>
+      <param name="subpopulation" value="ev_airport"/>
+      <param name="weight" value="0.1"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="TimeAllocationMutator_ReRoute"/>
+      <param name="subpopulation" value="ev_airport"/>
+      <param name="weight" value="0.1"/>
+    </parameterset>
+    <parameterset type="strategysettings">
+      <param name="disableAfterIteration" value="-1"/>
+      <param name="executionPath" value="null"/>
+      <param name="strategyName" value="ChangeExpBeta"/>
+      <param name="subpopulation" value="ev_airport"/>
+      <param name="weight" value="0.7"/>
+    </parameterset>
+  </module>
+</config>

--- a/docs/cutting-scenarios-CML/python_scripts/add_car_bike_access_for_all_stop_facilities_transit_schedule.py
+++ b/docs/cutting-scenarios-CML/python_scripts/add_car_bike_access_for_all_stop_facilities_transit_schedule.py
@@ -1,0 +1,46 @@
+from lxml import etree
+
+def modify_xml(input_file, output_file):
+    """
+    A method to add car and bike access to all of the stop facilities for testing cutter
+    """
+    parser = etree.XMLParser(recover=True)
+    tree = etree.parse(input_file, parser)
+    root = tree.getroot()
+
+    for stop_facility in root.findall('.//stopFacility'):
+        attributes = stop_facility.find('attributes')
+        if attributes is None:
+            attributes = etree.SubElement(stop_facility, 'attributes')
+
+        bike_accessible = False
+        for attribute in attributes.findall('attribute'):
+            if attribute.get('name') == 'bikeAccessible':
+                bike_accessible = True
+                break
+        
+        if not bike_accessible:
+            etree.SubElement(attributes, 'attribute', {
+                'name': 'bikeAccessible',
+                'class': 'java.lang.String'
+            }).text = 'True'
+
+        car_accessible = False
+        for attribute in attributes.findall('attribute'):
+            if attribute.get('name') == 'carAccessible':
+                car_accessible = True
+                break
+        
+        if not car_accessible:
+            etree.SubElement(attributes, 'attribute', {
+                'name': 'carAccessible',
+                'class': 'java.lang.String'
+            }).text = 'True'
+
+    tree.write(output_file, encoding='utf-8', xml_declaration=True, pretty_print=True)
+
+# Specify the input and output file paths
+input_file = '/mnt/efs/analysis/ys/matsim_cutter/input_files_locations_facilities_10pc_20240807/output_transitSchedule.xml'
+output_file = '/mnt/efs/analysis/ys/matsim_cutter/input_files_locations_facilities_10pc_20240807/output_transitSchedule_add_true_car_bike_attribute_20240805.xml'  # Correctly update the path as needed
+
+modify_xml(input_file, output_file)

--- a/docs/cutting-scenarios-CML/python_scripts/network_connectivity_validation.py
+++ b/docs/cutting-scenarios-CML/python_scripts/network_connectivity_validation.py
@@ -1,0 +1,46 @@
+import networkx as nx
+import geopandas as gpd
+import matplotlib.pyplot as plt
+
+
+network_links =  gpd.read_file('/mnt/efs/analysis/ys/matsim_cutter/te-10pc-outputs-ignoring-errors/genet-vis/network_links.geojson')
+
+G_directed = nx.DiGraph()
+
+print("Adding {} network links to a directed graph...".format(len(network_links)))
+for _, row in network_links.iterrows():
+    G_directed.add_node(row['from'], pos=(row['geometry'].coords[0][0], row['geometry'].coords[0][1]))
+    G_directed.add_node(row['to'], pos=(row['geometry'].coords[-1][0], row['geometry'].coords[-1][1]))
+
+for _, row in network_links.iterrows():
+    G_directed.add_edge(row['from'], row['to'], modes=row['modes'], length=row['length'])
+
+G_undirected = G_directed.to_undirected()
+print(f"Converted directed graph to an undirected graph with {len(G_undirected.nodes())} nodes")
+
+is_strongly_connected = nx.is_strongly_connected(G_directed)
+print(f"Is the directed graph strongly connected? {is_strongly_connected}")
+
+# Find connected components
+connected_components = list(nx.connected_components(G_undirected))
+print(f"Number of connected components: {len(connected_components)}")
+
+# Visualize the components in the undirected graph
+component_colors = {}
+for i, component in enumerate(connected_components):
+    for node in component:
+        component_colors[node] = i
+
+node_colors = [component_colors[node] for node in G_undirected.nodes()]
+pos = nx.get_node_attributes(G_undirected, 'pos')
+
+plt.figure(figsize=(12, 8))
+nx.draw(G_undirected, pos, node_color=node_colors, node_size=10, edge_color='gray', cmap=plt.cm.tab20)
+plt.title('Network Components Visualization')
+plt.show()
+
+isolated_nodes = [node for node, degree in G_directed.degree() if degree == 0]
+print(f"Number of isolated nodes: {len(isolated_nodes)}")
+
+dead_end_nodes = [node for node, degree in G_directed.degree() if degree == 1]
+print(f"Number of dead-end nodes: {len(dead_end_nodes)}")

--- a/docs/cutting-scenarios-CML/python_scripts/remove_freight_subpop.py
+++ b/docs/cutting-scenarios-CML/python_scripts/remove_freight_subpop.py
@@ -1,0 +1,24 @@
+import xml.etree.ElementTree as ET
+import xml.dom.minidom as minidom
+
+# Load and parse the XML file
+tree = ET.parse('/mnt/efs/analysis/ys/matsim_cutter/output_no_intermodal_20240909_10pct/TE_cutter_population.xml')
+root = tree.getroot()
+
+# List of subpopulations to remove
+subpopulations_to_remove = ['hgv', 'lgv', 'lgv-ev']
+
+for person in root.findall('person'):
+    subpopulation = person.find(".//attribute[@name='subpopulation']")
+    if subpopulation is not None and subpopulation.text in subpopulations_to_remove:
+        root.remove(person)
+
+def prettify(elem):
+    rough_string = ET.tostring(elem, 'utf-8')
+    reparsed = minidom.parseString(rough_string)
+    return reparsed.toprettyxml(indent="  ")
+
+pretty_xml_as_string = prettify(root)
+
+with open('/mnt/efs/analysis/ys/matsim_cutter/output_no_intermodal_20240909_10pct/modified_remove_freight_TE_cutter_population_v1.xml', 'w') as f:
+    f.write(pretty_xml_as_string)


### PR DESCRIPTION
As discussed in the previous PR in the Magellan repo [here](https://github.com/arup-group/magellan/pull/5#issuecomment-2348571019),  I have moved all the relevant files to this repo for easier maintenance in the future.

This PR includes two key documentation files, some Python scripts used in the cutting process, and example MATSim config files to help users track the workflow:

1. `cutting-scenarios-Transport-East.md`: This is a general guide on how to run the cutter. It includes instructions on setting up and executing the cutter for the Transport East (TE) simulations.
2. `matsim-cutter-debug-notes.md`: This file contains detailed notes on how we debugged the cutter, including two remaining questions. It provides a reference for others to follow or troubleshoot as needed.

Additionally, I added some other files:
- The Python scripts included were used during the debugging process.
- The MATSim config examples are attached to demonstrate different stages of the cutting process.

All relevant files from the Magellan repo have been copied here. Feel free to delete the original PR,  and I assume we can continue working on this one.
