### PR TITLE
feat: ModeAvailabilityWrappersModule

### DIFF
--- a/core/src/main/java/org/eqasim/core/simulation/mode_choice/AbstractEqasimExtension.java
+++ b/core/src/main/java/org/eqasim/core/simulation/mode_choice/AbstractEqasimExtension.java
@@ -4,6 +4,7 @@ import java.util.Map;
 
 import org.eqasim.core.components.config.EqasimConfigGroup;
 import org.eqasim.core.simulation.mode_choice.cost.CostModel;
+import org.eqasim.core.simulation.mode_choice.mode_availability_wrapper.ModeAvailabilityWrapperFactory;
 import org.eqasim.core.simulation.mode_choice.utilities.UtilityEstimator;
 import org.matsim.contribs.discrete_mode_choice.modules.AbstractDiscreteModeChoiceExtension;
 
@@ -14,11 +15,13 @@ import com.google.inject.multibindings.MapBinder;
 public abstract class AbstractEqasimExtension extends AbstractDiscreteModeChoiceExtension {
 	private MapBinder<String, UtilityEstimator> estimatorBinder;
 	private MapBinder<String, CostModel> costModelBinder;
+	private MapBinder<String, ModeAvailabilityWrapperFactory> modeAvailabilityWrapperFactoryBinder;
 
 	@Override
 	protected void installExtension() {
 		this.estimatorBinder = MapBinder.newMapBinder(binder(), String.class, UtilityEstimator.class);
 		this.costModelBinder = MapBinder.newMapBinder(binder(), String.class, CostModel.class);
+		this.modeAvailabilityWrapperFactoryBinder = MapBinder.newMapBinder(binder(), String.class, ModeAvailabilityWrapperFactory.class);
 
 		installEqasimExtension();
 	}
@@ -29,6 +32,10 @@ public abstract class AbstractEqasimExtension extends AbstractDiscreteModeChoice
 
 	protected LinkedBindingBuilder<CostModel> bindCostModel(String name) {
 		return costModelBinder.addBinding(name);
+	}
+
+	protected LinkedBindingBuilder<ModeAvailabilityWrapperFactory> bindModeAvailabilityWrapperFactory(String name) {
+		return modeAvailabilityWrapperFactoryBinder.addBinding(name);
 	}
 
 	abstract protected void installEqasimExtension();

--- a/core/src/main/java/org/eqasim/core/simulation/mode_choice/EqasimModeChoiceModule.java
+++ b/core/src/main/java/org/eqasim/core/simulation/mode_choice/EqasimModeChoiceModule.java
@@ -15,6 +15,7 @@ import org.eqasim.core.simulation.mode_choice.epsilon.EpsilonModule;
 import org.eqasim.core.simulation.mode_choice.epsilon.EpsilonProvider;
 import org.eqasim.core.simulation.mode_choice.filters.OutsideFilter;
 import org.eqasim.core.simulation.mode_choice.filters.TourLengthFilter;
+import org.eqasim.core.simulation.mode_choice.mode_availability_wrapper.ModeAvailabilityWrappersModule;
 import org.eqasim.core.simulation.mode_choice.parameters.ModeParameters;
 import org.eqasim.core.simulation.mode_choice.utilities.EqasimUtilityEstimator;
 import org.eqasim.core.simulation.mode_choice.utilities.UtilityEstimator;
@@ -28,6 +29,7 @@ import org.eqasim.core.simulation.mode_choice.utilities.predictors.CarPredictor;
 import org.eqasim.core.simulation.mode_choice.utilities.predictors.PersonPredictor;
 import org.eqasim.core.simulation.mode_choice.utilities.predictors.PtPredictor;
 import org.eqasim.core.simulation.mode_choice.utilities.predictors.WalkPredictor;
+import org.eqasim.core.simulation.modes.drt.mode_choice.DrtModeAvailabilityWrapper;
 import org.eqasim.core.simulation.modes.drt.mode_choice.constraints.DrtServiceAreaConstraint;
 import org.eqasim.core.simulation.modes.drt.mode_choice.constraints.DrtWalkConstraint;
 import org.eqasim.core.simulation.modes.drt.mode_choice.predictors.DefaultDrtPredictor;
@@ -49,6 +51,8 @@ import com.google.inject.Singleton;
 import com.google.inject.name.Named;
 
 public class EqasimModeChoiceModule extends AbstractEqasimExtension {
+	public static final String DRT_MODE_AVAILABILITY_WRAPPER_NAME = "drt";
+
 	public static final String PASSENGER_CONSTRAINT_NAME = "PassengerConstraint";
 	public static final String OUTSIDE_CONSTRAINT_NAME = "OutsideConstraint";
 	public static final String DRT_WALK_CONSTRAINT = "DrtWalkConstraint";
@@ -72,6 +76,8 @@ public class EqasimModeChoiceModule extends AbstractEqasimExtension {
 
 	@Override
 	protected void installEqasimExtension() {
+		bindModeAvailabilityWrapperFactory(DRT_MODE_AVAILABILITY_WRAPPER_NAME).toInstance(modeAvailability -> new DrtModeAvailabilityWrapper(getConfig(), modeAvailability));
+
 		bindTripConstraintFactory(PASSENGER_CONSTRAINT_NAME).to(PassengerConstraint.Factory.class);
 		bindTripConstraintFactory(OUTSIDE_CONSTRAINT_NAME).to(OutsideConstraint.Factory.class);
 		bindTripConstraintFactory(DRT_WALK_CONSTRAINT).to(DrtWalkConstraint.Factory.class);
@@ -102,6 +108,7 @@ public class EqasimModeChoiceModule extends AbstractEqasimExtension {
 		bindHomeFinder(HOME_FINDER).to(EqasimHomeFinder.class);
 
 		install(new EpsilonModule());
+		install(new ModeAvailabilityWrappersModule());
 
 		// default binding that should be overridden
 		bind(ModeParameters.class).toInstance(new ModeParameters());
@@ -110,7 +117,7 @@ public class EqasimModeChoiceModule extends AbstractEqasimExtension {
 	@Provides
 	public EqasimUtilityEstimator provideModularUtilityEstimator(TripRouter tripRouter, ActivityFacilities facilities,
 			Map<String, Provider<UtilityEstimator>> factory, EqasimConfigGroup config,
-			TimeInterpretation timeInterpretation, DiscreteModeChoiceConfigGroup dmcConfig,
+			TimeInterpretation timeInterpretation,
 			EpsilonProvider epsilonProvider, UtilityPenalty utilityPenalty) {
 		Map<String, UtilityEstimator> estimators = new HashMap<>();
 

--- a/core/src/main/java/org/eqasim/core/simulation/mode_choice/mode_availability_wrapper/ModeAvailabilityWrapperFactory.java
+++ b/core/src/main/java/org/eqasim/core/simulation/mode_choice/mode_availability_wrapper/ModeAvailabilityWrapperFactory.java
@@ -1,0 +1,7 @@
+package org.eqasim.core.simulation.mode_choice.mode_availability_wrapper;
+
+import org.matsim.contribs.discrete_mode_choice.model.mode_availability.ModeAvailability;
+
+public interface ModeAvailabilityWrapperFactory {
+    ModeAvailability wrap(ModeAvailability wrapped);
+}

--- a/core/src/main/java/org/eqasim/core/simulation/mode_choice/mode_availability_wrapper/ModeAvailabilityWrappersModule.java
+++ b/core/src/main/java/org/eqasim/core/simulation/mode_choice/mode_availability_wrapper/ModeAvailabilityWrappersModule.java
@@ -1,0 +1,44 @@
+package org.eqasim.core.simulation.mode_choice.mode_availability_wrapper;
+
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import org.eqasim.core.simulation.mode_choice.AbstractEqasimExtension;
+import org.matsim.contribs.discrete_mode_choice.model.mode_availability.ModeAvailability;
+import org.matsim.contribs.discrete_mode_choice.modules.config.DiscreteModeChoiceConfigGroup;
+
+import java.util.Map;
+
+public class ModeAvailabilityWrappersModule extends AbstractEqasimExtension {
+    @Override
+    protected void installEqasimExtension() {
+        DiscreteModeChoiceConfigGroup discreteModeChoiceConfigGroup = (DiscreteModeChoiceConfigGroup) getConfig().getModules().get(DiscreteModeChoiceConfigGroup.GROUP_NAME);
+        String modeAvailabilityString = discreteModeChoiceConfigGroup.getModeAvailability();
+        if(!modeAvailabilityString.contains(":")) {
+            return;
+        }
+        bindModeAvailability(modeAvailabilityString).toProvider(new Provider<>() {
+            @Inject
+            Map<String, Provider<ModeAvailability>> modeAvailabilityProviders;
+
+            @Inject
+            Map<String, Provider<ModeAvailabilityWrapperFactory>> modeAvailabilityWrapperFactories;
+
+            @Override
+            public ModeAvailability get() {
+                String[] components = modeAvailabilityString.split(":");
+                if(!modeAvailabilityProviders.containsKey(components[components.length-1])) {
+                    throw new IllegalStateException("ModeAvailability not bound: " + components[components.length-1]);
+                }
+                ModeAvailability modeAvailability = modeAvailabilityProviders.get(components[components.length-1]).get();
+                for(int i=components.length-2; i>=0; i--) {
+                    if(!modeAvailabilityWrapperFactories.containsKey(components[i])) {
+                        throw new IllegalStateException("ModeAvailabilityWrapperFactory not bound: " + components[i]);
+                    }
+                    ModeAvailabilityWrapperFactory modeAvailabilityWrapperFactory = modeAvailabilityWrapperFactories.get(components[i]).get();
+                    modeAvailability = modeAvailabilityWrapperFactory.wrap(modeAvailability);
+                }
+                return modeAvailability;
+            }
+        });
+    }
+}

--- a/core/src/main/java/org/eqasim/core/simulation/modes/drt/utils/AdaptConfigForDrt.java
+++ b/core/src/main/java/org/eqasim/core/simulation/modes/drt/utils/AdaptConfigForDrt.java
@@ -45,7 +45,7 @@ import org.matsim.core.utils.misc.Time;
 
 public class AdaptConfigForDrt {
 
-    public static void adapt(Config config, Map<String, String> vehiclesPathByDrtMode, Map<String, String> operationalSchemes, Map<String, String> drtUtilityEstimators, Map<String, String> drtCostModels, Map<String, String> addLegTimeConstraint, String qsimEndtime, String modeAvailability) {
+    public static void adapt(Config config, Map<String, String> vehiclesPathByDrtMode, Map<String, String> operationalSchemes, Map<String, String> drtUtilityEstimators, Map<String, String> drtCostModels, Map<String, String> addLegTimeConstraint, String qsimEndtime) {
         if(!config.getModules().containsKey(DvrpConfigGroup.GROUP_NAME)) {
             config.addModule(new DvrpConfigGroup());
         }
@@ -59,8 +59,8 @@ public class AdaptConfigForDrt {
         List<LegTimeConstraintSingleLegConfigGroup> legTimeConstraintSingleLegConfigGroups = new ArrayList<>();
 
         // Add DRT to the available modes
-        if(modeAvailability != null) {
-            dmcConfig.setModeAvailability(modeAvailability);
+        if(!dmcConfig.getModeAvailability().contains(EqasimModeChoiceModule.DRT_MODE_AVAILABILITY_WRAPPER_NAME)) {
+            dmcConfig.setModeAvailability(EqasimModeChoiceModule.DRT_MODE_AVAILABILITY_WRAPPER_NAME + ":" + dmcConfig.getModeAvailability());
         }
 
 
@@ -178,7 +178,6 @@ public class AdaptConfigForDrt {
         CommandLine cmd = new CommandLine.Builder(args) //
                 .requireOptions("input-config-path", "output-config-path", "vehicles-paths")
                 .allowOptions("mode-names")
-                .allowOptions("mode-availability")
                 .allowOptions(EqasimConfigurator.CONFIGURATOR)
                 .allowOptions("operational-schemes")
                 .allowOptions("cost-models", "estimators")
@@ -212,7 +211,7 @@ public class AdaptConfigForDrt {
         Config config = ConfigUtils.loadConfig(inputConfigPath);
         configurator.updateConfig(config);
         
-        adapt(config, info.get("vehicles-paths"), info.get("operational-schemes"), info.get("estimators"), info.get("cost-models"), info.get("add-leg-time-constraint"), qsimEndtime, cmd.getOption("mode-availability").orElse(null));
+        adapt(config, info.get("vehicles-paths"), info.get("operational-schemes"), info.get("estimators"), info.get("cost-models"), info.get("add-leg-time-constraint"), qsimEndtime);
 
         cmd.applyConfiguration(config);
 

--- a/core/src/main/java/org/eqasim/core/simulation/modes/feeder_drt/mode_choice/EqasimFeederDrtModeChoiceModule.java
+++ b/core/src/main/java/org/eqasim/core/simulation/modes/feeder_drt/mode_choice/EqasimFeederDrtModeChoiceModule.java
@@ -16,11 +16,13 @@ import com.google.inject.Provides;
 public class EqasimFeederDrtModeChoiceModule extends AbstractEqasimExtension {
 
     public static final String FEEDER_DRT_ESTIMATOR_NAME = "DefaultFeederDrtUtilityEstimator";
+    public static final String FEEDER_DRT_MODE_AVAILABILITY_WRAPPER_NAME = "feederDrt";
 
     @Override
     protected void installEqasimExtension() {
         bindUtilityEstimator(FEEDER_DRT_ESTIMATOR_NAME).to(DefaultFeederDrtUtilityEstimator.class);
         bindTripConstraintFactory(FeederDrtConstraint.NAME).to(FeederDrtConstraint.Factory.class).asEagerSingleton();
+        bindModeAvailabilityWrapperFactory(FEEDER_DRT_MODE_AVAILABILITY_WRAPPER_NAME).toInstance(modeAvailability -> new FeederDrtModeAvailabilityWrapper(getConfig(), modeAvailability));
     }
 
     @Provides

--- a/core/src/main/java/org/eqasim/core/simulation/modes/feeder_drt/utils/AdaptConfigForFeederDrt.java
+++ b/core/src/main/java/org/eqasim/core/simulation/modes/feeder_drt/utils/AdaptConfigForFeederDrt.java
@@ -29,7 +29,7 @@ import org.matsim.pt.config.TransitConfigGroup;
 
 public class AdaptConfigForFeederDrt {
 
-    public static void adapt(Config config, Map<String, String> basePtModes, Map<String, String> baseDrtModes, Map<String, String> utilityEstimators, Map<String, String> accessEgressTransitStopModes, Map<String, String> accessEgressTransitStopIds, String modeAvailability) {
+    public static void adapt(Config config, Map<String, String> basePtModes, Map<String, String> baseDrtModes, Map<String, String> utilityEstimators, Map<String, String> accessEgressTransitStopModes, Map<String, String> accessEgressTransitStopIds) {
         if(!config.getModules().containsKey(MultiModeDrtConfigGroup.GROUP_NAME)) {
             throw new IllegalStateException(String.format("Cannot add module '%s' if module '%s' is not present already. You can use '%s' to configure it.", MultiModeFeederDrtConfigGroup.GROUP_NAME, MultiModeDrtConfigGroup.GROUP_NAME, AdaptConfigForDrt.class.getCanonicalName()));
         }
@@ -50,8 +50,8 @@ public class AdaptConfigForFeederDrt {
         }
 
         // Add DRT to the available modes
-        if(modeAvailability != null) {
-            dmcConfig.setModeAvailability(modeAvailability);
+        if(!dmcConfig.getModeAvailability().contains(EqasimFeederDrtModeChoiceModule.FEEDER_DRT_MODE_AVAILABILITY_WRAPPER_NAME)) {
+            dmcConfig.setModeAvailability(EqasimFeederDrtModeChoiceModule.FEEDER_DRT_MODE_AVAILABILITY_WRAPPER_NAME + ":" + dmcConfig.getModeAvailability());
         }
 
 
@@ -132,7 +132,6 @@ public class AdaptConfigForFeederDrt {
                 .allowOptions("estimators")
                 .allowOptions("access-egress-transit-stop-modes")
                 .allowOptions("access-egress-transit-stop-ids")
-                .allowOptions("mode-availability")
                 .allowOptions(EqasimConfigurator.CONFIGURATOR)
                 .build();
 
@@ -159,7 +158,7 @@ public class AdaptConfigForFeederDrt {
         Config config = ConfigUtils.loadConfig(inputConfigPath);
         configurator.updateConfig(config);
 
-        adapt(config, info.get("base-pt-modes"), info.get("base-drt-modes"), info.get("estimators"), info.get("access-egress-transit-stop-modes"), info.get("access-egress-transit-stop-ids"), cmd.getOption("mode-availability").orElse(null));
+        adapt(config, info.get("base-pt-modes"), info.get("base-drt-modes"), info.get("estimators"), info.get("access-egress-transit-stop-modes"), info.get("access-egress-transit-stop-ids"));
 
         ConfigUtils.writeConfig(config, outputConfigPath);
     }

--- a/core/src/main/java/org/eqasim/core/simulation/modes/transit_with_abstract_access/mode_choice/TransitWithAbstractAccessModeChoiceModule.java
+++ b/core/src/main/java/org/eqasim/core/simulation/modes/transit_with_abstract_access/mode_choice/TransitWithAbstractAccessModeChoiceModule.java
@@ -8,9 +8,11 @@ import org.eqasim.core.simulation.modes.transit_with_abstract_access.mode_choice
 public class TransitWithAbstractAccessModeChoiceModule extends AbstractEqasimExtension {
 
     public static final String TRANSIT_WITH_ABSTRACT_ACCESS_UTILITY_ESTIMATOR_NAME = "TransitWithAbstractAccessUtilityEstimator";
+    public static final String TRANSIT_WITH_ABSTRACT_ACCESS_MODE_AVAILABILITY_WRAPPER_NAME = "TransitWithAbstractAccessModeAvailabilityWrapper";
 
     @Override
     protected void installEqasimExtension() {
+        bindModeAvailabilityWrapperFactory(TRANSIT_WITH_ABSTRACT_ACCESS_MODE_AVAILABILITY_WRAPPER_NAME).toInstance(modeAvailability -> new TransitWithAbstractAccessModeAvailabilityWrapper(getConfig(), modeAvailability));
         bind(TransitWithAbstractAccessPredictor.class);
         bindUtilityEstimator(TRANSIT_WITH_ABSTRACT_ACCESS_UTILITY_ESTIMATOR_NAME).to(TransitWithAbstractAccessUtilityEstimator.class);
         bindTripConstraintFactory(TransitWithAbstractAccessConstraint.NAME).to(TransitWithAbstractAccessConstraint.Factory.class);

--- a/core/src/main/java/org/eqasim/core/simulation/modes/transit_with_abstract_access/utils/AdaptConfigForTransitWithAbstractAccess.java
+++ b/core/src/main/java/org/eqasim/core/simulation/modes/transit_with_abstract_access/utils/AdaptConfigForTransitWithAbstractAccess.java
@@ -31,6 +31,10 @@ public class AdaptConfigForTransitWithAbstractAccess {
         DiscreteModeChoiceConfigGroup dmcConfigGroup = (DiscreteModeChoiceConfigGroup) config.getModules().get(DiscreteModeChoiceConfigGroup.GROUP_NAME);
         dmcConfigGroup.getTripConstraints().add(TransitWithAbstractAccessConstraint.NAME);
 
+        if(!dmcConfigGroup.getModeAvailability().contains(TransitWithAbstractAccessModeChoiceModule.TRANSIT_WITH_ABSTRACT_ACCESS_MODE_AVAILABILITY_WRAPPER_NAME)) {
+            dmcConfigGroup.setModeAvailability(TransitWithAbstractAccessModeChoiceModule.TRANSIT_WITH_ABSTRACT_ACCESS_MODE_AVAILABILITY_WRAPPER_NAME + ":" + dmcConfigGroup.getModeAvailability());
+        }
+
         Set<String> cachedModes = new HashSet<>(dmcConfigGroup.getCachedModes());
         cachedModes.add(mode);
         dmcConfigGroup.setCachedModes(cachedModes);

--- a/core/src/test/java/org/eqasim/TestSimulationPipeline.java
+++ b/core/src/test/java/org/eqasim/TestSimulationPipeline.java
@@ -25,9 +25,7 @@ import org.eqasim.core.simulation.modes.drt.analysis.run.RunDrtVehicleAnalysis;
 import org.eqasim.core.simulation.modes.drt.utils.AdaptConfigForDrt;
 import org.eqasim.core.simulation.modes.drt.utils.CreateDrtVehicles;
 import org.eqasim.core.simulation.modes.feeder_drt.analysis.run.RunFeederDrtPassengerAnalysis;
-import org.eqasim.core.simulation.modes.feeder_drt.mode_choice.FeederDrtModeAvailabilityWrapper;
 import org.eqasim.core.simulation.modes.feeder_drt.utils.AdaptConfigForFeederDrt;
-import org.eqasim.core.simulation.modes.transit_with_abstract_access.mode_choice.TransitWithAbstractAccessModeAvailabilityWrapper;
 import org.eqasim.core.simulation.modes.transit_with_abstract_access.utils.AdaptConfigForTransitWithAbstractAccess;
 import org.eqasim.core.simulation.modes.transit_with_abstract_access.utils.CreateAbstractAccessItemsForTransitLines;
 import org.eqasim.core.simulation.vdf.VDFConfigGroup;
@@ -47,7 +45,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.matsim.api.core.v01.Scenario;
 import org.matsim.api.core.v01.network.Link;
-import org.matsim.contribs.discrete_mode_choice.model.mode_availability.ModeAvailability;
 import org.matsim.core.config.CommandLine;
 import org.matsim.core.config.CommandLine.ConfigurationException;
 import org.matsim.core.config.Config;
@@ -57,8 +54,6 @@ import org.matsim.core.controler.Controler;
 import org.matsim.core.scenario.ScenarioUtils;
 import org.matsim.core.utils.misc.CRCChecksum;
 
-import com.google.inject.Inject;
-import com.google.inject.Provider;
 
 public class TestSimulationPipeline {
 
@@ -108,16 +103,7 @@ public class TestSimulationPipeline {
             @Override
             protected void installEqasimExtension() {
                 bind(ModeParameters.class);
-                bindModeAvailability("DefaultModeAvailability").toProvider(new Provider<>() {
-                    @Inject
-                    private Config config;
-
-                    @Override
-                    public ModeAvailability get() {
-                        FeederDrtModeAvailabilityWrapper feederDrtModeAvailabilityWrapper = new FeederDrtModeAvailabilityWrapper(config, new TestModeAvailability());
-                        return new TransitWithAbstractAccessModeAvailabilityWrapper(config, feederDrtModeAvailabilityWrapper);
-                    }
-                }).asEagerSingleton();
+                bindModeAvailability("DefaultModeAvailability").to(TestModeAvailability.class).asEagerSingleton();
             }
         });
         controller.run();


### PR DESCRIPTION
This is an attempt to simplify the integration of new modes present in Eqasim (drt, feederDrt, transitWithAbstractAccess) in existing simulations. Mainly, we want them to work without having to manually override the `ModeAvailability` binding.

To do so, we allow to prefix the regular `modeAvailability` attribute in the `DiscreteModeChoiceConfigGroup` with a wrapper prefix (e.g. `feederDrt:IDFModeAvailability`). If one or more feederDrt modes are configured, they will then be allowed for all agents. Multiple wrapper prefixes can be chained to allow more than one extra mode. 

Technically, this feature is handled by a  `ModeAvailabilityWrappersModule` that checks the `modeAvailability` attribute and resolves the wrappers that are bound through the new method `AbstractEqasimExtension::bindModeAvailabilityWrapperFactory`. 