### PR TITLE
chore: update MATSim version

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -13,9 +13,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 17
+    - name: Set up JDK 21
       uses: actions/setup-java@v1
       with:
-        java-version: 17
+        java-version: 21
     - name: Build with Maven
       run: mvn test -B -Dmatsim.preferLocalDtds=true

--- a/core/src/main/java/org/eqasim/core/components/emissions/RunComputeEmissionsGrid.java
+++ b/core/src/main/java/org/eqasim/core/components/emissions/RunComputeEmissionsGrid.java
@@ -3,6 +3,7 @@ package org.eqasim.core.components.emissions;
 import org.apache.commons.lang3.ArrayUtils;
 import org.eqasim.core.misc.ClassUtils;
 import org.eqasim.core.simulation.EqasimConfigurator;
+import org.geotools.api.feature.simple.SimpleFeature;
 import org.locationtech.jts.geom.Geometry;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.contrib.emissions.analysis.EmissionGridAnalyzer;
@@ -14,7 +15,6 @@ import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.network.NetworkUtils;
 import org.matsim.core.network.io.MatsimNetworkReader;
 import org.matsim.core.utils.gis.ShapeFileReader;
-import org.opengis.feature.simple.SimpleFeature;
 
 public class RunComputeEmissionsGrid {
 

--- a/core/src/main/java/org/eqasim/core/components/emissions/RunExportEmissionsNetwork.java
+++ b/core/src/main/java/org/eqasim/core/components/emissions/RunExportEmissionsNetwork.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import org.apache.commons.lang3.ArrayUtils;
 import org.eqasim.core.misc.ClassUtils;
 import org.eqasim.core.simulation.EqasimConfigurator;
+import org.geotools.api.feature.simple.SimpleFeature;
 import org.locationtech.jts.geom.Coordinate;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
@@ -30,7 +31,6 @@ import org.matsim.core.network.io.MatsimNetworkReader;
 import org.matsim.core.utils.geometry.geotools.MGC;
 import org.matsim.core.utils.gis.PolylineFeatureFactory;
 import org.matsim.core.utils.gis.ShapeFileWriter;
-import org.opengis.feature.simple.SimpleFeature;
 
 public class RunExportEmissionsNetwork {
 

--- a/core/src/main/java/org/eqasim/core/scenario/RunInsertVehicles.java
+++ b/core/src/main/java/org/eqasim/core/scenario/RunInsertVehicles.java
@@ -14,11 +14,7 @@ import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.population.io.PopulationReader;
 import org.matsim.core.population.io.PopulationWriter;
 import org.matsim.core.scenario.ScenarioUtils;
-import org.matsim.vehicles.MatsimVehicleWriter;
-import org.matsim.vehicles.Vehicle;
-import org.matsim.vehicles.VehicleUtils;
-import org.matsim.vehicles.Vehicles;
-import org.matsim.vehicles.VehiclesFactory;
+import org.matsim.vehicles.*;
 
 public class RunInsertVehicles {
 
@@ -26,13 +22,14 @@ public class RunInsertVehicles {
 		Vehicles vehicles = scenario.getVehicles();
 		VehiclesFactory factory = vehicles.getFactory();
 
-		vehicles.addVehicleType(VehicleUtils.getDefaultVehicleType());
+		VehicleType vehicleType = VehicleUtils.createVehicleType(Id.create("defaultVehicleType", VehicleType.class));
+		vehicles.addVehicleType(vehicleType);
 		for (Person person : scenario.getPopulation().getPersons().values()) {
 			Map<String, Id<Vehicle>> personVehicles = new HashMap<>();
 
 			for (String mode : config.routing().getNetworkModes()) {
 				Vehicle vehicle = factory.createVehicle(Id.createVehicleId(person.getId().toString() + ":" + mode),
-						VehicleUtils.getDefaultVehicleType());
+						vehicleType);
 				vehicles.addVehicle(vehicle);
 
 				personVehicles.put(mode, vehicle.getId());

--- a/core/src/main/java/org/eqasim/core/scenario/SpatialUtils.java
+++ b/core/src/main/java/org/eqasim/core/scenario/SpatialUtils.java
@@ -6,15 +6,15 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 
-import org.geotools.data.DataStore;
-import org.geotools.data.DataStoreFinder;
+import org.geotools.api.data.DataStore;
+import org.geotools.api.data.DataStoreFinder;
+import org.geotools.api.data.SimpleFeatureSource;
+import org.geotools.api.feature.simple.SimpleFeature;
 import org.geotools.data.simple.SimpleFeatureCollection;
 import org.geotools.data.simple.SimpleFeatureIterator;
-import org.geotools.data.simple.SimpleFeatureSource;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.MultiPolygon;
 import org.locationtech.jts.geom.Polygon;
-import org.opengis.feature.simple.SimpleFeature;
 
 public class SpatialUtils {
 	static public Polygon loadPolygon(URL url, String attribute, String value) throws IOException {

--- a/core/src/main/java/org/eqasim/core/scenario/cutter/RunScenarioCutter.java
+++ b/core/src/main/java/org/eqasim/core/scenario/cutter/RunScenarioCutter.java
@@ -33,6 +33,7 @@ import org.eqasim.core.simulation.EqasimConfigurator;
 import org.eqasim.core.simulation.mode_choice.AbstractEqasimExtension;
 import org.eqasim.core.simulation.termination.EqasimTerminationModule;
 import org.matsim.api.core.v01.Scenario;
+import org.matsim.contribs.discrete_mode_choice.modules.DiscreteModeChoiceModule;
 import org.matsim.core.config.CommandLine;
 import org.matsim.core.config.CommandLine.ConfigurationException;
 import org.matsim.core.config.Config;
@@ -111,7 +112,7 @@ public class RunScenarioCutter {
 		// Cut population
 		Injector populationCutterInjector = new InjectorBuilder(scenario) //
 				.addOverridingModules(configurator.getModules().stream()
-						.filter(module -> !(module instanceof AbstractEqasimExtension)).toList()) //
+						.filter(module -> !(module instanceof AbstractEqasimExtension) && !(module instanceof DiscreteModeChoiceModule)).toList()) //
 				.addOverridingModule(
 						new PopulationCutterModule(extent, numberOfThreads, 40, cmd.getOption("events-path"))) //
 				.addOverridingModule(new CutterTravelTimeModule(travelTime)) //
@@ -169,7 +170,7 @@ public class RunScenarioCutter {
 		// Final routing
 		Injector routingInjector = new InjectorBuilder(scenario) //
 				.addOverridingModules(configurator.getModules().stream()
-						.filter(module -> !(module instanceof AbstractEqasimExtension)).toList()) //
+						.filter(module -> !(module instanceof AbstractEqasimExtension) && !(module instanceof DiscreteModeChoiceModule)).toList()) //
 				.addOverridingModule(new PopulationRouterModule(numberOfThreads, 100, false)) //
 				.addOverridingModule(new CutterTravelTimeModule(travelTime)) //
 				.addOverridingModule(new TimeInterpretationModule()) //

--- a/core/src/main/java/org/eqasim/core/scenario/cutter/extent/ShapeScenarioExtent.java
+++ b/core/src/main/java/org/eqasim/core/scenario/cutter/extent/ShapeScenarioExtent.java
@@ -9,12 +9,13 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
 
-import org.geotools.data.DataStore;
-import org.geotools.data.DataStoreFinder;
+import org.geotools.api.data.DataStore;
+import org.geotools.api.data.DataStoreFinder;
+import org.geotools.api.data.SimpleFeatureReader;
+import org.geotools.api.data.SimpleFeatureSource;
+import org.geotools.api.feature.simple.SimpleFeature;
 import org.geotools.data.simple.SimpleFeatureCollection;
 import org.geotools.data.simple.SimpleFeatureIterator;
-import org.geotools.data.simple.SimpleFeatureReader;
-import org.geotools.data.simple.SimpleFeatureSource;
 import org.geotools.geopkg.FeatureEntry;
 import org.geotools.geopkg.GeoPackage;
 import org.locationtech.jts.geom.Coordinate;
@@ -25,7 +26,6 @@ import org.locationtech.jts.geom.MultiPolygon;
 import org.locationtech.jts.geom.Point;
 import org.locationtech.jts.geom.Polygon;
 import org.matsim.api.core.v01.Coord;
-import org.opengis.feature.simple.SimpleFeature;
 
 public class ShapeScenarioExtent implements ScenarioExtent {
 	private final GeometryFactory factory = new GeometryFactory();

--- a/core/src/main/java/org/eqasim/core/simulation/modes/drt/utils/AdaptConfigForDrt.java
+++ b/core/src/main/java/org/eqasim/core/simulation/modes/drt/utils/AdaptConfigForDrt.java
@@ -1,14 +1,11 @@
 package org.eqasim.core.simulation.modes.drt.utils;
 
-import java.io.File;
 import java.net.MalformedURLException;
 import java.nio.file.Path;
 import java.util.*;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.DoubleStream;
 import java.util.stream.IntStream;
-import java.util.stream.Stream;
 
 import org.eqasim.core.components.config.EqasimConfigGroup;
 import org.eqasim.core.misc.ClassUtils;
@@ -17,9 +14,6 @@ import org.eqasim.core.simulation.mode_choice.EqasimModeChoiceModule;
 import org.eqasim.core.simulation.mode_choice.constraints.leg_time.LegTimeConstraintConfigGroup;
 import org.eqasim.core.simulation.mode_choice.constraints.leg_time.LegTimeConstraintModule;
 import org.eqasim.core.simulation.mode_choice.constraints.leg_time.LegTimeConstraintSingleLegConfigGroup;
-import org.matsim.contrib.common.zones.ZoneSystem;
-import org.matsim.contrib.common.zones.ZoneSystemParams;
-import org.matsim.contrib.common.zones.systems.grid.square.SquareGridZoneSystem;
 import org.matsim.contrib.common.zones.systems.grid.square.SquareGridZoneSystemParams;
 import org.matsim.contrib.drt.analysis.zonal.DrtZoneSystemParams;
 import org.matsim.contrib.drt.optimizer.constraints.DefaultDrtOptimizationConstraintsSet;
@@ -34,7 +28,6 @@ import org.matsim.contrib.dvrp.fleet.FleetReader;
 import org.matsim.contrib.dvrp.fleet.FleetSpecification;
 import org.matsim.contrib.dvrp.fleet.FleetSpecificationImpl;
 import org.matsim.contrib.dvrp.run.DvrpConfigGroup;
-import org.matsim.contrib.zone.ZonalSystemParams;
 import org.matsim.contribs.discrete_mode_choice.modules.config.DiscreteModeChoiceConfigGroup;
 import org.matsim.core.config.CommandLine;
 import org.matsim.core.config.Config;
@@ -46,13 +39,8 @@ import org.matsim.core.utils.misc.Time;
 
 public class AdaptConfigForDrt {
 
-    public static void adapt(Config config, Map<String, String> vehiclesPathByDrtMode, Map<String, String> operationalSchemes, Map<String, String> drtUtilityEstimators, Map<String, String> drtCostModels, Map<String, String> addLegTimeConstraint, String qsimEndtime, String modeAvailability) throws MalformedURLException {
+    public static void adapt(Config config, Map<String, String> vehiclesPathByDrtMode, Map<String, String> operationalSchemes, Map<String, String> drtUtilityEstimators, Map<String, String> drtCostModels, Map<String, String> addLegTimeConstraint, String qsimEndtime, String modeAvailability) {
         if(!config.getModules().containsKey(DvrpConfigGroup.GROUP_NAME)) {
-            //DvrpConfigGroup dvrpConfigGroup = new DvrpConfigGroup();
-            //SquareGridZoneSystemParams squareGridZoneSystemParams = new SquareGridZoneSystemParams();
-            //squareGridZoneSystemParams.cellSize = 200;
-            //dvrpConfigGroup.getTravelTimeMatrixParams().addParameterSet(squareGridZoneSystemParams);
-
             config.addModule(new DvrpConfigGroup());
         }
         if(!config.getModules().containsKey(MultiModeDrtConfigGroup.GROUP_NAME)) {
@@ -87,7 +75,7 @@ public class AdaptConfigForDrt {
             drtConfigGroup.vehiclesFile  = vehiclesPathByDrtMode.get(drtMode);
 
             DrtInsertionSearchParams searchParams = new ExtensiveInsertionSearchParams();
-            drtConfigGroup.addDrtInsertionSearchParams(searchParams);
+            drtConfigGroup.setDrtInsertionSearchParams(searchParams);
 
             RebalancingParams rebalancingParams = new RebalancingParams();
             rebalancingParams.interval  =1800;
@@ -159,7 +147,7 @@ public class AdaptConfigForDrt {
             Map<String, String> resultingMap;
 
             if(drtModeNames.length == currentElements.length) {
-                resultingMap = IntStream.range(0, drtModeNames.length).boxed().collect(Collectors.toMap(integer -> drtModeNames[integer], (Function<Integer, String>) integer -> currentElements[integer]));
+                resultingMap = IntStream.range(0, drtModeNames.length).boxed().collect(Collectors.toMap(integer -> drtModeNames[integer], integer -> currentElements[integer]));
             } else {
                 if(currentElements.length != 1) {
                     throw new IllegalStateException(String.format("When the number of provided drt mode names is not equal to the number of provided %s," +

--- a/core/src/main/java/org/eqasim/core/simulation/modes/feeder_drt/config/AccessEgressStopSelectorParams.java
+++ b/core/src/main/java/org/eqasim/core/simulation/modes/feeder_drt/config/AccessEgressStopSelectorParams.java
@@ -2,7 +2,7 @@ package org.eqasim.core.simulation.modes.feeder_drt.config;
 
 import jakarta.validation.constraints.NotNull;
 import org.eqasim.core.simulation.modes.feeder_drt.router.access_egress_selector.ClosestAccessEgressStopSelectorParameterSet;
-import org.matsim.contrib.util.ReflectiveConfigGroupWithConfigurableParameterSets;
+import org.matsim.contrib.common.util.ReflectiveConfigGroupWithConfigurableParameterSets;
 import org.matsim.core.config.ReflectiveConfigGroup;
 
 public class AccessEgressStopSelectorParams extends ReflectiveConfigGroupWithConfigurableParameterSets {

--- a/core/src/main/java/org/eqasim/core/simulation/modes/feeder_drt/config/FeederDrtConfigGroup.java
+++ b/core/src/main/java/org/eqasim/core/simulation/modes/feeder_drt/config/FeederDrtConfigGroup.java
@@ -2,8 +2,8 @@ package org.eqasim.core.simulation.modes.feeder_drt.config;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import org.matsim.contrib.common.util.ReflectiveConfigGroupWithConfigurableParameterSets;
 import org.matsim.contrib.dvrp.run.Modal;
-import org.matsim.contrib.util.ReflectiveConfigGroupWithConfigurableParameterSets;
 
 public class FeederDrtConfigGroup extends ReflectiveConfigGroupWithConfigurableParameterSets implements Modal {
     public static final String GROUP_NAME = "feederDrt";

--- a/core/src/main/java/org/eqasim/core/simulation/modes/transit_with_abstract_access/utils/ExportAbstractAccessItemsToShapefile.java
+++ b/core/src/main/java/org/eqasim/core/simulation/modes/transit_with_abstract_access/utils/ExportAbstractAccessItemsToShapefile.java
@@ -3,6 +3,7 @@ package org.eqasim.core.simulation.modes.transit_with_abstract_access.utils;
 
 import org.eqasim.core.simulation.modes.transit_with_abstract_access.abstract_access.AbstractAccessItem;
 import org.eqasim.core.simulation.modes.transit_with_abstract_access.abstract_access.AbstractAccessesFileReader;
+import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
 import org.matsim.api.core.v01.Scenario;
 import org.matsim.core.config.CommandLine;
 import org.matsim.core.config.Config;
@@ -12,8 +13,7 @@ import org.matsim.core.utils.geometry.geotools.MGC;
 import org.matsim.core.utils.gis.PointFeatureFactory;
 import org.matsim.core.utils.gis.ShapeFileWriter;
 import org.matsim.pt.transitSchedule.api.TransitScheduleReader;
-import org.opengis.feature.simple.SimpleFeature;
-import org.opengis.referencing.crs.CoordinateReferenceSystem;
+import org.geotools.api.feature.simple.SimpleFeature;
 
 import java.util.Collection;
 import java.util.LinkedList;

--- a/core/src/main/java/org/eqasim/core/tools/ExportActivitiesToShapefile.java
+++ b/core/src/main/java/org/eqasim/core/tools/ExportActivitiesToShapefile.java
@@ -1,5 +1,6 @@
 package org.eqasim.core.tools;
 
+import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
 import org.locationtech.jts.geom.Coordinate;
 import org.matsim.api.core.v01.Scenario;
 import org.matsim.api.core.v01.population.Activity;
@@ -13,8 +14,7 @@ import org.matsim.core.scenario.ScenarioUtils;
 import org.matsim.core.utils.geometry.geotools.MGC;
 import org.matsim.core.utils.gis.PointFeatureFactory;
 import org.matsim.core.utils.gis.ShapeFileWriter;
-import org.opengis.feature.simple.SimpleFeature;
-import org.opengis.referencing.crs.CoordinateReferenceSystem;
+import org.geotools.api.feature.simple.SimpleFeature;
 
 import java.util.*;
 import java.util.stream.Collectors;

--- a/core/src/main/java/org/eqasim/core/tools/ExportNetworkRoutesToGeopackage.java
+++ b/core/src/main/java/org/eqasim/core/tools/ExportNetworkRoutesToGeopackage.java
@@ -2,6 +2,7 @@ package org.eqasim.core.tools;
 
 import org.eqasim.core.misc.ClassUtils;
 import org.eqasim.core.simulation.EqasimConfigurator;
+import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
 import org.geotools.feature.DefaultFeatureCollection;
 import org.geotools.feature.simple.SimpleFeatureBuilder;
 import org.geotools.feature.simple.SimpleFeatureTypeBuilder;
@@ -25,9 +26,8 @@ import org.matsim.core.population.routes.NetworkRoute;
 import org.matsim.core.router.TripStructureUtils;
 import org.matsim.core.scenario.ScenarioUtils;
 import org.matsim.core.utils.geometry.geotools.MGC;
-import org.opengis.feature.simple.SimpleFeature;
-import org.opengis.feature.simple.SimpleFeatureType;
-import org.opengis.referencing.crs.CoordinateReferenceSystem;
+import org.geotools.api.feature.simple.SimpleFeature;
+import org.geotools.api.feature.simple.SimpleFeatureType;
 
 import java.io.File;
 import java.io.IOException;

--- a/core/src/main/java/org/eqasim/core/tools/ExportNetworkToGeopackage.java
+++ b/core/src/main/java/org/eqasim/core/tools/ExportNetworkToGeopackage.java
@@ -6,6 +6,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.LinkedList;
 
+import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
 import org.geotools.feature.DefaultFeatureCollection;
 import org.geotools.feature.simple.SimpleFeatureBuilder;
 import org.geotools.feature.simple.SimpleFeatureTypeBuilder;
@@ -20,9 +21,8 @@ import org.matsim.core.config.CommandLine;
 import org.matsim.core.network.NetworkUtils;
 import org.matsim.core.network.io.MatsimNetworkReader;
 import org.matsim.core.utils.geometry.geotools.MGC;
-import org.opengis.feature.simple.SimpleFeature;
-import org.opengis.feature.simple.SimpleFeatureType;
-import org.opengis.referencing.crs.CoordinateReferenceSystem;
+import org.geotools.api.feature.simple.SimpleFeature;
+import org.geotools.api.feature.simple.SimpleFeatureType;
 
 public class ExportNetworkToGeopackage {
 	public static void main(String[] args) throws Exception {

--- a/core/src/main/java/org/eqasim/core/tools/ExportNetworkToShapefile.java
+++ b/core/src/main/java/org/eqasim/core/tools/ExportNetworkToShapefile.java
@@ -5,6 +5,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.LinkedList;
 
+import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
 import org.locationtech.jts.geom.Coordinate;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
@@ -14,8 +15,7 @@ import org.matsim.core.network.io.MatsimNetworkReader;
 import org.matsim.core.utils.geometry.geotools.MGC;
 import org.matsim.core.utils.gis.PolylineFeatureFactory;
 import org.matsim.core.utils.gis.ShapeFileWriter;
-import org.opengis.feature.simple.SimpleFeature;
-import org.opengis.referencing.crs.CoordinateReferenceSystem;
+import org.geotools.api.feature.simple.SimpleFeature;
 
 public class ExportNetworkToShapefile {
 	public static void main(String[] args) throws Exception {

--- a/core/src/main/java/org/eqasim/core/tools/ExportTransitLinesToShapefile.java
+++ b/core/src/main/java/org/eqasim/core/tools/ExportTransitLinesToShapefile.java
@@ -4,6 +4,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.BooleanUtils;
+import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
 import org.locationtech.jts.geom.Coordinate;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.IdSet;
@@ -22,8 +23,7 @@ import org.matsim.core.utils.gis.ShapeFileWriter;
 import org.matsim.pt.transitSchedule.api.TransitLine;
 import org.matsim.pt.transitSchedule.api.TransitRoute;
 import org.matsim.pt.transitSchedule.api.TransitScheduleReader;
-import org.opengis.feature.simple.SimpleFeature;
-import org.opengis.referencing.crs.CoordinateReferenceSystem;
+import org.geotools.api.feature.simple.SimpleFeature;
 
 public class ExportTransitLinesToShapefile {
 	public static void main(String[] args) throws Exception {

--- a/core/src/main/java/org/eqasim/core/tools/ExportTransitStopsToShapefile.java
+++ b/core/src/main/java/org/eqasim/core/tools/ExportTransitStopsToShapefile.java
@@ -3,6 +3,7 @@ package org.eqasim.core.tools;
 import java.util.Collection;
 import java.util.LinkedList;
 
+import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
 import org.locationtech.jts.geom.Coordinate;
 import org.matsim.api.core.v01.Scenario;
 import org.matsim.core.config.CommandLine;
@@ -14,8 +15,7 @@ import org.matsim.core.utils.gis.PointFeatureFactory;
 import org.matsim.core.utils.gis.ShapeFileWriter;
 import org.matsim.pt.transitSchedule.api.TransitScheduleReader;
 import org.matsim.pt.transitSchedule.api.TransitStopFacility;
-import org.opengis.feature.simple.SimpleFeature;
-import org.opengis.referencing.crs.CoordinateReferenceSystem;
+import org.geotools.api.feature.simple.SimpleFeature;
 
 public class ExportTransitStopsToShapefile {
 	public static void main(String[] args) throws Exception {

--- a/core/src/test/java/org/eqasim/TestEmissions.java
+++ b/core/src/test/java/org/eqasim/TestEmissions.java
@@ -69,7 +69,7 @@ import org.matsim.vehicles.Vehicle;
 import org.matsim.vehicles.VehicleType;
 import org.matsim.vehicles.VehicleUtils;
 import org.matsim.vehicles.Vehicles;
-import org.opengis.feature.simple.SimpleFeature;
+import org.geotools.api.feature.simple.SimpleFeature;
 
 public class TestEmissions {
 

--- a/core/src/test/java/org/eqasim/mode_choice/TestSpecialModeChoiceCases.java
+++ b/core/src/test/java/org/eqasim/mode_choice/TestSpecialModeChoiceCases.java
@@ -3,6 +3,8 @@ package org.eqasim.mode_choice;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.io.File;
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -13,6 +15,7 @@ import java.util.Random;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.apache.commons.io.FileUtils;
 import org.eqasim.core.components.config.EqasimConfigGroup;
 import org.eqasim.core.components.raptor.EqasimRaptorConfigGroup;
 import org.eqasim.core.misc.InjectorBuilder;
@@ -21,6 +24,7 @@ import org.eqasim.core.simulation.EqasimConfigurator;
 import org.eqasim.core.simulation.mode_choice.EqasimModeChoiceModule;
 import org.eqasim.core.simulation.mode_choice.parameters.ModeParameters;
 import org.eqasim.core.simulation.termination.EqasimTerminationModule;
+import org.junit.After;
 import org.junit.Test;
 import org.matsim.api.core.v01.Coord;
 import org.matsim.api.core.v01.Id;
@@ -42,6 +46,8 @@ import org.matsim.core.config.CommandLine;
 import org.matsim.core.config.CommandLine.ConfigurationException;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigUtils;
+import org.matsim.core.controler.AbstractModule;
+import org.matsim.core.controler.OutputDirectoryHierarchy;
 import org.matsim.core.population.PopulationUtils;
 import org.matsim.core.router.RoutingModule;
 import org.matsim.core.router.RoutingRequest;
@@ -54,6 +60,11 @@ import com.google.inject.Injector;
 import com.google.inject.Singleton;
 
 public class TestSpecialModeChoiceCases {
+	@After
+	public void tearDown() throws IOException {
+		FileUtils.deleteDirectory(new File("simulation_output"));
+	}
+
 	@Test
 	public void testOrdinaryTour() throws ConfigurationException, NoFeasibleChoiceException {
 		List<DiscreteModeChoiceTrip> trips = new LinkedList<>();
@@ -171,6 +182,12 @@ public class TestSpecialModeChoiceCases {
 				.addOverridingModule(new EqasimModeChoiceModule()) //
 				.addOverridingModule(new StaticModeAvailabilityModule()) //
 				.addOverridingModule(new TimeInterpretationModule()) //
+				.addOverridingModule(new AbstractModule() {
+					@Override
+					public void install() {
+						bind(OutputDirectoryHierarchy.class).toInstance(new OutputDirectoryHierarchy(scenario.getConfig()));
+					}
+				})
 				.build();
 
 		DiscreteModeChoiceModel model = injector.getInstance(DiscreteModeChoiceModel.class);

--- a/examples/src/main/java/org/eqasim/examples/corsica_drt/RunCorsicaDrtSimulation.java
+++ b/examples/src/main/java/org/eqasim/examples/corsica_drt/RunCorsicaDrtSimulation.java
@@ -16,6 +16,7 @@ import org.eqasim.examples.corsica_drt.rejections.RejectionModule;
 import org.eqasim.ile_de_france.IDFConfigurator;
 import org.eqasim.ile_de_france.mode_choice.IDFModeChoiceModule;
 import org.matsim.api.core.v01.Scenario;
+import org.matsim.contrib.drt.optimizer.constraints.DefaultDrtOptimizationConstraintsSet;
 import org.matsim.contrib.drt.optimizer.insertion.DrtInsertionSearchParams;
 import org.matsim.contrib.drt.optimizer.insertion.selective.SelectiveInsertionSearchParams;
 import org.matsim.contrib.drt.routing.DrtRoute;
@@ -75,13 +76,15 @@ public class RunCorsicaDrtSimulation {
 			drtConfig.mode = "drt";
 			drtConfig.operationalScheme = OperationalScheme.door2door;
 			drtConfig.stopDuration = 15.0;
-			drtConfig.maxWaitTime = 3600.0;
-			drtConfig.maxTravelTimeAlpha = 3.0;
-			drtConfig.maxTravelTimeBeta = 3600.0;
+			DefaultDrtOptimizationConstraintsSet defaultDrtOptimizationConstraintsSet = new DefaultDrtOptimizationConstraintsSet();
+			defaultDrtOptimizationConstraintsSet.maxWaitTime = 3600;
+			defaultDrtOptimizationConstraintsSet.maxTravelTimeAlpha = 3;
+			defaultDrtOptimizationConstraintsSet.maxTravelTimeBeta = 3600;
+			drtConfig.addOrGetDrtOptimizationConstraintsParams().addParameterSet(defaultDrtOptimizationConstraintsSet);
 			drtConfig.vehiclesFile = Resources.getResource("corsica_drt/drt_vehicles.xml").toString();
 
 			DrtInsertionSearchParams searchParams = new SelectiveInsertionSearchParams();
-			drtConfig.addDrtInsertionSearchParams(searchParams);
+			drtConfig.setDrtInsertionSearchParams(searchParams);
 
 			multiModeDrtConfig.addParameterSet(drtConfig);
 			DrtConfigs.adjustMultiModeDrtConfig(multiModeDrtConfig, config.scoring(), config.routing());

--- a/los_angeles/src/main/java/org/eqasim/los_angeles/preparation/LATract.java
+++ b/los_angeles/src/main/java/org/eqasim/los_angeles/preparation/LATract.java
@@ -7,17 +7,17 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.geotools.data.DataStore;
-import org.geotools.data.DataStoreFinder;
+import org.geotools.api.data.DataStore;
+import org.geotools.api.data.DataStoreFinder;
 import org.geotools.data.simple.SimpleFeatureCollection;
 import org.geotools.data.simple.SimpleFeatureIterator;
-import org.geotools.data.simple.SimpleFeatureSource;
+import org.geotools.api.data.SimpleFeatureSource;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.Point;
 import org.matsim.api.core.v01.Coord;
-import org.opengis.feature.simple.SimpleFeature;
+import org.geotools.api.feature.simple.SimpleFeature;
 
 public class LATract {
 	private final static GeometryFactory factory = new GeometryFactory();

--- a/pom.xml
+++ b/pom.xml
@@ -20,9 +20,9 @@
 	</modules>
 
 	<properties>
-		<maven.compiler.source>17</maven.compiler.source>
-		<maven.compiler.target>17</maven.compiler.target>
-		<matsim.version>2025.0-PR3223</matsim.version>
+		<maven.compiler.source>21</maven.compiler.source>
+		<maven.compiler.target>21</maven.compiler.target>
+		<matsim.version>2025.0-PR3483</matsim.version>
 	</properties>
 
 	<distributionManagement>
@@ -48,7 +48,7 @@
 		<dependency>
 			<groupId>org.geotools</groupId>
 			<artifactId>gt-geopkg</artifactId>
-			<version>29.0</version>
+			<version>31.3</version>
 		</dependency>
 
 		<dependency>
@@ -79,7 +79,7 @@
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>2.7</version>
+			<version>2.16.1</version>
 		</dependency>
 
 		<dependency>
@@ -136,6 +136,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-source-plugin</artifactId>
+				<version>3.2.1</version>
 				<executions>
 					<execution>
 						<id>attach-sources</id>

--- a/san_francisco/src/main/java/org/eqasim/san_francisco/preparation/SFTract.java
+++ b/san_francisco/src/main/java/org/eqasim/san_francisco/preparation/SFTract.java
@@ -7,17 +7,17 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.geotools.data.DataStore;
-import org.geotools.data.DataStoreFinder;
+import org.geotools.api.data.DataStore;
+import org.geotools.api.data.DataStoreFinder;
 import org.geotools.data.simple.SimpleFeatureCollection;
 import org.geotools.data.simple.SimpleFeatureIterator;
-import org.geotools.data.simple.SimpleFeatureSource;
+import org.geotools.api.data.SimpleFeatureSource;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.Point;
 import org.matsim.api.core.v01.Coord;
-import org.opengis.feature.simple.SimpleFeature;
+import org.geotools.api.feature.simple.SimpleFeature;
 
 public class SFTract {
 	private final static GeometryFactory factory = new GeometryFactory();

--- a/sao_paulo/src/main/java/org/eqasim/sao_paulo/preparation/SPTract.java
+++ b/sao_paulo/src/main/java/org/eqasim/sao_paulo/preparation/SPTract.java
@@ -7,17 +7,17 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.geotools.data.DataStore;
-import org.geotools.data.DataStoreFinder;
+import org.geotools.api.data.DataStore;
+import org.geotools.api.data.DataStoreFinder;
 import org.geotools.data.simple.SimpleFeatureCollection;
 import org.geotools.data.simple.SimpleFeatureIterator;
-import org.geotools.data.simple.SimpleFeatureSource;
+import org.geotools.api.data.SimpleFeatureSource;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.Point;
 import org.matsim.api.core.v01.Coord;
-import org.opengis.feature.simple.SimpleFeature;
+import org.geotools.api.feature.simple.SimpleFeature;
 
 public class SPTract {
 	private final static GeometryFactory factory = new GeometryFactory();


### PR DESCRIPTION
This PR updates eqasim-java to use a more recent version of MATSim. 

A big change here is the update of the java version used in the MATSim repo (now 21) as well as the versions of geotools and commons-io that are used in MATSim. All of these are applied now in Eqasim.

Then, with the new feature implemented in the discrete_mode_choice contrib allowing to write, as an output, the utilities computed by the DMC model, the DiscreteModeChoiceModule now adds a handler that requires an OutputDirectoryHierarchy object. In The scenario cutter, since we do not have such an object, we make sure to filter the modules of the configurator and avoid adding a DiscreteModeChoiceModule.

