### PR TITLE
fix: various fixes for vdf

### DIFF
--- a/core/src/main/java/org/eqasim/core/simulation/vdf/VDFModule.java
+++ b/core/src/main/java/org/eqasim/core/simulation/vdf/VDFModule.java
@@ -17,6 +17,7 @@ import org.eqasim.core.simulation.vdf.travel_time.function.BPRFunction;
 import org.eqasim.core.simulation.vdf.travel_time.function.VolumeDelayFunction;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.core.config.ConfigGroup;
+import org.matsim.core.config.groups.ControllerConfigGroup;
 import org.matsim.core.config.groups.QSimConfigGroup;
 import org.matsim.core.controler.OutputDirectoryHierarchy;
 
@@ -52,12 +53,12 @@ public class VDFModule extends AbstractEqasimExtension {
 	@Provides
 	@Singleton
 	public VDFUpdateListener provideVDFUpdateListener(VDFScope scope, VDFTrafficHandler handler,
-			VDFTravelTime travelTime, VDFConfigGroup config, OutputDirectoryHierarchy outputHierarchy,
-			Network network) {
+			VDFTravelTime travelTime, VDFConfigGroup config, OutputDirectoryHierarchy outputHierarchy, Network network,
+			ControllerConfigGroup controllerConfig) {
 		URL inputFile = config.getInputFile() == null ? null
 				: ConfigGroup.getInputFileURL(getConfig().getContext(), config.getInputFile());
 		return new VDFUpdateListener(network, scope, handler, travelTime, outputHierarchy, config.getWriteInterval(),
-				config.getWriteFlowInterval(), inputFile);
+				config.getWriteFlowInterval(), controllerConfig.getFirstIteration(), inputFile);
 	}
 
 	@Provides

--- a/core/src/main/java/org/eqasim/core/simulation/vdf/handlers/VDFHorizonHandler.java
+++ b/core/src/main/java/org/eqasim/core/simulation/vdf/handlers/VDFHorizonHandler.java
@@ -63,7 +63,7 @@ public class VDFHorizonHandler implements VDFTrafficHandler, LinkEnterEventHandl
 	}
 
 	@Override
-	public IdMap<Link, List<Double>> aggregate() {
+	public IdMap<Link, List<Double>> aggregate(boolean ignoreIteration) {
 		while (state.size() > horizon) {
 			state.remove(0);
 		}
@@ -71,14 +71,15 @@ public class VDFHorizonHandler implements VDFTrafficHandler, LinkEnterEventHandl
 		logger.info(String.format("Starting aggregation of %d slices", state.size()));
 
 		// Make a copy to add to the history
+		if (!ignoreIteration) {
+			IdMap<Link, List<Double>> copy = new IdMap<>(Link.class);
 
-		IdMap<Link, List<Double>> copy = new IdMap<>(Link.class);
+			for (Map.Entry<Id<Link>, List<Double>> entry : counts.entrySet()) {
+				copy.put(entry.getKey(), new ArrayList<>(entry.getValue()));
+			}
 
-		for (Map.Entry<Id<Link>, List<Double>> entry : counts.entrySet()) {
-			copy.put(entry.getKey(), new ArrayList<>(entry.getValue()));
+			state.add(copy);
 		}
-
-		state.add(copy);
 
 		IdMap<Link, List<Double>> aggregated = new IdMap<>(Link.class);
 

--- a/core/src/main/java/org/eqasim/core/simulation/vdf/handlers/VDFInterpolationHandler.java
+++ b/core/src/main/java/org/eqasim/core/simulation/vdf/handlers/VDFInterpolationHandler.java
@@ -53,14 +53,19 @@ public class VDFInterpolationHandler implements VDFTrafficHandler, LinkEnterEven
 	}
 
 	@Override
-	public IdMap<Link, List<Double>> aggregate() {
-		interpolatedCounts.forEach((id, interpolated) -> {
-			List<Double> current = currentCounts.get(id);
+	public IdMap<Link, List<Double>> aggregate(boolean ignoreIteration) {
+		for (var item : interpolatedCounts.entrySet()) {
+			List<Double> current = currentCounts.get(item.getKey());
+			List<Double> interpolated = item.getValue();
 
 			for (int i = 0; i < interpolated.size(); i++) {
-				interpolated.set(i, (1.0 - updateFactor) * interpolated.get(i) + updateFactor * current.get(i));
+				if (!ignoreIteration) {
+					interpolated.set(i, (1.0 - updateFactor) * interpolated.get(i) + updateFactor * current.get(i));
+				}
+
+				current.set(i, 0.0);
 			}
-		});
+		}
 
 		return interpolatedCounts;
 	}
@@ -113,7 +118,7 @@ public class VDFInterpolationHandler implements VDFTrafficHandler, LinkEnterEven
 				outputStream.writeDouble(scope.getStartTime());
 				outputStream.writeDouble(scope.getEndTime());
 				outputStream.writeDouble(scope.getIntervalTime());
-				outputStream.writeDouble(scope.getIntervals());
+				outputStream.writeInt(scope.getIntervals());
 
 				for (var entry : interpolatedCounts.entrySet()) {
 					outputStream.writeUTF(entry.getKey().toString());

--- a/core/src/main/java/org/eqasim/core/simulation/vdf/handlers/VDFTrafficHandler.java
+++ b/core/src/main/java/org/eqasim/core/simulation/vdf/handlers/VDFTrafficHandler.java
@@ -11,7 +11,7 @@ import org.matsim.api.core.v01.network.Link;
 public interface VDFTrafficHandler {
 	void processEnterLink(double time, Id<Link> linkId);
 
-	IdMap<Link, List<Double>> aggregate();
+	IdMap<Link, List<Double>> aggregate(boolean ignoreIteration);
 
 	VDFReaderInterface getReader();
 


### PR DESCRIPTION
Various fixes for VDF:
- Ignore flows of the first iteration when a simulation is restarted (because the "iteration 0" that is going to be replayed right in the beginning is supposed to produce the same results as the last flows that are saved in the previous simulation's output flow)
- Add parameter to VDFHandler.aggregate to ignore flows, which also helps in loading the VDF flows and then updating travel times for simple routign applications
- Some fixes in the logic and IO of the interpolation-based handler