### PR TITLE
fix: adapt to new way of configuring link speed calculator

### DIFF
--- a/core/src/main/java/org/eqasim/core/components/traffic/DefaultEqasimLinkSpeedCalculator.java
+++ b/core/src/main/java/org/eqasim/core/components/traffic/DefaultEqasimLinkSpeedCalculator.java
@@ -1,0 +1,33 @@
+package org.eqasim.core.components.traffic;
+
+import org.matsim.api.core.v01.network.Link;
+import org.matsim.core.mobsim.qsim.qnetsimengine.QVehicle;
+
+public class DefaultEqasimLinkSpeedCalculator implements EqasimLinkSpeedCalculator {
+	final private double crossingPenalty;
+
+	public DefaultEqasimLinkSpeedCalculator(double crossingPenalty) {
+		this.crossingPenalty = crossingPenalty;
+	}
+
+	@Override
+	public double getMaximumVelocity(QVehicle vehicle, Link link, double time) {
+		boolean isMajor = true;
+
+		for (Link other : link.getToNode().getInLinks().values()) {
+			if (other.getCapacity() >= link.getCapacity()) {
+				isMajor = false;
+			}
+		}
+
+		double maximumVelocity = Math.min(vehicle.getMaximumVelocity(), link.getFreespeed(time));
+
+		if (isMajor || link.getToNode().getInLinks().size() == 1) {
+			return maximumVelocity;
+		} else {
+			double travelTime = link.getLength() / maximumVelocity;
+			travelTime += crossingPenalty;
+			return link.getLength() / travelTime;
+		}
+	}
+}

--- a/core/src/main/java/org/eqasim/core/components/traffic/EqasimLinkSpeedCalculator.java
+++ b/core/src/main/java/org/eqasim/core/components/traffic/EqasimLinkSpeedCalculator.java
@@ -1,34 +1,6 @@
 package org.eqasim.core.components.traffic;
 
-import org.matsim.api.core.v01.network.Link;
-import org.matsim.core.mobsim.qsim.qnetsimengine.QVehicle;
 import org.matsim.core.mobsim.qsim.qnetsimengine.linkspeedcalculator.LinkSpeedCalculator;
 
-public class EqasimLinkSpeedCalculator implements LinkSpeedCalculator {
-	final private double crossingPenalty;
-
-	public EqasimLinkSpeedCalculator(double crossingPenalty) {
-		this.crossingPenalty = crossingPenalty;
-	}
-
-	@Override
-	public double getMaximumVelocity(QVehicle vehicle, Link link, double time) {
-		boolean isMajor = true;
-
-		for (Link other : link.getToNode().getInLinks().values()) {
-			if (other.getCapacity() >= link.getCapacity()) {
-				isMajor = false;
-			}
-		}
-
-		double maximumVelocity = Math.min(vehicle.getMaximumVelocity(), link.getFreespeed(time));
-
-		if (isMajor || link.getToNode().getInLinks().size() == 1) {
-			return maximumVelocity;
-		} else {
-			double travelTime = link.getLength() / maximumVelocity;
-			travelTime += crossingPenalty;
-			return link.getLength() / travelTime;
-		}
-	}
+public interface EqasimLinkSpeedCalculator extends LinkSpeedCalculator {
 }

--- a/core/src/main/java/org/eqasim/core/components/traffic/EqasimTrafficQSimModule.java
+++ b/core/src/main/java/org/eqasim/core/components/traffic/EqasimTrafficQSimModule.java
@@ -2,7 +2,6 @@ package org.eqasim.core.components.traffic;
 
 import org.eqasim.core.components.config.EqasimConfigGroup;
 import org.matsim.core.mobsim.qsim.AbstractQSimModule;
-import org.matsim.core.mobsim.qsim.qnetsimengine.linkspeedcalculator.LinkSpeedCalculator;
 
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
@@ -10,12 +9,13 @@ import com.google.inject.Singleton;
 public class EqasimTrafficQSimModule extends AbstractQSimModule {
 	@Override
 	protected void configureQSim() {
-		bind(LinkSpeedCalculator.class).to(EqasimLinkSpeedCalculator.class);
+		addLinkSpeedCalculator().to(EqasimLinkSpeedCalculator.class);
+		bind(EqasimLinkSpeedCalculator.class).to(DefaultEqasimLinkSpeedCalculator.class);
 	}
 
 	@Provides
 	@Singleton
-	public EqasimLinkSpeedCalculator provideBaselineLinkSpeedCalculator(EqasimConfigGroup eqasimConfig) {
-		return new EqasimLinkSpeedCalculator(eqasimConfig.getCrossingPenalty());
+	public DefaultEqasimLinkSpeedCalculator provideDefaultEqasimLinkSpeedCalculator(EqasimConfigGroup eqasimConfig) {
+		return new DefaultEqasimLinkSpeedCalculator(eqasimConfig.getCrossingPenalty());
 	}
 }

--- a/core/src/main/java/org/eqasim/core/simulation/vdf/VDFQSimModule.java
+++ b/core/src/main/java/org/eqasim/core/simulation/vdf/VDFQSimModule.java
@@ -1,13 +1,10 @@
 package org.eqasim.core.simulation.vdf;
 
+import org.eqasim.core.components.traffic.EqasimLinkSpeedCalculator;
 import org.eqasim.core.simulation.vdf.travel_time.VDFLinkSpeedCalculator;
 import org.eqasim.core.simulation.vdf.travel_time.VDFTravelTime;
-import org.matsim.api.core.v01.Scenario;
 import org.matsim.api.core.v01.population.Population;
-import org.matsim.core.api.experimental.events.EventsManager;
 import org.matsim.core.mobsim.qsim.AbstractQSimModule;
-import org.matsim.core.mobsim.qsim.qnetsimengine.ConfigurableQNetworkFactory;
-import org.matsim.core.mobsim.qsim.qnetsimengine.QNetworkFactory;
 
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
@@ -15,15 +12,7 @@ import com.google.inject.Singleton;
 public class VDFQSimModule extends AbstractQSimModule {
 	@Override
 	protected void configureQSim() {
-	}
-
-	@Provides
-	@Singleton
-	public QNetworkFactory provideQNetworkFactory(EventsManager events, Scenario scenario,
-			VDFLinkSpeedCalculator linkSpeedCalculator) {
-		ConfigurableQNetworkFactory networkFactory = new ConfigurableQNetworkFactory(events, scenario);
-		networkFactory.setLinkSpeedCalculator(linkSpeedCalculator);
-		return networkFactory;
+		bind(EqasimLinkSpeedCalculator.class).to(VDFLinkSpeedCalculator.class);
 	}
 
 	@Provides

--- a/core/src/main/java/org/eqasim/core/simulation/vdf/travel_time/VDFLinkSpeedCalculator.java
+++ b/core/src/main/java/org/eqasim/core/simulation/vdf/travel_time/VDFLinkSpeedCalculator.java
@@ -1,12 +1,12 @@
 package org.eqasim.core.simulation.vdf.travel_time;
 
+import org.eqasim.core.components.traffic.EqasimLinkSpeedCalculator;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.population.Person;
 import org.matsim.api.core.v01.population.Population;
 import org.matsim.core.mobsim.qsim.qnetsimengine.QVehicle;
-import org.matsim.core.mobsim.qsim.qnetsimengine.linkspeedcalculator.LinkSpeedCalculator;
 
-public class VDFLinkSpeedCalculator implements LinkSpeedCalculator {
+public class VDFLinkSpeedCalculator implements EqasimLinkSpeedCalculator {
 	private final VDFTravelTime travelTime;
 	private final Population population;
 

--- a/core/src/test/java/org/eqasim/TestEmissions.java
+++ b/core/src/test/java/org/eqasim/TestEmissions.java
@@ -165,7 +165,7 @@ public class TestEmissions {
 				"sample_41_EFA_ColdStart_SubSegm_2020detailed.csv", "--hbefa-hot-detailed",
 				"sample_41_EFA_HOT_SubSegm_2020detailed.csv", });
 
-		assertEquals(355977, countLines(new File("melun_test/output/output_emissions_events.xml.gz")));
+		assertEquals(353704, countLines(new File("melun_test/output/output_emissions_events.xml.gz")));
 
 		RunExportEmissionsNetwork.main(new String[] { "--config-path", "melun_test/input/config.xml",
 				"--pollutants", "PM,CO,NOx,Unknown", "--time-bin-size", "3600" });

--- a/ile_de_france/src/test/java/org/eqasim/ile_de_france/TestCorisica.java
+++ b/ile_de_france/src/test/java/org/eqasim/ile_de_france/TestCorisica.java
@@ -76,7 +76,7 @@ public class TestCorisica {
 			Assert.assertEquals(389, countPersons("corsica_test/simulation_output/output_plans.xml.gz"));
 
 			Map<String, Long> counts = countLegs("corsica_test/simulation_output/output_events.xml.gz");
-			Assert.assertEquals(992, (long) counts.get("car"));
+			Assert.assertEquals(994, (long) counts.get("car"));
 			Assert.assertEquals(129, (long) counts.get("car_passenger"));
 			Assert.assertEquals(221, (long) counts.get("walk"));
 			Assert.assertEquals(0, (long) counts.getOrDefault("bike", 0L));
@@ -120,7 +120,7 @@ public class TestCorisica {
 			});
 
 			Map<String, Long> counts = countLegs("corsica_test/cut_output/output_events.xml.gz");
-			Assert.assertEquals(422, (long) counts.get("car"));
+			Assert.assertEquals(424, (long) counts.get("car"));
 			Assert.assertEquals(53, (long) counts.get("car_passenger"));
 			Assert.assertEquals(101, (long) counts.get("walk"));
 			Assert.assertEquals(0, (long) counts.getOrDefault("bike", 0L));


### PR DESCRIPTION
This PR adapts the code to the new way of configuring the `LinkSpeedCalculator`. In particular, only VDF was using the crossing penalty in recent `develop` versions. Now, also the non-VDF simulations will use the proper calculator that takes into account the crossing penalty.