### PR TITLE
feat: departureId in PublicTransitEvent and in eqasim_pt.csv

### DIFF
--- a/core/src/main/java/org/eqasim/core/analysis/pt/PublicTransportLegItem.java
+++ b/core/src/main/java/org/eqasim/core/analysis/pt/PublicTransportLegItem.java
@@ -2,10 +2,7 @@ package org.eqasim.core.analysis.pt;
 
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.population.Person;
-import org.matsim.pt.transitSchedule.api.TransitLine;
-import org.matsim.pt.transitSchedule.api.TransitRoute;
-import org.matsim.pt.transitSchedule.api.TransitStopArea;
-import org.matsim.pt.transitSchedule.api.TransitStopFacility;
+import org.matsim.pt.transitSchedule.api.*;
 
 public class PublicTransportLegItem {
 	public Id<Person> personId;
@@ -20,12 +17,13 @@ public class PublicTransportLegItem {
 
 	public Id<TransitStopArea> accessAreaId;
 	public Id<TransitStopArea> egressAreaId;
+	public Id<Departure> departureId;
 
 	public String transitMode;
 
 	public PublicTransportLegItem(Id<Person> personId, int personTripId, int legIndex,
 			Id<TransitStopFacility> accessStopId, Id<TransitStopFacility> egressStopId, Id<TransitLine> transitLineId,
-			Id<TransitRoute> transitRouteId, Id<TransitStopArea> accessAreaId, Id<TransitStopArea> egressAreaId,
+			Id<TransitRoute> transitRouteId, Id<TransitStopArea> accessAreaId, Id<TransitStopArea> egressAreaId, Id<Departure> departureId,
 			String transitMode) {
 		this.personId = personId;
 		this.personTripId = personTripId;
@@ -39,6 +37,7 @@ public class PublicTransportLegItem {
 
 		this.accessAreaId = accessAreaId;
 		this.egressAreaId = egressAreaId;
+		this.departureId = departureId;
 
 		this.transitMode = transitMode;
 	}

--- a/core/src/main/java/org/eqasim/core/analysis/pt/PublicTransportLegListener.java
+++ b/core/src/main/java/org/eqasim/core/analysis/pt/PublicTransportLegListener.java
@@ -56,7 +56,8 @@ public class PublicTransportLegListener implements PersonDepartureEventHandler, 
 				event.getTransitLineId(), //
 				event.getTransitRouteId(), //
 				accessAreaId, //
-				egressAreaId, //
+				egressAreaId,
+				event.getDepartureId(),//
 				routeMode //
 		));
 	}

--- a/core/src/main/java/org/eqasim/core/analysis/pt/PublicTransportLegReaderFromPopulation.java
+++ b/core/src/main/java/org/eqasim/core/analysis/pt/PublicTransportLegReaderFromPopulation.java
@@ -69,7 +69,8 @@ public class PublicTransportLegReaderFromPopulation {
             Id<TransitStopArea> egressStopAreaId = this.transitSchedule.getFacilities().get(transitPassengerRoute.getEgressStopId()).getStopAreaId();
             String mode = this.transitSchedule.getTransitLines().get(transitPassengerRoute.getLineId()).getRoutes().get(transitPassengerRoute.getRouteId()).getTransportMode();
 
-            PublicTransportLegItem item = new PublicTransportLegItem(person.getId(), tripIndex, legIndex, transitPassengerRoute.getAccessStopId(), transitPassengerRoute.getEgressStopId(), transitPassengerRoute.getLineId(), transitPassengerRoute.getRouteId(), accessStopAreaId, egressStopAreaId, mode);
+            //Cannot read a departure ID from a population, as it is determined during MOBSim. We put a null value here.
+            PublicTransportLegItem item = new PublicTransportLegItem(person.getId(), tripIndex, legIndex, transitPassengerRoute.getAccessStopId(), transitPassengerRoute.getEgressStopId(), transitPassengerRoute.getLineId(), transitPassengerRoute.getRouteId(), accessStopAreaId, egressStopAreaId, null, mode);
             legItems.add(item);
         }
         return legItems;

--- a/core/src/main/java/org/eqasim/core/analysis/pt/PublicTransportLegWriter.java
+++ b/core/src/main/java/org/eqasim/core/analysis/pt/PublicTransportLegWriter.java
@@ -42,7 +42,8 @@ public class PublicTransportLegWriter {
 				"access_stop_id", //
 				"egress_stop_id", //
 				"transit_line_id", //
-				"transit_route_id", //
+				"transit_route_id",
+				"departure_id",//
 				"access_area_id", //
 				"egress_area_id", //
 				"transit_mode" //
@@ -57,7 +58,8 @@ public class PublicTransportLegWriter {
 				trip.accessStopId.toString(), //
 				trip.egressStopId.toString(), //
 				trip.transitLineId.toString(), //
-				trip.transitRouteId.toString(), //
+				trip.transitRouteId.toString(),
+				trip.departureId == null ? "" : trip.departureId.toString(), //
 				trip.accessAreaId == null ? "" : trip.accessAreaId.toString(), //
 				trip.egressAreaId == null ? "" : trip.egressAreaId.toString(), //
 				trip.transitMode //

--- a/core/src/main/java/org/eqasim/core/components/transit/EqasimTransitEngine.java
+++ b/core/src/main/java/org/eqasim/core/components/transit/EqasimTransitEngine.java
@@ -110,7 +110,7 @@ public class EqasimTransitEngine implements DepartureHandler, MobsimEngine {
 				Id<Link> arrivalLinkId = transitSchedule.getFacilities().get(route.getEgressStopId()).getLinkId();
 
 				PublicTransitEvent transitEvent = new PublicTransitEvent(arrivalTime, agent.getId(),
-						transitLine.getId(), transitRoute.getId(), route.getAccessStopId(), route.getEgressStopId(),
+						transitLine.getId(), transitRoute.getId(), route.getAccessStopId(), route.getEgressStopId(), stopDeparture.departure.getId(),
 						vehicleDepartureTime, route.getDistance());
 
 				internalInterface.registerAdditionalAgentOnLink(agent);

--- a/core/src/main/java/org/eqasim/core/components/transit/events/PublicTransitEvent.java
+++ b/core/src/main/java/org/eqasim/core/components/transit/events/PublicTransitEvent.java
@@ -6,6 +6,7 @@ import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.events.GenericEvent;
 import org.matsim.api.core.v01.events.HasPersonId;
 import org.matsim.api.core.v01.population.Person;
+import org.matsim.pt.transitSchedule.api.Departure;
 import org.matsim.pt.transitSchedule.api.TransitLine;
 import org.matsim.pt.transitSchedule.api.TransitRoute;
 import org.matsim.pt.transitSchedule.api.TransitStopFacility;
@@ -18,11 +19,12 @@ public class PublicTransitEvent extends GenericEvent implements HasPersonId {
 	final private Id<TransitRoute> transitRouteId;
 	final private Id<TransitStopFacility> accessStopId;
 	final private Id<TransitStopFacility> egressStopId;
+	final private Id<Departure> departureId;
 	final private double vehicleDepartureTime;
 	final private double travelDistance;
 
 	public PublicTransitEvent(double arrivalTime, Id<Person> personId, Id<TransitLine> transitLineId,
-			Id<TransitRoute> transitRouteId, Id<TransitStopFacility> accessStopId, Id<TransitStopFacility> egressStopId,
+			Id<TransitRoute> transitRouteId, Id<TransitStopFacility> accessStopId, Id<TransitStopFacility> egressStopId, Id<Departure> departureId,
 			double vehicleDepartureTime, double travelDistance) {
 		super(TYPE, arrivalTime);
 
@@ -31,13 +33,14 @@ public class PublicTransitEvent extends GenericEvent implements HasPersonId {
 		this.transitRouteId = transitRouteId;
 		this.accessStopId = accessStopId;
 		this.egressStopId = egressStopId;
+		this.departureId = departureId;
 		this.vehicleDepartureTime = vehicleDepartureTime;
 		this.travelDistance = travelDistance;
 	}
 
 	public PublicTransitEvent(double now, PublicTransitEvent delegate) {
 		this(now, delegate.getPersonId(), delegate.getTransitLineId(), delegate.getTransitRouteId(),
-				delegate.getAccessStopId(), delegate.getEgressStopId(), delegate.getVehicleDepartureTime(),
+				delegate.getAccessStopId(), delegate.getEgressStopId(), delegate.getDepartureId(), delegate.getVehicleDepartureTime(),
 				delegate.getTravelDistance());
 	}
 
@@ -55,6 +58,10 @@ public class PublicTransitEvent extends GenericEvent implements HasPersonId {
 
 	public Id<TransitStopFacility> getEgressStopId() {
 		return egressStopId;
+	}
+
+	public Id<Departure> getDepartureId() {
+		return departureId;
 	}
 
 	public double getVehicleDepartureTime() {
@@ -83,6 +90,7 @@ public class PublicTransitEvent extends GenericEvent implements HasPersonId {
 		attributes.put("route", transitRouteId.toString());
 		attributes.put("accessStop", accessStopId.toString());
 		attributes.put("egressStop", egressStopId.toString());
+		attributes.put("departure", departureId.toString());
 		attributes.put("vehicleDepartureTime", String.valueOf(vehicleDepartureTime));
 		attributes.put("travelDistance", String.valueOf(travelDistance));
 		return attributes;
@@ -98,9 +106,10 @@ public class PublicTransitEvent extends GenericEvent implements HasPersonId {
 		Id<TransitRoute> transitRouteId = Id.create(attributes.get("route"), TransitRoute.class);
 		Id<TransitStopFacility> accessStopId = Id.create(attributes.get("accessStop"), TransitStopFacility.class);
 		Id<TransitStopFacility> egressStopId = Id.create(attributes.get("egressStop"), TransitStopFacility.class);
+		Id<Departure> departureId = Id.create(attributes.get("departure"), Departure.class);
 		double vehicleDepartureTime = Double.parseDouble(attributes.get("vehicleDepartureTime"));
 		double travelDistance = Double.parseDouble(attributes.get("travelDistance"));
 
-		return new PublicTransitEvent(genericEvent.getTime(), personId, transitLineId, transitRouteId, accessStopId, egressStopId, vehicleDepartureTime, travelDistance);
+		return new PublicTransitEvent(genericEvent.getTime(), personId, transitLineId, transitRouteId, accessStopId, egressStopId, departureId, vehicleDepartureTime, travelDistance);
 	}
 }

--- a/core/src/main/java/org/eqasim/core/components/transit/events/PublicTransitEventMapper.java
+++ b/core/src/main/java/org/eqasim/core/components/transit/events/PublicTransitEventMapper.java
@@ -4,6 +4,7 @@ import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.events.GenericEvent;
 import org.matsim.api.core.v01.population.Person;
 import org.matsim.core.events.MatsimEventsReader.CustomEventMapper;
+import org.matsim.pt.transitSchedule.api.Departure;
 import org.matsim.pt.transitSchedule.api.TransitLine;
 import org.matsim.pt.transitSchedule.api.TransitRoute;
 import org.matsim.pt.transitSchedule.api.TransitStopFacility;
@@ -19,10 +20,11 @@ public class PublicTransitEventMapper implements CustomEventMapper {
 				TransitStopFacility.class);
 		Id<TransitStopFacility> egressStopId = Id.create(event.getAttributes().get("egressStop"),
 				TransitStopFacility.class);
+		Id<Departure> departureId = Id.create(event.getAttributes().get("departure"), Departure.class);
 		double vehicleDepartureTime = Double.parseDouble(event.getAttributes().get("vehicleDepartureTime"));
 		double travelDistance = Double.parseDouble(event.getAttributes().get("travelDistance"));
 
-		return new PublicTransitEvent(arrivalTime, personId, transitLineId, transitRouteId, accessStopId, egressStopId,
+		return new PublicTransitEvent(arrivalTime, personId, transitLineId, transitRouteId, accessStopId, egressStopId, departureId,
 				vehicleDepartureTime, travelDistance);
 	}
 }


### PR DESCRIPTION
This PR adds a departureId attribute in the PublicTransitEvent objects to track the departure used during the simulation (the departure is determined during mobsim and not as part of the transit route).  This allows to have a departureId column in the generated `eqasim_pt.csv` files.

**Note**
Since the departure ID information is not part of the route, it is not stored in the population file, so running the analyses from a plans file without and events file will generate an empty `departure_id` column. 