### PR TITLE
chore: simplify configurator structure

### DIFF
--- a/core/src/main/java/org/eqasim/core/components/config/ConfigAdapter.java
+++ b/core/src/main/java/org/eqasim/core/components/config/ConfigAdapter.java
@@ -14,8 +14,8 @@ public class ConfigAdapter {
 				.requireOptions("input-path", "output-path", "prefix") //
 				.build();
 
-		Config config = ConfigUtils.loadConfig(cmd.getOptionStrict("input-path"), configurator.getConfigGroups());
-		configurator.addOptionalConfigGroups(config);
+		Config config = ConfigUtils.loadConfig(cmd.getOptionStrict("input-path"));
+		configurator.updateConfig(config);
 		adapter.accept(config, cmd.getOptionStrict("prefix"));
 
 		new ConfigWriter(config).write(cmd.getOptionStrict("output-path"));

--- a/core/src/main/java/org/eqasim/core/components/emissions/RunComputeEmissionsEvents.java
+++ b/core/src/main/java/org/eqasim/core/components/emissions/RunComputeEmissionsEvents.java
@@ -1,6 +1,5 @@
 package org.eqasim.core.components.emissions;
 
-import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.eqasim.core.misc.ClassUtils;
 import org.eqasim.core.simulation.EqasimConfigurator;
@@ -13,7 +12,6 @@ import org.matsim.contrib.emissions.utils.EmissionsConfigGroup;
 import org.matsim.core.api.experimental.events.EventsManager;
 import org.matsim.core.config.CommandLine;
 import org.matsim.core.config.Config;
-import org.matsim.core.config.ConfigGroup;
 import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.controler.AbstractModule;
 import org.matsim.core.controler.Injector;
@@ -39,9 +37,9 @@ public class RunComputeEmissionsEvents {
             configurator = new EqasimConfigurator();
         }
 
-        ConfigGroup[] configGroups = ArrayUtils.addAll(configurator.getConfigGroups(), new EmissionsConfigGroup());
-
-        Config config = ConfigUtils.loadConfig(cmd.getOptionStrict("config-path"), configGroups);
+        Config config = ConfigUtils.loadConfig(cmd.getOptionStrict("config-path"));
+        configurator.registerConfigGroup(new EmissionsConfigGroup(), false);
+        configurator.updateConfig(config);
         cmd.applyConfiguration(config);
 
         EmissionsConfigGroup emissionsConfig = (EmissionsConfigGroup) config.getModules().get("emissions");

--- a/core/src/main/java/org/eqasim/core/components/emissions/RunComputeEmissionsGrid.java
+++ b/core/src/main/java/org/eqasim/core/components/emissions/RunComputeEmissionsGrid.java
@@ -1,16 +1,13 @@
 package org.eqasim.core.components.emissions;
 
-import org.apache.commons.lang3.ArrayUtils;
 import org.eqasim.core.misc.ClassUtils;
 import org.eqasim.core.simulation.EqasimConfigurator;
 import org.geotools.api.feature.simple.SimpleFeature;
 import org.locationtech.jts.geom.Geometry;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.contrib.emissions.analysis.EmissionGridAnalyzer;
-import org.matsim.contrib.emissions.utils.EmissionsConfigGroup;
 import org.matsim.core.config.CommandLine;
 import org.matsim.core.config.Config;
-import org.matsim.core.config.ConfigGroup;
 import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.network.NetworkUtils;
 import org.matsim.core.network.io.MatsimNetworkReader;
@@ -32,9 +29,8 @@ public class RunComputeEmissionsGrid {
             configurator = new EqasimConfigurator();
         }
 
-        ConfigGroup[] configGroups = ArrayUtils.addAll(configurator.getConfigGroups(), new EmissionsConfigGroup());
-
-        Config config = ConfigUtils.loadConfig(cmd.getOptionStrict("config-path"), configGroups);
+        Config config = ConfigUtils.loadConfig(cmd.getOptionStrict("config-path"));
+        configurator.updateConfig(config);
         cmd.applyConfiguration(config);
         final String outputDirectory = config.controller().getOutputDirectory() + "/";
 

--- a/core/src/main/java/org/eqasim/core/components/emissions/RunExportEmissionsNetwork.java
+++ b/core/src/main/java/org/eqasim/core/components/emissions/RunExportEmissionsNetwork.java
@@ -6,7 +6,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.lang3.ArrayUtils;
 import org.eqasim.core.misc.ClassUtils;
 import org.eqasim.core.simulation.EqasimConfigurator;
 import org.geotools.api.feature.simple.SimpleFeature;
@@ -19,11 +18,9 @@ import org.matsim.contrib.emissions.Pollutant;
 import org.matsim.contrib.emissions.analysis.EmissionsByPollutant;
 import org.matsim.contrib.emissions.analysis.EmissionsOnLinkEventHandler;
 import org.matsim.contrib.emissions.events.EmissionEventsReader;
-import org.matsim.contrib.emissions.utils.EmissionsConfigGroup;
 import org.matsim.core.api.experimental.events.EventsManager;
 import org.matsim.core.config.CommandLine;
 import org.matsim.core.config.Config;
-import org.matsim.core.config.ConfigGroup;
 import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.events.EventsUtils;
 import org.matsim.core.network.NetworkUtils;
@@ -49,9 +46,8 @@ public class RunExportEmissionsNetwork {
             configurator = new EqasimConfigurator();
         }
         
-        ConfigGroup[] configGroups = ArrayUtils.addAll(configurator.getConfigGroups(), new EmissionsConfigGroup());
-
-        Config config = ConfigUtils.loadConfig(cmd.getOptionStrict("config-path"), configGroups);
+        Config config = ConfigUtils.loadConfig(cmd.getOptionStrict("config-path"));
+        configurator.updateConfig(config);
         cmd.applyConfiguration(config);
         final String outputDirectory = config.controller().getOutputDirectory() + "/";
 

--- a/core/src/main/java/org/eqasim/core/scenario/config/RunGenerateConfig.java
+++ b/core/src/main/java/org/eqasim/core/scenario/config/RunGenerateConfig.java
@@ -15,7 +15,8 @@ public class RunGenerateConfig {
 				.build();
 
 		EqasimConfigurator configurator = new EqasimConfigurator();
-		Config config = ConfigUtils.createConfig(configurator.getConfigGroups());
+		Config config = ConfigUtils.createConfig();
+		configurator.updateConfig(config);
 
 		String prefix = cmd.getOptionStrict("prefix");
 		double sampleSize = Double.parseDouble(cmd.getOptionStrict("sample-size"));

--- a/core/src/main/java/org/eqasim/core/scenario/cutter/RunScenarioCutterV2.java
+++ b/core/src/main/java/org/eqasim/core/scenario/cutter/RunScenarioCutterV2.java
@@ -44,9 +44,9 @@ public class RunScenarioCutterV2 {
         String outputPath = cmd.getOptionStrict("output-path");
 
         EqasimConfigurator eqasimConfigurator = new EqasimConfigurator();
-        Config config = ConfigUtils.loadConfig(cmd.getOptionStrict("config-path"), eqasimConfigurator.getConfigGroups());
+        Config config = ConfigUtils.loadConfig(cmd.getOptionStrict("config-path"));
+        eqasimConfigurator.updateConfig(config);
         cmd.applyConfiguration(config);
-        eqasimConfigurator.addOptionalConfigGroups(config);
 
         if(!config.getModules().containsKey(VDFConfigGroup.GROUP_NAME) || !config.getModules().containsKey(VDFEngineConfigGroup.GROUP_NAME)) {
             throw new IllegalStateException(String.format("This scenario cutter only works with configs where both '%s' and '%s' modules are used", VDFConfigGroup.GROUP_NAME, VDFEngineConfigGroup.GROUP_NAME));
@@ -126,9 +126,9 @@ public class RunScenarioCutterV2 {
 
         // "Cut" config
         // (we need to reload it, because it has become locked at this point)
-        config = ConfigUtils.loadConfig(cmd.getOptionStrict("config-path"), eqasimConfigurator.getConfigGroups());
+        config = ConfigUtils.loadConfig(cmd.getOptionStrict("config-path"));
+        eqasimConfigurator.updateConfig(config);
         cmd.applyConfiguration(config);
-        eqasimConfigurator.addOptionalConfigGroups(config);
         ConfigCutter configCutter = new ConfigCutter(prefix);
         configCutter.run(config);
 

--- a/core/src/main/java/org/eqasim/core/scenario/routing/RunPopulationRouting.java
+++ b/core/src/main/java/org/eqasim/core/scenario/routing/RunPopulationRouting.java
@@ -29,9 +29,9 @@ public class RunPopulationRouting {
 				.build();
 
 		EqasimConfigurator configurator = new EqasimConfigurator();
-		Config config = ConfigUtils.loadConfig(cmd.getOptionStrict("config-path"), configurator.getConfigGroups());
+		Config config = ConfigUtils.loadConfig(cmd.getOptionStrict("config-path"));
+		configurator.updateConfig(config);
 		config.getModules().remove(EqasimTerminationConfigGroup.GROUP_NAME);
-		configurator.addOptionalConfigGroups(config);
 		cmd.applyConfiguration(config);
 		config.replanning().clearStrategySettings();
 		VehiclesValidator.validate(config);
@@ -59,7 +59,7 @@ public class RunPopulationRouting {
 		}
 
 		Injector injector = new InjectorBuilder(scenario) //
-				.addOverridingModules(configurator.getModules().stream()
+				.addOverridingModules(configurator.getModules(config).stream()
 						.filter(module -> !(module instanceof AbstractEqasimExtension)) //
 						.filter(module -> !(module instanceof DiscreteModeChoiceModule)).toList()) //
 				.addOverridingModule(new PopulationRouterModule(numberOfThreads, batchSize, true, modes)) //

--- a/core/src/main/java/org/eqasim/core/simulation/modes/drt/utils/AdaptConfigForDrt.java
+++ b/core/src/main/java/org/eqasim/core/simulation/modes/drt/utils/AdaptConfigForDrt.java
@@ -2,7 +2,14 @@ package org.eqasim.core.simulation.modes.drt.utils;
 
 import java.net.MalformedURLException;
 import java.nio.file.Path;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.DoubleSummaryStatistics;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.DoubleStream;
 import java.util.stream.IntStream;
@@ -200,8 +207,9 @@ public class AdaptConfigForDrt {
             configurator = new EqasimConfigurator();
         }
 
-        Config config = ConfigUtils.loadConfig(inputConfigPath, configurator.getConfigGroups());
-
+        Config config = ConfigUtils.loadConfig(inputConfigPath);
+        configurator.updateConfig(config);
+        
         adapt(config, info.get("vehicles-paths"), info.get("operational-schemes"), info.get("estimators"), info.get("cost-models"), info.get("add-leg-time-constraint"), qsimEndtime, cmd.getOption("mode-availability").orElse(null));
 
         cmd.applyConfiguration(config);

--- a/core/src/main/java/org/eqasim/core/simulation/modes/feeder_drt/analysis/run/RunFeederDrtPassengerAnalysis.java
+++ b/core/src/main/java/org/eqasim/core/simulation/modes/feeder_drt/analysis/run/RunFeederDrtPassengerAnalysis.java
@@ -1,5 +1,9 @@
 package org.eqasim.core.simulation.modes.feeder_drt.analysis.run;
 
+import java.io.File;
+import java.io.IOException;
+import java.util.Map;
+
 import org.eqasim.core.simulation.EqasimConfigurator;
 import org.eqasim.core.simulation.modes.drt.analysis.utils.VehicleRegistry;
 import org.eqasim.core.simulation.modes.feeder_drt.analysis.passengers.FeederTripSequenceListener;
@@ -15,10 +19,6 @@ import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.events.EventsUtils;
 import org.matsim.core.network.NetworkUtils;
 import org.matsim.core.network.io.MatsimNetworkReader;
-
-import java.io.File;
-import java.io.IOException;
-import java.util.Map;
 
 
 public class RunFeederDrtPassengerAnalysis {
@@ -53,8 +53,8 @@ public class RunFeederDrtPassengerAnalysis {
         String outputPath = cmd.getOptionStrict("output-path");
 
         EqasimConfigurator configurator = new EqasimConfigurator();
-        Config config = ConfigUtils.loadConfig(configPath, configurator.getConfigGroups());
-        configurator.addOptionalConfigGroups(config);
+        Config config = ConfigUtils.loadConfig(configPath);
+        configurator.updateConfig(config);
 
         Network network = NetworkUtils.createNetwork();
         new MatsimNetworkReader(network).readFile(networkPath);

--- a/core/src/main/java/org/eqasim/core/simulation/modes/feeder_drt/utils/AdaptConfigForFeederDrt.java
+++ b/core/src/main/java/org/eqasim/core/simulation/modes/feeder_drt/utils/AdaptConfigForFeederDrt.java
@@ -162,8 +162,8 @@ public class AdaptConfigForFeederDrt {
             configurator = new EqasimConfigurator();
         }
 
-        Config config = ConfigUtils.loadConfig(inputConfigPath, configurator.getConfigGroups());
-        configurator.addOptionalConfigGroups(config);
+        Config config = ConfigUtils.loadConfig(inputConfigPath);
+        configurator.updateConfig(config);
 
         adapt(config, info.get("base-pt-modes"), info.get("base-drt-modes"), info.get("estimators"), info.get("access-egress-transit-stop-modes"), info.get("access-egress-transit-stop-ids"), cmd.getOption("mode-availability").orElse(null));
 

--- a/core/src/main/java/org/eqasim/core/simulation/termination/mode_share/TerminationModeShareModule.java
+++ b/core/src/main/java/org/eqasim/core/simulation/termination/mode_share/TerminationModeShareModule.java
@@ -7,7 +7,7 @@ import org.matsim.core.controler.AbstractModule;
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
 
-public class ModeShareModule extends AbstractModule {
+public class TerminationModeShareModule extends AbstractModule {
 	@Override
 	public void install() {
 		EqasimTerminationConfigGroup terminationConfig = EqasimTerminationConfigGroup.getOrCreate(getConfig());

--- a/core/src/main/java/org/eqasim/core/simulation/vdf/VDFModule.java
+++ b/core/src/main/java/org/eqasim/core/simulation/vdf/VDFModule.java
@@ -8,6 +8,7 @@ import java.util.Optional;
 import org.eqasim.core.components.config.EqasimConfigGroup;
 import org.eqasim.core.scenario.cutter.extent.ScenarioExtent;
 import org.eqasim.core.scenario.cutter.extent.ShapeScenarioExtent;
+import org.eqasim.core.simulation.mode_choice.AbstractEqasimExtension;
 import org.eqasim.core.simulation.vdf.handlers.VDFHorizonHandler;
 import org.eqasim.core.simulation.vdf.handlers.VDFInterpolationHandler;
 import org.eqasim.core.simulation.vdf.handlers.VDFTrafficHandler;
@@ -17,15 +18,14 @@ import org.eqasim.core.simulation.vdf.travel_time.function.VolumeDelayFunction;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.core.config.ConfigGroup;
 import org.matsim.core.config.groups.QSimConfigGroup;
-import org.matsim.core.controler.AbstractModule;
 import org.matsim.core.controler.OutputDirectoryHierarchy;
 
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
 
-public class VDFModule extends AbstractModule {
+public class VDFModule extends AbstractEqasimExtension {
 	@Override
-	public void install() {
+	protected void installEqasimExtension() {
 		VDFConfigGroup vdfConfig = VDFConfigGroup.getOrCreate(getConfig());
 
 		for (String mode : vdfConfig.getModes()) {
@@ -70,7 +70,10 @@ public class VDFModule extends AbstractModule {
 	@Singleton
 	public VDFTravelTime provideVDFTravelTime(VDFConfigGroup config, VDFScope scope, Network network,
 			VolumeDelayFunction vdf, QSimConfigGroup qsimConfig, EqasimConfigGroup eqasimConfig) throws IOException {
-		ScenarioExtent updateExtent = config.getUpdateAreaShapefile() == null ? null : new ShapeScenarioExtent.Builder(new File(ConfigGroup.getInputFileURL(getConfig().getContext(), config.getUpdateAreaShapefile()).getPath()), Optional.empty(), Optional.empty()).build();
+		ScenarioExtent updateExtent = config.getUpdateAreaShapefile() == null ? null
+				: new ShapeScenarioExtent.Builder(new File(ConfigGroup
+						.getInputFileURL(getConfig().getContext(), config.getUpdateAreaShapefile()).getPath()),
+						Optional.empty(), Optional.empty()).build();
 		return new VDFTravelTime(scope, config.getMinimumSpeed(), config.getCapacityFactor(),
 				eqasimConfig.getSampleSize(), network, vdf, eqasimConfig.getCrossingPenalty(), updateExtent);
 	}

--- a/core/src/main/java/org/eqasim/core/simulation/vdf/engine/VDFEngineModule.java
+++ b/core/src/main/java/org/eqasim/core/simulation/vdf/engine/VDFEngineModule.java
@@ -1,20 +1,21 @@
 package org.eqasim.core.simulation.vdf.engine;
 
+import org.eqasim.core.simulation.mode_choice.AbstractEqasimExtension;
 import org.eqasim.core.simulation.vdf.handlers.VDFTrafficHandler;
 import org.eqasim.core.simulation.vdf.travel_time.VDFTravelTime;
 import org.matsim.api.core.v01.network.Network;
-import org.matsim.core.controler.AbstractModule;
 import org.matsim.core.mobsim.qsim.AbstractQSimModule;
+import org.matsim.core.mobsim.qsim.components.QSimComponentsConfig;
 
 import com.google.common.base.Verify;
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
 
-public class VDFEngineModule extends AbstractModule {
+public class VDFEngineModule extends AbstractEqasimExtension {
 	public static final String COMPONENT_NAME = "VDFEngine";
 
 	@Override
-	public void install() {
+	public void installEqasimExtension() {
 		VDFEngineConfigGroup engineConfig = VDFEngineConfigGroup.getOrCreate(getConfig());
 
 		for (String mode : engineConfig.getModes()) {
@@ -35,5 +36,9 @@ public class VDFEngineModule extends AbstractModule {
 						engineConfig.getGenerateNetworkEvents());
 			}
 		});
+	}
+
+	static public void configureQSim(QSimComponentsConfig components) {
+		components.addNamedComponent(COMPONENT_NAME);
 	}
 }

--- a/core/src/main/java/org/eqasim/core/simulation/vdf/utils/AdaptConfigForVDF.java
+++ b/core/src/main/java/org/eqasim/core/simulation/vdf/utils/AdaptConfigForVDF.java
@@ -54,7 +54,8 @@ public class AdaptConfigForVDF {
         boolean engine = Boolean.parseBoolean(commandLine.getOption("engine").orElse("false"));
 
         EqasimConfigurator eqasimConfigurator = new EqasimConfigurator();
-        Config config = ConfigUtils.loadConfig(inputPath, eqasimConfigurator.getConfigGroups());
+        Config config = ConfigUtils.loadConfig(inputPath);
+        eqasimConfigurator.updateConfig(config);
         adaptConfigForVDF(config, engine);
         commandLine.applyConfiguration(config);
         ConfigUtils.writeConfig(config, outputPath);

--- a/core/src/main/java/org/eqasim/core/standalone_mode_choice/RunStandaloneModeChoice.java
+++ b/core/src/main/java/org/eqasim/core/standalone_mode_choice/RunStandaloneModeChoice.java
@@ -44,7 +44,6 @@ import org.matsim.api.core.v01.population.Person;
 import org.matsim.api.core.v01.population.Population;
 import org.matsim.core.config.CommandLine;
 import org.matsim.core.config.Config;
-import org.matsim.core.config.ConfigGroup;
 import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.controler.AbstractModule;
 import org.matsim.core.controler.OutputDirectoryHierarchy;
@@ -162,17 +161,10 @@ public class RunStandaloneModeChoice {
 
         // Loading the config
         EqasimConfigurator configurator = cmd.hasOption(EQASIM_CONFIGURATOR_CLASS) ? ClassUtils.getInstanceOfClassExtendingOtherClass(cmd.getOptionStrict(EQASIM_CONFIGURATOR_CLASS), EqasimConfigurator.class) : new EqasimConfigurator();
-        ConfigGroup[] configGroups = new ConfigGroup[configurator.getConfigGroups().length+1];
-        int i=0;
-        for(ConfigGroup configGroup: configurator.getConfigGroups()) {
-            configGroups[i] = configGroup;
-            i++;
-        }
-        // We should add this module now so that parameters can be overridden by the commandline
-        configGroups[i] = new StandaloneModeChoiceConfigGroup();
+        configurator.registerConfigGroup(new StandaloneModeChoiceConfigGroup(), false);
 
-        Config config = ConfigUtils.loadConfig(cmd.getOptionStrict(CMD_CONFIG_PATH), configGroups);
-        configurator.addOptionalConfigGroups(config);
+        Config config = ConfigUtils.loadConfig(cmd.getOptionStrict(CMD_CONFIG_PATH));
+        configurator.updateConfig(config);
         cmd.applyConfiguration(config);
         VehiclesValidator.validate(config);
 

--- a/core/src/main/java/org/eqasim/core/standalone_mode_choice/StandaloneModeChoiceConfigurator.java
+++ b/core/src/main/java/org/eqasim/core/standalone_mode_choice/StandaloneModeChoiceConfigurator.java
@@ -56,7 +56,7 @@ public class StandaloneModeChoiceConfigurator {
 
     public final List<AbstractModule> getModeChoiceModules(Config config) {
         List<AbstractModule> modules = new ArrayList<>();
-        new EqasimConfigurator().getModules().stream().filter(module -> !(module instanceof EqasimTerminationModule)).forEach(modules::add);
+        new EqasimConfigurator().getModules(config).stream().filter(module -> !(module instanceof EqasimTerminationModule)).forEach(modules::add);
         modules.add(new TimeInterpretationModule());
         modules.add(new StandaloneModeChoiceModule(getConfig()));
         // We add a module that just binds the PersonAnalysisFilter without having to add the whole EqasimAnalysisModule

--- a/core/src/main/java/org/eqasim/core/tools/RunImputeHeadway.java
+++ b/core/src/main/java/org/eqasim/core/tools/RunImputeHeadway.java
@@ -22,7 +22,8 @@ public class RunImputeHeadway {
 				.build();
 
 		EqasimConfigurator configurator = new EqasimConfigurator();
-		Config config = ConfigUtils.loadConfig(cmd.getOptionStrict("config-path"), configurator.getConfigGroups());
+		Config config = ConfigUtils.loadConfig(cmd.getOptionStrict("config-path"));
+		configurator.updateConfig(config);
 		cmd.applyConfiguration(config);
 		config.replanning().clearStrategySettings();
 
@@ -35,7 +36,7 @@ public class RunImputeHeadway {
 		ScenarioUtils.loadScenario(scenario);
 
 		Injector injector = new InjectorBuilder(scenario) //
-				.addOverridingModules(configurator.getModules()) //
+				.addOverridingModules(configurator.getModules(config)) //
 				.addOverridingModule(new HeadwayImputerModule(numberOfThreads, batchSize, true, interval)) //
 				.build();
 

--- a/core/src/main/java/org/eqasim/core/tools/routing/RunBatchPublicTransportRouter.java
+++ b/core/src/main/java/org/eqasim/core/tools/routing/RunBatchPublicTransportRouter.java
@@ -66,7 +66,8 @@ public class RunBatchPublicTransportRouter {
 				.build();
 
 		EqasimConfigurator configurator = new EqasimConfigurator();
-		Config config = ConfigUtils.loadConfig(cmd.getOptionStrict("config-path"), configurator.getConfigGroups());
+		Config config = ConfigUtils.loadConfig(cmd.getOptionStrict("config-path"));
+		configurator.updateConfig(config);
 		cmd.applyConfiguration(config);
 
 		// No opportunity scoring
@@ -262,7 +263,7 @@ public class RunBatchPublicTransportRouter {
 		Optional<String> outputConfigPath = cmd.getOption("output-config-path");
 
 		Injector injector = new InjectorBuilder(scenario) //
-				.addOverridingModules(configurator.getModules()) //
+				.addOverridingModules(configurator.getModules(config)) //
 				.addOverridingModule(new HeadwayImputerModule(numberOfThreads, batchSize, false, interval)).build();
 
 		Provider<TransitRouter> routerProvider = injector.getProvider(TransitRouter.class);

--- a/core/src/main/java/org/eqasim/core/tools/routing/RunBatchRoadRouter.java
+++ b/core/src/main/java/org/eqasim/core/tools/routing/RunBatchRoadRouter.java
@@ -47,7 +47,8 @@ public class RunBatchRoadRouter {
 				.build();
 
 		EqasimConfigurator configurator = new EqasimConfigurator();
-		Config config = ConfigUtils.loadConfig(cmd.getOptionStrict("config-path"), configurator.getConfigGroups());
+		Config config = ConfigUtils.loadConfig(cmd.getOptionStrict("config-path"));
+		configurator.updateConfig(config);
 		cmd.applyConfiguration(config);
 
 		Scenario scenario = ScenarioUtils.createScenario(config);
@@ -66,7 +67,7 @@ public class RunBatchRoadRouter {
 		}
 
 		Injector injector = new InjectorBuilder(scenario) //
-				.addOverridingModules(configurator.getModules()) //
+				.addOverridingModules(configurator.getModules(config)) //
 				.addOverridingModule(new AbstractModule() {
 					@Override
 					public void install() {

--- a/core/src/test/java/org/eqasim/TestEmissions.java
+++ b/core/src/test/java/org/eqasim/TestEmissions.java
@@ -1,17 +1,6 @@
 package org.eqasim;
 
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
-
-import java.io.File;
-import java.io.IOException;
-import java.net.URL;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.Set;
-
-import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
@@ -38,23 +27,21 @@ import org.eqasim.core.simulation.analysis.EqasimAnalysisModule;
 import org.eqasim.core.simulation.mode_choice.AbstractEqasimExtension;
 import org.eqasim.core.simulation.mode_choice.EqasimModeChoiceModule;
 import org.eqasim.core.simulation.mode_choice.parameters.ModeParameters;
+import org.geotools.api.feature.simple.SimpleFeature;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.Scenario;
 import org.matsim.api.core.v01.TransportMode;
 import org.matsim.api.core.v01.events.handler.PersonDepartureEventHandler;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
-import org.matsim.api.core.v01.population.Person;
 import org.matsim.core.api.experimental.events.EventsManager;
 import org.matsim.core.config.CommandLine;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.config.groups.ControllerConfigGroup;
-import org.matsim.core.config.groups.QSimConfigGroup;
 import org.matsim.core.controler.Controler;
 import org.matsim.core.events.EventsUtils;
 import org.matsim.core.events.MatsimEventsReader;
@@ -65,11 +52,9 @@ import org.matsim.examples.ExamplesUtils;
 import org.matsim.utils.objectattributes.attributable.Attributes;
 import org.matsim.vehicles.MatsimVehicleReader;
 import org.matsim.vehicles.MatsimVehicleWriter;
-import org.matsim.vehicles.Vehicle;
 import org.matsim.vehicles.VehicleType;
 import org.matsim.vehicles.VehicleUtils;
 import org.matsim.vehicles.Vehicles;
-import org.geotools.api.feature.simple.SimpleFeature;
 
 public class TestEmissions {
 
@@ -94,8 +79,8 @@ public class TestEmissions {
 
 	private void runMelunSimulation() {
 		EqasimConfigurator eqasimConfigurator = new EqasimConfigurator();
-		Config config = ConfigUtils.loadConfig("melun_test/input/config.xml",
-				eqasimConfigurator.getConfigGroups());
+		Config config = ConfigUtils.loadConfig("melun_test/input/config.xml");
+		eqasimConfigurator.updateConfig(config);
 		((ControllerConfigGroup) config.getModules().get(ControllerConfigGroup.GROUP_NAME))
 				.setOutputDirectory("melun_test/output");
 

--- a/core/src/test/java/org/eqasim/TestSimulationPipeline.java
+++ b/core/src/test/java/org/eqasim/TestSimulationPipeline.java
@@ -81,7 +81,8 @@ public class TestSimulationPipeline {
 
     private void runMelunSimulation(String configPath, String outputPath, String inputPlansFile, Integer lastIteration) {
         EqasimConfigurator eqasimConfigurator = new EqasimConfigurator();
-        Config config = ConfigUtils.loadConfig(configPath, eqasimConfigurator.getConfigGroups());
+        Config config = ConfigUtils.loadConfig(configPath);
+        eqasimConfigurator.updateConfig(config);
         ((ControllerConfigGroup) config.getModules().get(ControllerConfigGroup.GROUP_NAME)).setOutputDirectory(outputPath);
         if(inputPlansFile != null) {
             config.plans().setInputFile(inputPlansFile);
@@ -89,7 +90,6 @@ public class TestSimulationPipeline {
         if(lastIteration != null) {
             config.controller().setLastIteration(lastIteration);
         }
-        eqasimConfigurator.addOptionalConfigGroups(config);
 
         Scenario scenario = ScenarioUtils.createScenario(config);
         eqasimConfigurator.configureScenario(scenario);

--- a/core/src/test/java/org/eqasim/mode_choice/TestSpecialModeChoiceCases.java
+++ b/core/src/test/java/org/eqasim/mode_choice/TestSpecialModeChoiceCases.java
@@ -23,6 +23,7 @@ import org.eqasim.core.scenario.config.GenerateConfig;
 import org.eqasim.core.simulation.EqasimConfigurator;
 import org.eqasim.core.simulation.mode_choice.EqasimModeChoiceModule;
 import org.eqasim.core.simulation.mode_choice.parameters.ModeParameters;
+import org.eqasim.core.simulation.termination.EqasimTerminationConfigGroup;
 import org.eqasim.core.simulation.termination.EqasimTerminationModule;
 import org.junit.After;
 import org.junit.Test;
@@ -158,6 +159,7 @@ public class TestSpecialModeChoiceCases {
 
 		new GenerateConfig(cmd, "", 1.0, 1, 1).run(config);
 		config.addModule(new EqasimRaptorConfigGroup());
+		config.removeModule(EqasimTerminationConfigGroup.GROUP_NAME);
 
 		// Make sure the two relevant options (walk vs. bike) both get zero utility
 		DiscreteModeChoiceConfigGroup.getOrCreate(config).setModeAvailability("static");
@@ -166,7 +168,6 @@ public class TestSpecialModeChoiceCases {
 
 		// Now create the model
 		EqasimConfigurator configurator = new EqasimConfigurator();
-		configurator.getModules().removeIf(m -> m instanceof EqasimTerminationModule);
 		
 		Scenario scenario = ScenarioUtils.createScenario(config);
 		
@@ -178,7 +179,7 @@ public class TestSpecialModeChoiceCases {
 		scenario.getNetwork().addLink(link);
 		
 		Injector injector = new InjectorBuilder(scenario) //
-				.addOverridingModules(configurator.getModules()) //
+				.addOverridingModules(configurator.getModules(config)) //
 				.addOverridingModule(new EqasimModeChoiceModule()) //
 				.addOverridingModule(new StaticModeAvailabilityModule()) //
 				.addOverridingModule(new TimeInterpretationModule()) //

--- a/examples/src/main/java/org/eqasim/examples/corsica_drt/RunCorsicaDrtSimulation.java
+++ b/examples/src/main/java/org/eqasim/examples/corsica_drt/RunCorsicaDrtSimulation.java
@@ -56,7 +56,8 @@ public class RunCorsicaDrtSimulation {
 		URL configUrl = Resources.getResource("corsica/corsica_config.xml");
 
 		IDFConfigurator configurator = new IDFConfigurator();
-		Config config = ConfigUtils.loadConfig(configUrl, configurator.getConfigGroups());
+		Config config = ConfigUtils.loadConfig(configUrl);
+		configurator.updateConfig(config);
 
 		config.controller().setLastIteration(2);
 		config.qsim().setFlowCapFactor(1e9);

--- a/examples/src/main/java/org/eqasim/examples/corsica_vdf/RunCorsicaVDFEngineSimulation.java
+++ b/examples/src/main/java/org/eqasim/examples/corsica_vdf/RunCorsicaVDFEngineSimulation.java
@@ -4,13 +4,12 @@ import java.net.URL;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.eqasim.core.components.traffic.EqasimTrafficQSimModule;
 import org.eqasim.core.simulation.analysis.EqasimAnalysisModule;
 import org.eqasim.core.simulation.mode_choice.EqasimModeChoiceModule;
-import org.eqasim.ile_de_france.IDFConfigurator;
-import org.eqasim.ile_de_france.mode_choice.IDFModeChoiceModule;
 import org.eqasim.core.simulation.vdf.VDFConfigGroup;
 import org.eqasim.core.simulation.vdf.engine.VDFEngineConfigGroup;
+import org.eqasim.ile_de_france.IDFConfigurator;
+import org.eqasim.ile_de_france.mode_choice.IDFModeChoiceModule;
 import org.matsim.api.core.v01.Scenario;
 import org.matsim.core.config.CommandLine;
 import org.matsim.core.config.CommandLine.ConfigurationException;
@@ -32,10 +31,10 @@ public class RunCorsicaVDFEngineSimulation {
 				.build();
 
 		IDFConfigurator configurator = new IDFConfigurator();
-		configurator.getQSimModules().removeIf(m -> m instanceof EqasimTrafficQSimModule);
 
 		URL configUrl = Resources.getResource("corsica/corsica_config.xml");
-		Config config = ConfigUtils.loadConfig(configUrl, configurator.getConfigGroups());
+		Config config = ConfigUtils.loadConfig(configUrl);
+		configurator.updateConfig(config);
 
 		config.controller().setLastIteration(2);
 

--- a/examples/src/main/java/org/eqasim/examples/corsica_vdf/RunCorsicaVDFSimulation.java
+++ b/examples/src/main/java/org/eqasim/examples/corsica_vdf/RunCorsicaVDFSimulation.java
@@ -2,12 +2,11 @@ package org.eqasim.examples.corsica_vdf;
 
 import java.net.URL;
 
-import org.eqasim.core.components.traffic.EqasimTrafficQSimModule;
 import org.eqasim.core.simulation.analysis.EqasimAnalysisModule;
 import org.eqasim.core.simulation.mode_choice.EqasimModeChoiceModule;
+import org.eqasim.core.simulation.vdf.VDFConfigGroup;
 import org.eqasim.ile_de_france.IDFConfigurator;
 import org.eqasim.ile_de_france.mode_choice.IDFModeChoiceModule;
-import org.eqasim.core.simulation.vdf.VDFConfigGroup;
 import org.matsim.api.core.v01.Scenario;
 import org.matsim.core.config.CommandLine;
 import org.matsim.core.config.CommandLine.ConfigurationException;
@@ -29,10 +28,10 @@ public class RunCorsicaVDFSimulation {
 				.build();
 
 		IDFConfigurator configurator = new IDFConfigurator();
-		configurator.getQSimModules().removeIf(m -> m instanceof EqasimTrafficQSimModule);
 
 		URL configUrl = Resources.getResource("corsica/corsica_config.xml");
-		Config config = ConfigUtils.loadConfig(configUrl, configurator.getConfigGroups());
+		Config config = ConfigUtils.loadConfig(configUrl);
+		configurator.updateConfig(config);
 
 		config.controller().setLastIteration(2);
 

--- a/ile_de_france/src/main/java/org/eqasim/ile_de_france/RunSimulation.java
+++ b/ile_de_france/src/main/java/org/eqasim/ile_de_france/RunSimulation.java
@@ -20,8 +20,8 @@ public class RunSimulation {
 				.build();
 
 		IDFConfigurator configurator = new IDFConfigurator();
-		Config config = ConfigUtils.loadConfig(cmd.getOptionStrict("config-path"), configurator.getConfigGroups());
-		configurator.addOptionalConfigGroups(config);
+		Config config = ConfigUtils.loadConfig(cmd.getOptionStrict("config-path"));
+		configurator.updateConfig(config);
 		cmd.applyConfiguration(config);
 		VehiclesValidator.validate(config);
 

--- a/ile_de_france/src/test/java/org/eqasim/ile_de_france/TestCorisica.java
+++ b/ile_de_france/src/test/java/org/eqasim/ile_de_france/TestCorisica.java
@@ -42,7 +42,8 @@ public class TestCorisica {
 
 	private void adjustConfig() {
 		IDFConfigurator configurator = new IDFConfigurator();
-		Config config = ConfigUtils.loadConfig("corsica_test/corsica_config.xml", configurator.getConfigGroups());
+		Config config = ConfigUtils.loadConfig("corsica_test/corsica_config.xml");
+		configurator.updateConfig(config);
 		config.vehicles().setVehiclesFile("corsica_vehicles.xml.gz");
 		config.qsim().setVehiclesSource(VehiclesSource.fromVehiclesData);
 		new ConfigWriter(config).write("corsica_test/corsica_config.xml");

--- a/los_angeles/src/main/java/org/eqasim/los_angeles/RunSimulation.java
+++ b/los_angeles/src/main/java/org/eqasim/los_angeles/RunSimulation.java
@@ -22,8 +22,8 @@ public class RunSimulation {
 				.build();
 
 		EqasimConfigurator configurator = new EqasimConfigurator();
-		Config config = ConfigUtils.loadConfig(cmd.getOptionStrict("config-path"), configurator.getConfigGroups());
-		configurator.addOptionalConfigGroups(config);
+		Config config = ConfigUtils.loadConfig(cmd.getOptionStrict("config-path"));
+		configurator.updateConfig(config);
 		EqasimConfigGroup.get(config).setAnalysisInterval(5);
 		EqasimConfigGroup.get(config).setDistanceUnit(DistanceUnit.foot);
 		cmd.applyConfiguration(config);

--- a/san_francisco/src/main/java/org/eqasim/san_francisco/RunSimulation.java
+++ b/san_francisco/src/main/java/org/eqasim/san_francisco/RunSimulation.java
@@ -22,8 +22,8 @@ public class RunSimulation {
 				.build();
 
 		EqasimConfigurator configurator = new EqasimConfigurator();
-		Config config = ConfigUtils.loadConfig(cmd.getOptionStrict("config-path"), configurator.getConfigGroups());
-		configurator.addOptionalConfigGroups(config);
+		Config config = ConfigUtils.loadConfig(cmd.getOptionStrict("config-path"));
+		configurator.updateConfig(config);
 		EqasimConfigGroup.get(config).setAnalysisInterval(5);
 		EqasimConfigGroup.get(config).setDistanceUnit(DistanceUnit.foot);
 		cmd.applyConfiguration(config);

--- a/sao_paulo/src/main/java/org/eqasim/sao_paulo/RunSimulation.java
+++ b/sao_paulo/src/main/java/org/eqasim/sao_paulo/RunSimulation.java
@@ -28,8 +28,8 @@ public class RunSimulation {
 				.build();
 
 		EqasimConfigurator configurator = new EqasimConfigurator();
-		Config config = ConfigUtils.loadConfig(cmd.getOptionStrict("config-path"), configurator.getConfigGroups());
-		configurator.addOptionalConfigGroups(config);
+		Config config = ConfigUtils.loadConfig(cmd.getOptionStrict("config-path"));
+		configurator.updateConfig(config);
 		EqasimConfigGroup.get(config).setAnalysisInterval(1);
 		cmd.applyConfiguration(config);
 

--- a/switzerland/src/main/java/org/eqasim/switzerland/RunSimulation.java
+++ b/switzerland/src/main/java/org/eqasim/switzerland/RunSimulation.java
@@ -22,8 +22,8 @@ public class RunSimulation {
 				.build();
 
 		SwitzerlandConfigurator configurator = new SwitzerlandConfigurator();
-		Config config = ConfigUtils.loadConfig(cmd.getOptionStrict("config-path"), configurator.getConfigGroups());
-		configurator.addOptionalConfigGroups(config);
+		Config config = ConfigUtils.loadConfig(cmd.getOptionStrict("config-path"));
+		configurator.updateConfig(config);
 		cmd.applyConfiguration(config);
 
 		if (cmd.hasOption("preventwaitingtoentertraffic")) {

--- a/switzerland/src/main/java/org/eqasim/switzerland/scenario/RunAdaptConfig.java
+++ b/switzerland/src/main/java/org/eqasim/switzerland/scenario/RunAdaptConfig.java
@@ -20,7 +20,7 @@ public class RunAdaptConfig {
 
 	static public void main(String[] args) throws ConfigurationException {
 		SwitzerlandConfigurator configurator = new SwitzerlandConfigurator();
-		SwissConfigAdapter.run(args, configurator.getConfigGroups(), RunAdaptConfig::adaptConfiguration);
+		SwissConfigAdapter.run(args, configurator, RunAdaptConfig::adaptConfiguration);
 	}
 
 	static public void adaptConfiguration(Config config) {

--- a/switzerland/src/main/java/org/eqasim/switzerland/scenario/SwissConfigAdapter.java
+++ b/switzerland/src/main/java/org/eqasim/switzerland/scenario/SwissConfigAdapter.java
@@ -1,5 +1,6 @@
 package org.eqasim.switzerland.scenario;
 
+import org.eqasim.switzerland.SwitzerlandConfigurator;
 import org.matsim.core.config.*;
 
 import java.util.Arrays;
@@ -14,7 +15,7 @@ public class SwissConfigAdapter {
     protected static double downsamplingRate = 1.0;
     protected static double replanningRate = 0.05;
 
-    public static void run(String[] args, ConfigGroup[] modules, Consumer<Config> adapter)
+    public static void run(String[] args, SwitzerlandConfigurator configurator, Consumer<Config> adapter)
             throws CommandLine.ConfigurationException {
         CommandLine cmd = new CommandLine.Builder(args) //
                 .requireOptions("input-path", "output-path", "downsamplingRate", "replanningRate") //
@@ -33,7 +34,8 @@ public class SwissConfigAdapter {
 
         downsamplingRate = Double.parseDouble(cmd.getOptionStrict("downsamplingRate"));
 
-        Config config = ConfigUtils.loadConfig(cmd.getOptionStrict("input-path"), modules);
+        Config config = ConfigUtils.loadConfig(cmd.getOptionStrict("input-path"));
+        configurator.updateConfig(config);
         adapter.accept(config);
 
         new ConfigWriter(config).write(cmd.getOptionStrict("output-path"));


### PR DESCRIPTION
This PR simplifies the structure of `EqasimConfigurator`. Before, there was a fixed order between optional and regular modules. Now the modules have a fixed order overall, and they are activated/deactivated based on the presence of certain config groups. See the constructor of `EqasimConfigurator` to see the standard setup.

Breaking changes:
- `EqasimConfigurator.getConfigGroups()` does not exist anymore, use `EqasimConfigurator.updateConfig` instead after initializing the `Config` object
- `EqasimConfigurator.getModules` cannot be used to modify the module list anymore