### PR TITLE
RunStandaloneModeChoice can now use travel times recorded by VDF

### DIFF
--- a/core/src/main/java/org/eqasim/core/standalone_mode_choice/RunStandaloneModeChoice.java
+++ b/core/src/main/java/org/eqasim/core/standalone_mode_choice/RunStandaloneModeChoice.java
@@ -15,6 +15,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.eqasim.core.analysis.DistanceUnit;
 import org.eqasim.core.analysis.PersonAnalysisFilter;
 import org.eqasim.core.analysis.pt.PublicTransportLegItem;
@@ -26,10 +28,11 @@ import org.eqasim.core.analysis.trips.TripWriter;
 import org.eqasim.core.components.travel_time.RecordedTravelTime;
 import org.eqasim.core.misc.ClassUtils;
 import org.eqasim.core.misc.InjectorBuilder;
-import org.eqasim.core.scenario.routing.RunPopulationRouting;
 import org.eqasim.core.scenario.validation.ScenarioValidator;
 import org.eqasim.core.scenario.validation.VehiclesValidator;
 import org.eqasim.core.simulation.EqasimConfigurator;
+import org.eqasim.core.simulation.vdf.VDFConfigGroup;
+import org.eqasim.core.simulation.vdf.VDFUpdateListener;
 import org.matsim.api.core.v01.Scenario;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.population.Person;
@@ -46,10 +49,8 @@ import org.matsim.core.trafficmonitoring.FreeSpeedTravelTime;
 import org.matsim.pt.transitSchedule.api.TransitSchedule;
 import org.matsim.vehicles.Vehicle;
 
-import com.google.inject.Key;
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
-import com.google.inject.name.Names;
 
 /**
  * This class offers the functionality of running the discrete mode choice model on the whole population without having to go through the whole iterative MATSim process. It is also possible to filter-out the persons that do not have a valid alternative.
@@ -130,6 +131,8 @@ public class RunStandaloneModeChoice {
         }
     }
 
+
+    private static final Logger logger = LogManager.getLogger(RunStandaloneModeChoice.class);
 
     public static final String CMD_WRITE_INPUT_CSV = "write-input-csv-trips";
     public static final String CMD_WRITE_OUTPUT_CSV = "write-output-csv-trips";
@@ -224,6 +227,16 @@ public class RunStandaloneModeChoice {
             }
         }));
 
+        boolean usingVdfTravelTime = false;
+        if(config.getModules().containsKey(VDFConfigGroup.GROUP_NAME) && VDFConfigGroup.getOrCreate(config).getInputFile() != null) {
+            String usedTravelTimeArg = recordedTravelTimesPath.isPresent() ? CMD_RECORDED_TRAVEL_TIMES_PATH : travelTimesFactorsPath.isPresent() ? CMD_TRAVEL_TIMES_FACTORS_PATH : null;
+            if(usedTravelTimeArg == null) {
+                usingVdfTravelTime = true;
+            } else {
+                logger.warn(String.format("Using '%s', the input file for the '%s' config group will not be considered", usedTravelTimeArg, VDFConfigGroup.GROUP_NAME));
+            }
+        }
+
         com.google.inject.Injector injector = injectorBuilder.build();
 
 
@@ -239,6 +252,11 @@ public class RunStandaloneModeChoice {
                 writePtLegsCsv(population, outputDirectoryHierarchy.getOutputFilename("input_pt_legs.csv"), ptLegReader);
             }
         });
+
+        if(usingVdfTravelTime) {
+            VDFUpdateListener vdfUpdateListener = injector.getInstance(VDFUpdateListener.class);
+            vdfUpdateListener.notifyStartup(null);
+        }
 
         StandaloneModeChoicePerformer modeChoicePerformer = injector.getInstance(StandaloneModeChoicePerformer.class);
 

--- a/core/src/main/java/org/eqasim/core/standalone_mode_choice/StandaloneModeChoiceConfigurator.java
+++ b/core/src/main/java/org/eqasim/core/standalone_mode_choice/StandaloneModeChoiceConfigurator.java
@@ -4,6 +4,8 @@ import org.eqasim.core.analysis.DefaultPersonAnalysisFilter;
 import org.eqasim.core.analysis.PersonAnalysisFilter;
 import org.eqasim.core.simulation.EqasimConfigurator;
 import org.eqasim.core.simulation.termination.EqasimTerminationModule;
+import org.eqasim.core.simulation.vdf.VDFConfigGroup;
+import org.eqasim.core.simulation.vdf.VDFModule;
 import org.matsim.core.config.CommandLine;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigGroup;
@@ -27,6 +29,8 @@ public class StandaloneModeChoiceConfigurator {
         this.config = config;
         this.commandLine = commandLine;
         this.optionalModules = new LinkedHashMap<>();
+
+        this.registerOptionalModule(new VDFConfigGroup(), new VDFModule());
     }
 
     public Config getConfig() {

--- a/core/src/test/java/org/eqasim/TestSimulationPipeline.java
+++ b/core/src/test/java/org/eqasim/TestSimulationPipeline.java
@@ -369,7 +369,7 @@ public class TestSimulationPipeline {
         runMelunSimulation("melun_test/input/config_abstract_access.xml", "melun_test/output_abstract_access");
     }
 
-    public void runVdf() throws CommandLine.ConfigurationException, IOException {
+    public void runVdf() throws CommandLine.ConfigurationException, IOException, InterruptedException {
         AdaptConfigForVDF.main(new String[] {
                 "--input-config-path", "melun_test/input/config.xml",
                 "--output-config-path", "melun_test/input/config_vdf.xml",
@@ -379,6 +379,14 @@ public class TestSimulationPipeline {
         });
 
         runMelunSimulation("melun_test/input/config_vdf.xml", "melun_test/output_vdf");
+
+        RunStandaloneModeChoice.main(new String[]{
+                "--config-path", "melun_test/input/config_vdf.xml",
+                "--config:standaloneModeChoice.outputDirectory", "melun_test/output_mode_choice_vdf",
+                "--config:eqasim:vdf.inputFile", "../output_vdf/vdf.bin", // Relative to the config file
+                "--mode-choice-configurator-class", TestModeChoiceConfigurator.class.getName(),
+                "--simulate-after", TestRunSimulation.class.getName()
+        });
 
         CreateDrtVehicles.main(new String[]{
                 "--network-path", "melun_test/input/network.xml.gz",

--- a/docs/standalone_mode_choice.md
+++ b/docs/standalone_mode_choice.md
@@ -27,4 +27,9 @@ More parameters can be supplied via the command line:
 In order to fully use it in your own use case, you need to implement a class extending the `StandaloneModeChoiceModule` class, your extension must have a constructor that matches the signature of the constructor present in the base class (taking a `Config` and a `CommandLine` as parameters). 
 Then, override the `getSpecificModeChoiceModules` to return the modules necessary to configure the mode choice model only.
 
+**Note: Using travel times recorded by the VDFModule**
+
+If your scenario has been simulated before using the VDF functionality and want to use the travel times recorded by the VDFModule (usually in a vdf.bin file), you need to call the `RunStandaloneModeCHoice` with a config file where the `eqasim:vdf` module is configured with the `inputFile` pointing to the file you want to use. Moreover, you must not pass `travel-times-factors-path` or `recorded-travel-times-path` arguments.
+
+
 For more details, you can check how this functionality is used in `org.eqasim.TestSimulationPipeline#TestPipeline()` and in `org.eqasim.ile_de_france.TestCorisica#testCorsicaPipeline()`.


### PR DESCRIPTION
This PR allows the `RunStandaloneModeChoice` script to use VDF travel times previously recorded in vdf.bin file. One just needs to provide a config file with the `eqasim:vdf` module configured (its `inputFile` parameter should point to the file you want to use)