### PR TITLE
chore: using more efficient buffered streams

### DIFF
--- a/core/src/main/java/org/eqasim/core/components/travel_time/RecordedTravelTime.java
+++ b/core/src/main/java/org/eqasim/core/components/travel_time/RecordedTravelTime.java
@@ -17,6 +17,7 @@ import org.matsim.core.events.EventsUtils;
 import org.matsim.core.events.MatsimEventsReader;
 import org.matsim.core.router.util.TravelTime;
 import org.matsim.core.trafficmonitoring.FreeSpeedTravelTime;
+import org.matsim.core.utils.io.IOUtils;
 import org.matsim.vehicles.Vehicle;
 
 /**
@@ -78,7 +79,7 @@ public class RecordedTravelTime implements TravelTime {
 	}
 
 	static public void writeBinary(String outputPath, RecordedTravelTime travelTime) throws IOException, InterruptedException {
-		OutputStream outputStream = new FileOutputStream(outputPath);
+		OutputStream outputStream = IOUtils.getOutputStream(new File(outputPath).toURI().toURL(), false);
 		RecordedTravelTime.writeBinary(outputStream, travelTime);
 		outputStream.close();
 	}

--- a/core/src/main/java/org/eqasim/core/simulation/vdf/handlers/VDFHorizonHandler.java
+++ b/core/src/main/java/org/eqasim/core/simulation/vdf/handlers/VDFHorizonHandler.java
@@ -3,7 +3,6 @@ package org.eqasim.core.simulation.vdf.handlers;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.URL;
 import java.util.ArrayList;
@@ -220,7 +219,7 @@ public class VDFHorizonHandler implements VDFTrafficHandler, LinkEnterEventHandl
 		@Override
 		public void writeFile(File outputFile) {
 			try {
-				DataOutputStream outputStream = new DataOutputStream(new FileOutputStream(outputFile.toString()));
+				DataOutputStream outputStream = new DataOutputStream(IOUtils.getOutputStream(outputFile.toURI().toURL(), false));
 
 				outputStream.writeDouble(scope.getStartTime());
 				outputStream.writeDouble(scope.getEndTime());

--- a/core/src/main/java/org/eqasim/core/simulation/vdf/handlers/VDFInterpolationHandler.java
+++ b/core/src/main/java/org/eqasim/core/simulation/vdf/handlers/VDFInterpolationHandler.java
@@ -3,7 +3,6 @@ package org.eqasim.core.simulation.vdf.handlers;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.URL;
 import java.util.ArrayList;
@@ -113,7 +112,7 @@ public class VDFInterpolationHandler implements VDFTrafficHandler, LinkEnterEven
 		@Override
 		public void writeFile(File outputFile) {
 			try {
-				DataOutputStream outputStream = new DataOutputStream(new FileOutputStream(outputFile.toString()));
+				DataOutputStream outputStream = new DataOutputStream(IOUtils.getOutputStream(outputFile.toURI().toURL(), false));
 
 				outputStream.writeDouble(scope.getStartTime());
 				outputStream.writeDouble(scope.getEndTime());

--- a/core/src/main/java/org/eqasim/core/simulation/vdf/handlers/VDFSparseHorizonHandler.java
+++ b/core/src/main/java/org/eqasim/core/simulation/vdf/handlers/VDFSparseHorizonHandler.java
@@ -3,7 +3,6 @@ package org.eqasim.core.simulation.vdf.handlers;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.URL;
 import java.util.ArrayList;
@@ -244,7 +243,7 @@ public class VDFSparseHorizonHandler implements VDFTrafficHandler, LinkEnterEven
 		@Override
 		public void writeFile(File outputFile) {
 			try {
-				DataOutputStream outputStream = new DataOutputStream(new FileOutputStream(outputFile.toString()));
+				DataOutputStream outputStream = new DataOutputStream(IOUtils.getOutputStream(outputFile.toURI().toURL(), false));
 
 				outputStream.writeDouble(scope.getStartTime());
 				outputStream.writeDouble(scope.getEndTime());

--- a/core/src/main/java/org/eqasim/core/standalone_mode_choice/RunStandaloneModeChoice.java
+++ b/core/src/main/java/org/eqasim/core/standalone_mode_choice/RunStandaloneModeChoice.java
@@ -1,12 +1,7 @@
 package org.eqasim.core.standalone_mode_choice;
 
 
-import java.io.BufferedReader;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
+import java.io.*;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.nio.file.Paths;
@@ -45,12 +40,14 @@ import org.matsim.api.core.v01.population.Person;
 import org.matsim.api.core.v01.population.Population;
 import org.matsim.core.config.CommandLine;
 import org.matsim.core.config.Config;
+import org.matsim.core.config.ConfigGroup;
 import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.controler.AbstractModule;
 import org.matsim.core.controler.OutputDirectoryHierarchy;
 import org.matsim.core.router.util.TravelTime;
 import org.matsim.core.scenario.ScenarioUtils;
 import org.matsim.core.trafficmonitoring.FreeSpeedTravelTime;
+import org.matsim.core.utils.io.IOUtils;
 import org.matsim.pt.transitSchedule.api.TransitSchedule;
 import org.matsim.vehicles.Vehicle;
 
@@ -71,7 +68,7 @@ import com.google.inject.Singleton;
  * - travel-times-factors-path: if provided, should point out to a csv file specifying the congestion levels on the network during the day as factors by which the free speed is divided. The file in question is a csv With a header timeUpperBound;travelTimeFactor in which the timeUpperBound should be ordered incrementally.
  * - recorded-travel-times-path: mutually exclusive with the travel-times-factors-path. Points to a RecordedTravelTime file.
  * - eqasim-configurator-class: The full name of a class extending the {@link org.eqasim.core.simulation.EqasimConfigurator} class, the provided configurator class will be instantiated and used to:
- *   - Detect optional config groups using the {@link org.eqasim.core.simulation.EqasimConfigurator#addOptionalConfigGroups(Config)} method
+ *   - Detect optional config groups using the {@link org.eqasim.core.simulation.EqasimConfigurator#registerConfigGroup(ConfigGroup, boolean)} (Config)} method
  *   - Configure the scenario using the {@link org.eqasim.core.simulation.EqasimConfigurator#configureScenario(Scenario)} before loading
  *   - Adjust the scenario using the {@link org.eqasim.core.simulation.EqasimConfigurator#adjustScenario(Scenario)} after loading
  * - mode-choice-configurator-class: The full name of a class the extending the {@link org.eqasim.core.standalone_mode_choice.StandaloneModeChoiceConfigurator} class.
@@ -216,7 +213,7 @@ public class RunStandaloneModeChoice {
             @Singleton
             RecordedTravelTime provideRecordedTravelTime() {
                 try {
-                    InputStream inputStream = new FileInputStream(path);
+                    InputStream inputStream = IOUtils.getInputStream(new File(path).toURI().toURL());
                     RecordedTravelTime recordedTravelTime = RecordedTravelTime.readBinary(inputStream);
                     inputStream.close();
                     return recordedTravelTime;


### PR DESCRIPTION
In a few places, especially VDF, we were using non-buffered streams which can often be too slow. This PR replaces them by Buffered ones, by going through MATSim's IOUtils.