### PR TITLE
fix: external inlinks for LTZ policy

### DIFF
--- a/ile_de_france/src/main/java/org/eqasim/ile_de_france/policies/city_tax/CityTaxPolicyFactory.java
+++ b/ile_de_france/src/main/java/org/eqasim/ile_de_france/policies/city_tax/CityTaxPolicyFactory.java
@@ -56,7 +56,7 @@ public class CityTaxPolicyFactory implements PolicyFactory {
 		IdSet<Link> linkIds = PolicyLinkFinder
 				.create(new File(
 						ConfigGroup.getInputFileURL(config.getContext(), enterConfig.perimetersPath).getPath()))
-				.findLinks(network, Predicate.Entering);
+				.findLinks(network, Predicate.Entering, false);
 
 		logger.info("  Affected entering links: " + linkIds.size());
 

--- a/ile_de_france/src/main/java/org/eqasim/ile_de_france/policies/limited_traffic_zone/LimitedTrafficZonePolicyFactory.java
+++ b/ile_de_france/src/main/java/org/eqasim/ile_de_france/policies/limited_traffic_zone/LimitedTrafficZonePolicyFactory.java
@@ -67,7 +67,7 @@ public class LimitedTrafficZonePolicyFactory implements PolicyFactory {
 			linkIds = PolicyLinkFinder
 					.create(new File(
 							ConfigGroup.getInputFileURL(config.getContext(), ltzConfig.perimetersPath).getPath()))
-					.findLinks(network, Predicate.Inside);
+					.findLinks(network, Predicate.Inside, true);
 
 			logger.info("  Affected inside links: " + linkIds.size());
 		} else if (!ltzConfig.linkListPath.isEmpty()) {

--- a/ile_de_france/src/main/java/org/eqasim/ile_de_france/policies/routing/PolicyLinkFinder.java
+++ b/ile_de_france/src/main/java/org/eqasim/ile_de_france/policies/routing/PolicyLinkFinder.java
@@ -14,9 +14,11 @@ import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.Point;
 import org.matsim.api.core.v01.Coord;
+import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.IdSet;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
+import org.matsim.api.core.v01.network.Node;
 
 public class PolicyLinkFinder {
 	private final static GeometryFactory geometryFactory = new GeometryFactory();
@@ -31,7 +33,7 @@ public class PolicyLinkFinder {
 		Entering, Exiting, Crossing, Inside
 	}
 
-	public IdSet<Link> findLinks(Network network, Predicate predicate) {
+	public IdSet<Link> findLinks(Network network, Predicate predicate, boolean includeConnecting) {
 		IdSet<Link> linkIds = new IdSet<>(Link.class);
 
 		for (Link link : network.getLinks().values()) {
@@ -54,6 +56,38 @@ public class PolicyLinkFinder {
 
 				if (isRelvant) {
 					linkIds.add(link.getId());
+				}
+			}
+		}
+
+		if (includeConnecting) {
+			boolean continueNextRound = true;
+			while (continueNextRound) {
+				continueNextRound = false;
+
+				for (Link link : network.getLinks().values()) {
+					if (linkIds.contains(link.getId())) {
+						continue; // skip tagged links
+					}
+
+					Node toNode = link.getToNode();
+
+					boolean allConnectionsTagged = true;
+					for (Id<Link> outlinkId : toNode.getOutLinks().keySet()) {
+						if (outlinkId.equals(link.getId())) {
+							continue; // skip self loops
+						}
+
+						if (!linkIds.contains(outlinkId)) {
+							allConnectionsTagged = false;
+							break;
+						}
+					}
+
+					if (allConnectionsTagged) {
+						continueNextRound = true;
+						linkIds.add(link.getId());
+					}
 				}
 			}
 		}


### PR DESCRIPTION
The LTZ policy currently can have certain edge cases where agents do traverse the Limited Traffic Zone, although they don't perform a stop inside. This happens if their origin is a link that is *outside* of the ZTL, but it leads to a node that has only outlinks that are inside the ZTL (i.e. their endpoint is inside). In that case the trip should perform a detour around the ZTL (and the agent will try to exit as quickly as possible due to the routing penalty), but the route will indeed pass through the ZTL for a small number of links.

This PR fixes the problem by first identifying all links that are inside the ZTL and then also including links that lead to intersections that don't have another exit than into the ZTL. The links are identified in a round-based approach.