### PR TITLE
feat: vdf sparse horizon handler - file writing and reading

### DIFF
--- a/core/src/main/java/org/eqasim/core/simulation/vdf/handlers/VDFSparseHorizonHandler.java
+++ b/core/src/main/java/org/eqasim/core/simulation/vdf/handlers/VDFSparseHorizonHandler.java
@@ -87,7 +87,7 @@ public class VDFSparseHorizonHandler implements VDFTrafficHandler, LinkEnterEven
 				}
 
 				if (total > 0.0) {
-					LinkState linkState = newState.get(entry.getKey());
+					LinkState linkState = new LinkState(new ArrayList<>(), new ArrayList<>());
 					newState.put(entry.getKey(), linkState);
 
 					int timeIndex = 0;
@@ -211,6 +211,9 @@ public class VDFSparseHorizonHandler implements VDFTrafficHandler, LinkEnterEven
 					state.add(slice);
 
 					int sliceLinkCount = inputStream.readInt();
+
+					logger.info(String.format("Slice %d/%d, Reading %d link states", sliceIndex+1, slices, sliceLinkCount));
+
 					for (int sliceLinkIndex = 0; sliceLinkIndex < sliceLinkCount; sliceLinkIndex++) {
 						int linkIndex = inputStream.readInt();
 						int linkStateSize = inputStream.readInt();
@@ -256,12 +259,18 @@ public class VDFSparseHorizonHandler implements VDFTrafficHandler, LinkEnterEven
 					outputStream.writeUTF(linkIds.get(linkIndex).toString());
 				}
 
+				logger.info(String.format("About to write %d slices", state.size()));
+
 				for (int sliceIndex = 0; sliceIndex < state.size(); sliceIndex++) {
 					IdMap<Link, LinkState> slice = state.get(sliceIndex);
 					outputStream.writeInt(slice.size());
 
+					int sliceLinkIndex = 0;
 					for (Id<Link> linkId : linkIds) {
 						LinkState linkState = slice.get(linkId);
+						if(linkState == null) {
+							continue;
+						}
 						outputStream.writeInt(linkIds.indexOf(linkId));
 						outputStream.writeInt(linkState.count.size());
 
@@ -269,7 +278,9 @@ public class VDFSparseHorizonHandler implements VDFTrafficHandler, LinkEnterEven
 							outputStream.writeInt(linkState.time.get(i));
 							outputStream.writeDouble(linkState.count.get(i));
 						}
+						sliceLinkIndex += 1;
 					}
+					assert sliceLinkIndex == slice.size();
 				}
 
 				outputStream.close();

--- a/core/src/main/java/org/eqasim/core/simulation/vdf/utils/AdaptConfigForVDF.java
+++ b/core/src/main/java/org/eqasim/core/simulation/vdf/utils/AdaptConfigForVDF.java
@@ -25,9 +25,8 @@ public class AdaptConfigForVDF {
         VDFConfigGroup.getOrCreate(config).setWriteInterval(1);
         VDFConfigGroup.getOrCreate(config).setWriteFlowInterval(1);
 
-        // VDF: Set capacity factor instead (We retrieve it form the Eqasim config group)
-        EqasimConfigGroup eqasimConfigGroup = (EqasimConfigGroup) config.getModules().get(EqasimConfigGroup.GROUP_NAME);
-        VDFConfigGroup.getOrCreate(config).setCapacityFactor(eqasimConfigGroup.getSampleSize());
+        VDFConfigGroup vdfConfigGroup = VDFConfigGroup.getOrCreate(config);
+        vdfConfigGroup.setHandler(VDFConfigGroup.HandlerType.SparseHorizon);
 
         if(engine) {
             // VDF Engine: Add config group

--- a/core/src/main/java/org/eqasim/core/simulation/vdf/utils/AdaptConfigForVDF.java
+++ b/core/src/main/java/org/eqasim/core/simulation/vdf/utils/AdaptConfigForVDF.java
@@ -1,6 +1,5 @@
 package org.eqasim.core.simulation.vdf.utils;
 
-import org.eqasim.core.components.config.EqasimConfigGroup;
 import org.eqasim.core.simulation.EqasimConfigurator;
 import org.eqasim.core.simulation.vdf.VDFConfigGroup;
 import org.eqasim.core.simulation.vdf.engine.VDFEngineConfigGroup;

--- a/core/src/test/java/org/eqasim/TestSimulationPipeline.java
+++ b/core/src/test/java/org/eqasim/TestSimulationPipeline.java
@@ -378,6 +378,7 @@ public class TestSimulationPipeline {
     }
 
     public void runVdf() throws CommandLine.ConfigurationException, IOException, InterruptedException {
+        // This one will use the SparseHorizon handler
         AdaptConfigForVDF.main(new String[] {
                 "--input-config-path", "melun_test/input/config.xml",
                 "--output-config-path", "melun_test/input/config_vdf.xml",
@@ -387,6 +388,20 @@ public class TestSimulationPipeline {
         });
 
         runMelunSimulation("melun_test/input/config_vdf.xml", "melun_test/output_vdf");
+
+
+        // We force this one to use the legacy horizon handler
+        AdaptConfigForVDF.main(new String[] {
+                "--input-config-path", "melun_test/input/config.xml",
+                "--output-config-path", "melun_test/input/config_vdf_horizon.xml",
+                "--engine", "true",
+                "--config:eqasim:vdf_engine.generateNetworkEvents", "true",
+                "--config:eqasim:vdf.handler", "Horizon"
+        });
+
+        runMelunSimulation("melun_test/input/config_vdf_horizon.xml", "melun_test/output_vdf_horizon");
+
+        //assert CRCChecksum.getCRCFromFile("melun_test/output_vdf_horizon/output_events.xml.gz") == CRCChecksum.getCRCFromFile("melun_test/output_vdf/output_events.xml.gz");
 
         RunStandaloneModeChoice.main(new String[]{
                 "--config-path", "melun_test/input/config_vdf.xml",


### PR DESCRIPTION
This PR fixes the reading and writing of the vdf.bin file in the VDFSparseHorizonHandler currently under implementation (see PR #276). 

The writing and reading are tested in TestSimulationPipeline::runVdf by first running a VDF simulation using the VDFSparseHorizonHandler and then running a standalone mode choice on the same config while passing the written vdf.bin. 

Moreover, this PR prepares the comparison of simulation outputs with the VDFSparseHorizonHandler and the old VDFHorizonHandler by comparing the output events. This test is not passing currently, line 404 should be un-commented to check before merging into the develop branch.  