### PR TITLE
chore: modify RunAdaptConfig behavior

### DIFF
--- a/core/src/main/java/org/eqasim/core/components/config/ConfigAdapter.java
+++ b/core/src/main/java/org/eqasim/core/components/config/ConfigAdapter.java
@@ -1,25 +1,26 @@
 package org.eqasim.core.components.config;
 
+import org.eqasim.core.simulation.EqasimConfigurator;
 import org.matsim.core.config.CommandLine;
 import org.matsim.core.config.CommandLine.ConfigurationException;
 import org.matsim.core.config.Config;
-import org.matsim.core.config.ConfigGroup;
 import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.config.ConfigWriter;
 
 public class ConfigAdapter {
-	static public void run(String[] args, ConfigGroup[] modules, ConfigAdapterConsumer adapter)
+	static public void run(String[] args, EqasimConfigurator configurator, ConfigAdapterConsumer adapter)
 			throws ConfigurationException {
 		CommandLine cmd = new CommandLine.Builder(args) //
 				.requireOptions("input-path", "output-path", "prefix") //
 				.build();
 
-		Config config = ConfigUtils.loadConfig(cmd.getOptionStrict("input-path"), modules);
+		Config config = ConfigUtils.loadConfig(cmd.getOptionStrict("input-path"), configurator.getConfigGroups());
+		configurator.addOptionalConfigGroups(config);
 		adapter.accept(config, cmd.getOptionStrict("prefix"));
 
 		new ConfigWriter(config).write(cmd.getOptionStrict("output-path"));
 	}
-	
+
 	public interface ConfigAdapterConsumer {
 		void accept(Config config, String prefix);
 	}

--- a/core/src/main/java/org/eqasim/core/scenario/routing/RunPopulationRouting.java
+++ b/core/src/main/java/org/eqasim/core/scenario/routing/RunPopulationRouting.java
@@ -9,6 +9,7 @@ import org.eqasim.core.simulation.EqasimConfigurator;
 import org.eqasim.core.simulation.mode_choice.AbstractEqasimExtension;
 import org.eqasim.core.simulation.termination.EqasimTerminationConfigGroup;
 import org.matsim.api.core.v01.Scenario;
+import org.matsim.contribs.discrete_mode_choice.modules.DiscreteModeChoiceModule;
 import org.matsim.core.config.CommandLine;
 import org.matsim.core.config.CommandLine.ConfigurationException;
 import org.matsim.core.config.Config;
@@ -59,7 +60,8 @@ public class RunPopulationRouting {
 
 		Injector injector = new InjectorBuilder(scenario) //
 				.addOverridingModules(configurator.getModules().stream()
-						.filter(module -> !(module instanceof AbstractEqasimExtension)).toList()) //
+						.filter(module -> !(module instanceof AbstractEqasimExtension)) //
+						.filter(module -> !(module instanceof DiscreteModeChoiceModule)).toList()) //
 				.addOverridingModule(new PopulationRouterModule(numberOfThreads, batchSize, true, modes)) //
 				.addOverridingModule(new TimeInterpretationModule()).build();
 

--- a/core/src/main/java/org/eqasim/core/simulation/termination/EqasimTerminationModule.java
+++ b/core/src/main/java/org/eqasim/core/simulation/termination/EqasimTerminationModule.java
@@ -6,9 +6,9 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
+import org.eqasim.core.simulation.mode_choice.AbstractEqasimExtension;
 import org.matsim.core.config.ConfigGroup;
 import org.matsim.core.config.groups.ControllerConfigGroup;
-import org.matsim.core.controler.AbstractModule;
 import org.matsim.core.controler.OutputDirectoryHierarchy;
 import org.matsim.core.controler.TerminationCriterion;
 
@@ -18,12 +18,12 @@ import com.google.inject.Singleton;
 import com.google.inject.binder.LinkedBindingBuilder;
 import com.google.inject.multibindings.MapBinder;
 
-public class EqasimTerminationModule extends AbstractModule {
+public class EqasimTerminationModule extends AbstractEqasimExtension {
 	private static final String TERMINATION_CSV_FILE = "eqasim_termination.csv";
 	private static final String TERMINATION_HTML_FILE = "eqasim_termination.html";
 
 	@Override
-	public void install() {
+	protected void installEqasimExtension() {
 		bind(TerminationCriterion.class).to(EqasimTerminationCriterion.class);
 	}
 

--- a/core/src/test/java/org/eqasim/TestSimulationPipeline.java
+++ b/core/src/test/java/org/eqasim/TestSimulationPipeline.java
@@ -15,6 +15,7 @@ import org.eqasim.core.analysis.run.RunPublicTransportLegAnalysis;
 import org.eqasim.core.analysis.run.RunTripAnalysis;
 import org.eqasim.core.scenario.cutter.RunScenarioCutter;
 import org.eqasim.core.scenario.cutter.RunScenarioCutterV2;
+import org.eqasim.core.scenario.routing.RunPopulationRouting;
 import org.eqasim.core.simulation.EqasimConfigurator;
 import org.eqasim.core.simulation.analysis.EqasimAnalysisModule;
 import org.eqasim.core.simulation.mode_choice.AbstractEqasimExtension;
@@ -34,7 +35,12 @@ import org.eqasim.core.simulation.modes.transit_with_abstract_access.utils.Creat
 import org.eqasim.core.simulation.vdf.utils.AdaptConfigForVDF;
 import org.eqasim.core.standalone_mode_choice.RunStandaloneModeChoice;
 import org.eqasim.core.standalone_mode_choice.StandaloneModeChoiceConfigurator;
-import org.eqasim.core.tools.*;
+import org.eqasim.core.tools.ExportActivitiesToShapefile;
+import org.eqasim.core.tools.ExportNetworkRoutesToGeopackage;
+import org.eqasim.core.tools.ExportNetworkToShapefile;
+import org.eqasim.core.tools.ExportPopulationToCSV;
+import org.eqasim.core.tools.ExportTransitLinesToShapefile;
+import org.eqasim.core.tools.ExportTransitStopsToShapefile;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -407,6 +413,7 @@ public class TestSimulationPipeline {
     @Test
     public void testPipeline() throws Exception {
         runMelunSimulation("melun_test/input/config.xml", "melun_test/output");
+        runPopulationRouting();
         runStandaloneModeChoice();
         runVdf();
         runAnalyses();
@@ -415,6 +422,12 @@ public class TestSimulationPipeline {
         runCutterV2();
     }
 
+    public void runPopulationRouting() throws CommandLine.ConfigurationException, IOException, InterruptedException {
+        RunPopulationRouting.main(new String[] {
+                "--config-path", "melun_test/input/config.xml",
+                "--output-path", "melun_test/output/routed_population.xml.gz"
+        });
+    }
 
     public void runStandaloneModeChoice() throws CommandLine.ConfigurationException, IOException, InterruptedException {
         RunStandaloneModeChoice.main(new String[] {

--- a/ile_de_france/src/main/java/org/eqasim/ile_de_france/scenario/RunAdaptConfig.java
+++ b/ile_de_france/src/main/java/org/eqasim/ile_de_france/scenario/RunAdaptConfig.java
@@ -14,8 +14,7 @@ import org.matsim.core.config.groups.VehiclesConfigGroup;
 
 public class RunAdaptConfig {
 	static public void main(String[] args) throws ConfigurationException {
-		IDFConfigurator configurator = new IDFConfigurator();
-		ConfigAdapter.run(args, configurator.getConfigGroups(), RunAdaptConfig::adaptConfiguration);
+		ConfigAdapter.run(args, new IDFConfigurator(), RunAdaptConfig::adaptConfiguration);
 	}
 
 	static public void adaptConfiguration(Config config, String prefix) {
@@ -40,11 +39,11 @@ public class RunAdaptConfig {
 			config.qsim().setFlowCapFactor(0.045);
 			config.qsim().setStorageCapFactor(0.045);
 		}
-		
+
 		// Vehicles
 		QSimConfigGroup qsimConfig = config.qsim();
 		qsimConfig.setVehiclesSource(VehiclesSource.fromVehiclesData);
-		
+
 		VehiclesConfigGroup vehiclesConfig = config.vehicles();
 		vehiclesConfig.setVehiclesFile(prefix + "vehicles.xml.gz");
 	}

--- a/los_angeles/src/main/java/org/eqasim/los_angeles/scenario/RunAdaptConfig.java
+++ b/los_angeles/src/main/java/org/eqasim/los_angeles/scenario/RunAdaptConfig.java
@@ -20,8 +20,7 @@ public class RunAdaptConfig {
 	protected final static List<String> ACTIVITY_TYPES = Arrays.asList("business");
 
 	static public void main(String[] args) throws ConfigurationException {
-		EqasimConfigurator configurator = new EqasimConfigurator();
-		ConfigAdapter.run(args, configurator.getConfigGroups(), RunAdaptConfig::adaptConfiguration);
+		ConfigAdapter.run(args, new EqasimConfigurator(), RunAdaptConfig::adaptConfiguration);
 	}
 
 	static public void adaptConfiguration(Config config, String prefix) {

--- a/san_francisco/src/main/java/org/eqasim/san_francisco/scenario/RunAdaptConfig.java
+++ b/san_francisco/src/main/java/org/eqasim/san_francisco/scenario/RunAdaptConfig.java
@@ -21,8 +21,7 @@ public class RunAdaptConfig {
 	protected final static List<String> ACTIVITY_TYPES = Arrays.asList("business");
 
 	static public void main(String[] args) throws ConfigurationException {
-		EqasimConfigurator configurator = new EqasimConfigurator();
-		ConfigAdapter.run(args, configurator.getConfigGroups(), RunAdaptConfig::adaptConfiguration);
+		ConfigAdapter.run(args, new EqasimConfigurator(), RunAdaptConfig::adaptConfiguration);
 	}
 
 	static public void adaptConfiguration(Config config, String prefix) {

--- a/sao_paulo/src/main/java/org/eqasim/sao_paulo/scenario/RunAdaptConfig.java
+++ b/sao_paulo/src/main/java/org/eqasim/sao_paulo/scenario/RunAdaptConfig.java
@@ -17,8 +17,7 @@ import org.matsim.core.config.groups.ScoringConfigGroup.ModeParams;
 
 public class RunAdaptConfig {
 	static public void main(String[] args) throws ConfigurationException {
-		EqasimConfigurator configurator = new EqasimConfigurator();
-		ConfigAdapter.run(args, configurator.getConfigGroups(), RunAdaptConfig::adaptConfiguration);
+		ConfigAdapter.run(args, new EqasimConfigurator(), RunAdaptConfig::adaptConfiguration);
 	}
 
 	static public void adaptConfiguration(Config config, String prefix) {


### PR DESCRIPTION
- Need to pass an `EqasimConfigurator` now to `RunAdaptConfig`
- Added `RunPopulationRouting` to the unit tests
- Fixes several problems with handling configuration changes in the scenario pipeline