### PR TITLE
feat(server): process requests in batch from a file

### DIFF
--- a/server/src/main/java/org/eqasim/server/RunProcessor.java
+++ b/server/src/main/java/org/eqasim/server/RunProcessor.java
@@ -1,0 +1,131 @@
+package org.eqasim.server;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.function.Function;
+
+import org.eqasim.core.misc.ParallelProgress;
+import org.eqasim.server.ServiceBuilder.Services;
+import org.eqasim.server.services.isochrone.road.RoadIsochroneRequest;
+import org.eqasim.server.services.isochrone.road.RoadIsochroneResponse;
+import org.eqasim.server.services.isochrone.transit.TransitIsochroneRequest;
+import org.eqasim.server.services.isochrone.transit.TransitIsochroneResponse;
+import org.eqasim.server.services.router.road.FreespeedSettings;
+import org.eqasim.server.services.router.road.RoadRouterRequest;
+import org.eqasim.server.services.router.road.RoadRouterResponse;
+import org.eqasim.server.services.router.transit.TransitRouterRequest;
+import org.eqasim.server.services.router.transit.TransitRouterResponse;
+import org.eqasim.server.services.router.transit.TransitUtilities;
+import org.matsim.core.config.CommandLine;
+import org.matsim.core.config.CommandLine.ConfigurationException;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class RunProcessor {
+	public static void main(String[] args)
+			throws ConfigurationException, JsonParseException, JsonMappingException, IOException, InterruptedException,
+			ExecutionException {
+		CommandLine cmd = new CommandLine.Builder(args) //
+				.requireOptions("config-path", "input-path", "output-path") //
+				.allowOptions("threads", "configuration-path", "use-transit", "indent-response") //
+				.build();
+
+		Services services = new ServiceBuilder().build(cmd);
+
+		int threads = cmd.getOption("threads").map(Integer::parseInt)
+				.orElse(Runtime.getRuntime().availableProcessors());
+
+		ObjectMapper objectMapper = new ObjectMapper();
+		if (cmd.getOption("indent-response").map(Boolean::parseBoolean).orElse(false)) {
+
+		}
+
+		ProcessorInput input = objectMapper.readValue(new File(cmd.getOptionStrict("input-path")),
+				ProcessorInput.class);
+		ProcessorOutput output = new ProcessorOutput();
+
+		ExecutorService executor = Executors.newFixedThreadPool(threads);
+
+		process(input.roadRouter, output.roadRouter,
+				request -> services.roadRouterService().processRequest(request, input.freespeed), "road_router",
+				executor);
+
+		process(input.roadIsochrone, output.roadIsochrone, services.roadIsochroneService()::processRequest,
+				"road_isochrone", executor);
+
+		process(input.transitRouter, output.transitRouter,
+				request -> services.transitRouterService().processRequest(request, input.transitUtilities),
+				"transit_router", executor);
+
+		process(input.transitIsochrone, output.transitIsochrone, services.transitIsochroneService()::processRequest,
+				"transit_isochrone", executor);
+
+		objectMapper.writerWithDefaultPrettyPrinter().writeValue(new File(cmd.getOptionStrict("output-path")), output);
+	}
+
+	private static class ProcessorInput {
+		@JsonProperty("freespeed")
+		FreespeedSettings freespeed = null;
+
+		@JsonProperty("road_router")
+		List<RoadRouterRequest> roadRouter = new LinkedList<>();
+
+		@JsonProperty("road_isochrone")
+		List<RoadIsochroneRequest> roadIsochrone = new LinkedList<>();
+
+		@JsonProperty("transit_utilities")
+		TransitUtilities transitUtilities = null;
+
+		@JsonProperty("transit_router")
+		List<TransitRouterRequest> transitRouter = new LinkedList<>();
+
+		@JsonProperty("transit_isochrone")
+		List<TransitIsochroneRequest> transitIsochrone = new LinkedList<>();
+	}
+
+	private static class ProcessorOutput {
+		@JsonProperty("road_router")
+		List<RoadRouterResponse> roadRouter = new LinkedList<>();
+
+		@JsonProperty("road_isochrone")
+		List<RoadIsochroneResponse> roadIsochrone = new LinkedList<>();
+
+		@JsonProperty("transit_router")
+		List<TransitRouterResponse> transitRouter = new LinkedList<>();
+
+		@JsonProperty("transit_isochrone")
+		List<TransitIsochroneResponse> transitIsochrone = new LinkedList<>();
+	}
+
+	private static <Response, Request> void process(List<Request> requests, List<Response> responses,
+			Function<Request, Response> service, String serivceName, ExecutorService executor)
+			throws InterruptedException, ExecutionException {
+		if (requests.size() > 0) {
+			ParallelProgress progress = new ParallelProgress("Processing " + serivceName, requests.size());
+
+			List<Callable<Response>> tasks = new LinkedList<>();
+			for (Request request : requests) {
+				tasks.add(() -> {
+					Response response = service.apply(request);
+					progress.update();
+					return response;
+				});
+			}
+
+			for (var task : executor.invokeAll(tasks)) {
+				responses.add(task.get());
+			}
+
+			progress.close();
+		}
+	}
+}

--- a/server/src/main/java/org/eqasim/server/RunServer.java
+++ b/server/src/main/java/org/eqasim/server/RunServer.java
@@ -1,38 +1,19 @@
 package org.eqasim.server;
 
-import java.io.File;
 import java.io.IOException;
-import java.util.Collections;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
-import org.eqasim.core.components.raptor.EqasimRaptorConfigGroup;
+import org.eqasim.server.ServiceBuilder.Services;
 import org.eqasim.server.api.RoadIsochroneEndpoint;
 import org.eqasim.server.api.RoadRouterEndpoint;
 import org.eqasim.server.api.TransitIsochroneEndpoint;
 import org.eqasim.server.api.TransitRouterEndpoint;
-import org.eqasim.server.services.ServiceConfiguration;
-import org.eqasim.server.services.isochrone.road.RoadIsochroneService;
-import org.eqasim.server.services.isochrone.transit.TransitIsochroneService;
-import org.eqasim.server.services.router.road.RoadRouterService;
-import org.eqasim.server.services.router.transit.TransitRouterService;
-import org.matsim.api.core.v01.Scenario;
-import org.matsim.api.core.v01.network.Network;
 import org.matsim.core.config.CommandLine;
 import org.matsim.core.config.CommandLine.ConfigurationException;
-import org.matsim.core.config.Config;
-import org.matsim.core.config.ConfigGroup;
-import org.matsim.core.config.ConfigUtils;
-import org.matsim.core.network.NetworkUtils;
-import org.matsim.core.network.algorithms.NetworkCleaner;
-import org.matsim.core.network.algorithms.TransportModeNetworkFilter;
-import org.matsim.core.network.io.MatsimNetworkReader;
-import org.matsim.core.scenario.ScenarioUtils;
-import org.matsim.pt.transitSchedule.api.TransitScheduleReader;
 
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonMappingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.javalin.Javalin;
 
@@ -44,16 +25,10 @@ public class RunServer {
 				.allowOptions("threads", "configuration-path", "use-transit") //
 				.build();
 
+		Services services = new ServiceBuilder().build(cmd);
+
 		int threads = cmd.getOption("threads").map(Integer::parseInt)
 				.orElse(Runtime.getRuntime().availableProcessors());
-
-		ServiceConfiguration configuration = new ServiceConfiguration();
-
-		if (cmd.hasOption("configuration-path")) {
-			ObjectMapper objectMapper = new ObjectMapper();
-			configuration = objectMapper.readValue(new File(cmd.getOptionStrict("configuration-path")),
-					ServiceConfiguration.class);
-		}
 
 		// Create Javalin application and enable CORS
 		Javalin app = Javalin.create(config -> {
@@ -64,44 +39,22 @@ public class RunServer {
 			});
 		});
 
-		Config config = ConfigUtils.loadConfig(cmd.getOptionStrict("config-path"), new EqasimRaptorConfigGroup());
-		Scenario scenario = ScenarioUtils.createScenario(config);
-
-		new MatsimNetworkReader(scenario.getNetwork())
-				.readURL(ConfigGroup.getInputFileURL(config.getContext(), config.network().getInputFile()));
-
-		boolean useTransit = cmd.getOption("use-transit").map(Boolean::parseBoolean).orElse(true);
-		if (useTransit) {
-			new TransitScheduleReader(scenario).readURL(
-					ConfigGroup.getInputFileURL(config.getContext(), config.transit().getTransitScheduleFile()));
-		}
-
 		ExecutorService executor = Executors.newFixedThreadPool(threads);
 
-		Network roadNetwork = NetworkUtils.createNetwork();
-		new TransportModeNetworkFilter(scenario.getNetwork()).filter(roadNetwork, Collections.singleton("car"));
-		new NetworkCleaner().run(roadNetwork);
-
-		RoadRouterService roadRouterService = RoadRouterService.create(config, roadNetwork, configuration.walk,
-				threads);
-		RoadRouterEndpoint roadRouterEndpoint = new RoadRouterEndpoint(executor, roadRouterService);
+		RoadRouterEndpoint roadRouterEndpoint = new RoadRouterEndpoint(executor, services.roadRouterService());
 		app.post("/router/road", roadRouterEndpoint::post);
 
-		RoadIsochroneService roadIsochroneService = RoadIsochroneService.create(config, roadNetwork,
-				configuration.walk);
-		RoadIsochroneEndpoint roadIsochroneEndpoint = new RoadIsochroneEndpoint(executor, roadIsochroneService);
+		RoadIsochroneEndpoint roadIsochroneEndpoint = new RoadIsochroneEndpoint(executor,
+				services.roadIsochroneService());
 		app.post("/isochrone/road", roadIsochroneEndpoint::post);
 
-		if (useTransit) {
-			TransitRouterService transitRouterService = TransitRouterService.create(config, scenario.getNetwork(),
-					scenario.getTransitSchedule(), configuration.transit, configuration.walk);
-			TransitRouterEndpoint transitRouterEndpoint = new TransitRouterEndpoint(executor, transitRouterService);
+		if (services.transitRouterService() != null) {
+			TransitRouterEndpoint transitRouterEndpoint = new TransitRouterEndpoint(executor,
+					services.transitRouterService());
 			app.post("/router/transit", transitRouterEndpoint::post);
 
-			TransitIsochroneService transitIsochroneService = TransitIsochroneService.create(config,
-					scenario.getTransitSchedule(), configuration.transit, configuration.walk);
 			TransitIsochroneEndpoint transitIsochroneEndpoint = new TransitIsochroneEndpoint(executor,
-					transitIsochroneService);
+					services.transitIsochroneService());
 			app.post("/isochrone/transit", transitIsochroneEndpoint::post);
 		}
 

--- a/server/src/main/java/org/eqasim/server/ServiceBuilder.java
+++ b/server/src/main/java/org/eqasim/server/ServiceBuilder.java
@@ -1,0 +1,95 @@
+package org.eqasim.server;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Collections;
+
+import org.eqasim.core.components.raptor.EqasimRaptorConfigGroup;
+import org.eqasim.server.services.ServiceConfiguration;
+import org.eqasim.server.services.isochrone.road.RoadIsochroneService;
+import org.eqasim.server.services.isochrone.transit.TransitIsochroneService;
+import org.eqasim.server.services.router.road.RoadRouterService;
+import org.eqasim.server.services.router.transit.TransitRouterService;
+import org.matsim.api.core.v01.Scenario;
+import org.matsim.api.core.v01.network.Network;
+import org.matsim.core.config.CommandLine;
+import org.matsim.core.config.CommandLine.ConfigurationException;
+import org.matsim.core.config.Config;
+import org.matsim.core.config.ConfigGroup;
+import org.matsim.core.config.ConfigUtils;
+import org.matsim.core.network.NetworkUtils;
+import org.matsim.core.network.algorithms.NetworkCleaner;
+import org.matsim.core.network.algorithms.TransportModeNetworkFilter;
+import org.matsim.core.network.io.MatsimNetworkReader;
+import org.matsim.core.scenario.ScenarioUtils;
+import org.matsim.pt.transitSchedule.api.TransitScheduleReader;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class ServiceBuilder {
+	public record Services(
+			RoadRouterService roadRouterService,
+			RoadIsochroneService roadIsochroneService,
+			TransitRouterService transitRouterService,
+			TransitIsochroneService transitIsochroneService) {
+	}
+
+	public Services build(CommandLine cmd)
+			throws JsonParseException, JsonMappingException, IOException, ConfigurationException {
+		int threads = cmd.getOption("threads").map(Integer::parseInt)
+				.orElse(Runtime.getRuntime().availableProcessors());
+
+		ServiceConfiguration configuration = new ServiceConfiguration();
+
+		if (cmd.hasOption("configuration-path")) {
+			ObjectMapper objectMapper = new ObjectMapper();
+			configuration = objectMapper.readValue(new File(cmd.getOptionStrict("configuration-path")),
+					ServiceConfiguration.class);
+		}
+
+		Config config = ConfigUtils.loadConfig(cmd.getOptionStrict("config-path"),
+				new EqasimRaptorConfigGroup());
+		Scenario scenario = ScenarioUtils.createScenario(config);
+
+		new MatsimNetworkReader(scenario.getNetwork())
+				.readURL(ConfigGroup.getInputFileURL(config.getContext(),
+						config.network().getInputFile()));
+
+		boolean useTransit = cmd.getOption("use-transit").map(Boolean::parseBoolean).orElse(true);
+		if (useTransit) {
+			new TransitScheduleReader(scenario).readURL(
+					ConfigGroup.getInputFileURL(config.getContext(),
+							config.transit().getTransitScheduleFile()));
+		}
+
+		Network roadNetwork = NetworkUtils.createNetwork();
+		new TransportModeNetworkFilter(scenario.getNetwork()).filter(roadNetwork, Collections.singleton("car"));
+		new NetworkCleaner().run(roadNetwork);
+
+		final RoadRouterService roadRouterService;
+		final RoadIsochroneService roadIsochroneService;
+		final TransitRouterService transitRouterService;
+		final TransitIsochroneService transitIsochroneService;
+
+		roadRouterService = RoadRouterService.create(config, roadNetwork, configuration.walk,
+				threads);
+
+		roadIsochroneService = RoadIsochroneService.create(config, roadNetwork,
+				configuration.walk);
+
+		if (useTransit) {
+			transitRouterService = TransitRouterService.create(config, scenario.getNetwork(),
+					scenario.getTransitSchedule(), configuration.transit, configuration.walk);
+
+			transitIsochroneService = TransitIsochroneService.create(config,
+					scenario.getTransitSchedule(), configuration.transit, configuration.walk);
+		} else {
+			transitRouterService = null;
+			transitIsochroneService = null;
+		}
+
+		return new Services(roadRouterService, roadIsochroneService, transitRouterService, transitIsochroneService);
+	}
+}

--- a/server/src/test/java/org/eqasim/server/TestProcessor.java
+++ b/server/src/test/java/org/eqasim/server/TestProcessor.java
@@ -1,0 +1,54 @@
+package org.eqasim.server;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.util.concurrent.ExecutionException;
+
+import org.apache.commons.io.FileUtils;
+import org.eqasim.core.simulation.EqasimConfigurator;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.matsim.core.config.CommandLine.ConfigurationException;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+
+public class TestProcessor {
+    @Before
+    public void setUp() throws IOException {
+        new File("processor_test").mkdirs();
+    }
+
+    @After
+    public void tearDown() throws IOException {
+        FileUtils.deleteDirectory(new File("processor_test"));
+    }
+
+    @Test
+    public void testProcessor() throws JsonParseException, JsonMappingException, ConfigurationException, IOException,
+            InterruptedException, ExecutionException {
+        URL scenarioUrl = EqasimConfigurator.class.getClassLoader().getResource("melun");
+        String configPath = new File(scenarioUrl.getPath(), "config.xml").getAbsolutePath();
+
+        URL resourcesUrl = getClass().getClassLoader().getResource("processor");
+        String inputPath = new File(resourcesUrl.getPath(), "input.json").getAbsolutePath();
+        String expectedOutputPath = new File(resourcesUrl.getPath(), "output.json").getAbsolutePath();
+        String outputPath = new File("processor_test/output.json").getPath();
+
+        // uncomment to regenerate
+        outputPath = expectedOutputPath;
+
+        RunProcessor.main(new String[] {
+                "--config-path", configPath,
+                "--input-path", inputPath,
+                "--output-path", outputPath,
+                "--threads", "4"
+        });
+
+        assertTrue(FileUtils.contentEquals(new File(expectedOutputPath), new File(outputPath)));
+    }
+}

--- a/server/src/test/resources/processor/input.json
+++ b/server/src/test/resources/processor/input.json
@@ -1,0 +1,12 @@
+{
+    "road_router": [
+        { "origin_x": 673335, "origin_y": 6826738, "destination_x": 676489, "destination_y": 6825926, "departure_time_s": 28800.0 },
+        { "origin_x": 673692, "origin_y": 6827989, "destination_x": 674379, "destination_y": 6827303, "departure_time_s": 28800.0 },
+        { "origin_x": 674668, "origin_y": 6826155, "destination_x": 676489, "destination_y": 6822978, "departure_time_s": 28800.0, "provide_geometry": true }
+    ],
+    "transit_router": [
+        { "origin_x": 673335, "origin_y": 6826738, "destination_x": 676489, "destination_y": 6825926, "departure_time_s": 28800.0 },
+        { "origin_x": 673692, "origin_y": 6827989, "destination_x": 674379, "destination_y": 6827303, "departure_time_s": 28800.0 },
+        { "origin_x": 674668, "origin_y": 6826155, "destination_x": 676489, "destination_y": 6822978, "departure_time_s": 28800.0, "provide_itinerary": true }
+    ]
+}

--- a/server/src/test/resources/processor/output.json
+++ b/server/src/test/resources/processor/output.json
@@ -1,0 +1,154 @@
+{
+    "road_router" : [ {
+      "request_index" : 0,
+      "in_vehicle_distance_km" : 3.842583879491435,
+      "in_vehicle_time_min" : 7.6439559922733675,
+      "access_time_min" : 3.3851857729347667,
+      "egress_time_min" : 4.592847727130273,
+      "access_distance_km" : 0.18748721203946403,
+      "egress_distance_km" : 0.25437310488721515,
+      "arrivalTime_s" : 29461.74850591249,
+      "total_travel_time_min" : 15.621989492338408
+    }, {
+      "request_index" : 0,
+      "in_vehicle_distance_km" : 1.1351695235411883,
+      "in_vehicle_time_min" : 1.7865556266096367,
+      "access_time_min" : 0.6834207730734212,
+      "egress_time_min" : 1.696209610188495,
+      "access_distance_km" : 0.03785099666252795,
+      "egress_distance_km" : 0.09394391687197819,
+      "arrivalTime_s" : 28948.198583980982,
+      "total_travel_time_min" : 4.166186009871553
+    }, {
+      "request_index" : 0,
+      "in_vehicle_distance_km" : 4.888854014354464,
+      "in_vehicle_time_min" : 5.630312133922416,
+      "access_time_min" : 0.7695219730018122,
+      "egress_time_min" : 2.942835411617807,
+      "access_distance_km" : 0.042619678504715756,
+      "egress_distance_km" : 0.16298780741267854,
+      "arrivalTime_s" : 29183.990046415453,
+      "total_travel_time_min" : 9.342669518542035,
+      "road_geometry" : "LINESTRING (674709.5320588042 6826145.433125519, 674781.1829609717 6826116.79770454, 674796.9823562971 6826110.037204346, 674837.4097994815 6826085.96195032, 674856.4882493154 6826074.285056951, 674934.2737875809 6826024.559205507, 674838.7606062001 6825971.299939094, 674833.0952634732 6825970.690750408, 674821.2746841208 6825985.9603553265, 674818.7053796867 6825999.622583058, 674873.8700236891 6826179.383941381, 674878.1536319541 6826191.760455639, 674897.1930905357 6826232.809754058, 674904.8241738515 6826251.085896134, 674921.9078109921 6826294.066879439, 674926.1126775135 6826305.343235749, 674949.671288017 6826362.270013471, 674953.0786751758 6826370.092563611, 674995.5299172394 6826360.294469901, 675114.0956071103 6826274.689677653, 675128.2926490621 6826259.210397221, 675130.9367622876 6826256.019776154, 675137.3652467302 6826248.688765734, 675157.743894111 6826219.87666277, 675159.7188876151 6826217.311435279, 675499.904543003 6825799.668076514, 675533.4208930166 6825747.90214219, 675755.272176121 6825089.300793759, 675856.3267726926 6824619.455727902, 675888.9397730104 6824453.952752363, 675882.470450992 6824441.4068300165, 675888.1920415745 6824428.499234143, 675894.301811382 6824339.776066263, 675891.5785452506 6824306.271335751, 675887.041016451 6824260.868441364, 675884.037268742 6824241.705058056, 675970.7124981324 6823932.489337387, 676035.6769254997 6823860.966023872, 676047.5573234658 6823845.84341052, 676104.0154176578 6823752.712284363, 676235.4836084226 6823428.789236426, 676259.0457267754 6823374.434427309, 676301.2397212159 6823284.520672108, 676450.9110313156 6822996.024067507, 676541.708731346 6822823.511198556, 676559.4651015565 6822832.266147972, 676570.1911327371 6822837.8478959, 676578.5320447701 6822841.805145749)",
+      "access_geometry" : "LINESTRING (674668 6826155, 674709.5320588042 6826145.433125519)",
+      "egress_geometry" : "LINESTRING (676578.5320447701 6822841.805145749, 676489 6822978)"
+    } ],
+    "road_isochrone" : [ ],
+    "transit_router" : [ {
+      "request_index" : 0,
+      "in_vehicle_travel_time" : 13.916666666666666,
+      "in_vehicle_travel_time_by_mode_min" : {
+        "bus" : 13.916666666666666
+      },
+      "in_vehicle_distance_km" : 5.987919399385293,
+      "in_vehicle_distance_by_mode_km" : {
+        "bus" : 5.987919399385293
+      },
+      "vehicle_legs_by_mode" : {
+        "bus" : 2
+      },
+      "access_walk_time_min" : 4.866666666666666,
+      "egress_walk_time_min" : 7.183333333333334,
+      "transfer_walk_time_min" : 5.766666666666667,
+      "access_walk_distance_km" : 0.26864842128155164,
+      "egress_walk_distance_km" : 0.39779049650824566,
+      "transfer_walk_distance_km" : 0.36,
+      "initial_wait_time_min" : 4.133333333333334,
+      "transfer_wait_time_min" : 9.233333333333333,
+      "transfers" : 1,
+      "total_travel_time_min" : 45.099999999999994,
+      "arrivalTime_s" : 31506.0,
+      "is_only_walk" : false
+    }, {
+      "request_index" : 0,
+      "in_vehicle_travel_time" : 0.0,
+      "in_vehicle_travel_time_by_mode_min" : { },
+      "in_vehicle_distance_km" : 0.0,
+      "in_vehicle_distance_by_mode_km" : { },
+      "vehicle_legs_by_mode" : { },
+      "access_walk_time_min" : 0.0,
+      "egress_walk_time_min" : 0.0,
+      "transfer_walk_time_min" : 22.78819162561142,
+      "access_walk_distance_km" : 0.0,
+      "egress_walk_distance_km" : 0.0,
+      "transfer_walk_distance_km" : 0.9708578680733859,
+      "initial_wait_time_min" : 0.0,
+      "transfer_wait_time_min" : 0.0,
+      "transfers" : 0,
+      "total_travel_time_min" : 22.78819162561142,
+      "arrivalTime_s" : 30167.291497536684,
+      "is_only_walk" : true
+    }, {
+      "request_index" : 0,
+      "in_vehicle_travel_time" : 25.0,
+      "in_vehicle_travel_time_by_mode_min" : {
+        "bus" : 25.0
+      },
+      "in_vehicle_distance_km" : 8.212808999095579,
+      "in_vehicle_distance_by_mode_km" : {
+        "bus" : 8.212808999095579
+      },
+      "vehicle_legs_by_mode" : {
+        "bus" : 1
+      },
+      "access_walk_time_min" : 5.833333333333333,
+      "egress_walk_time_min" : 8.783333333333333,
+      "transfer_walk_time_min" : 0.0,
+      "access_walk_distance_km" : 0.32231799858086674,
+      "egress_walk_distance_km" : 0.48569296588135297,
+      "transfer_walk_distance_km" : 0.0,
+      "initial_wait_time_min" : 24.166666666666668,
+      "transfer_wait_time_min" : 0.0,
+      "transfers" : 0,
+      "total_travel_time_min" : 63.78333333333333,
+      "arrivalTime_s" : 32627.0,
+      "is_only_walk" : false,
+      "itinerary" : {
+        "stops" : [ {
+          "id" : "IDFM:30984.link:316446",
+          "name" : "Notre Dame",
+          "x" : 674904.0000200471,
+          "y" : 6826231.004656577,
+          "arrival_time_s" : 29150.0,
+          "departure_time_s" : 30600.0,
+          "wait_time_s" : 24.166666666666668
+        }, {
+          "id" : "IDFM:30942.link:473818",
+          "name" : "Fief du Pré",
+          "x" : 676564.0000187175,
+          "y" : 6823344.004658005,
+          "arrival_time_s" : 29150.0,
+          "departure_time_s" : 29150.0,
+          "wait_time_s" : 0.0
+        } ],
+        "legs" : [ {
+          "type" : "access",
+          "mode" : "walk",
+          "departure_time_s" : 28800.0,
+          "arrival_time_s" : 29150.0,
+          "travel_time_min" : 5.833333333333333,
+          "distance_km" : 0.32231799858086674
+        }, {
+          "type" : "vehicle",
+          "mode" : "bus",
+          "departure_time_s" : 29150.0,
+          "arrival_time_s" : 32100.0,
+          "travel_time_min" : 49.166666666666664,
+          "distance_km" : 8.212808999095579,
+          "in_vehicle_time_min" : 25.0,
+          "wait_time_min" : 24.166666666666668,
+          "line_id" : "IDFM:C00877",
+          "route_id" : "IDFM:TRANSDEV_MELUN:40913-C00877-14444775",
+          "line_name" : "C"
+        }, {
+          "type" : "egress",
+          "mode" : "walk",
+          "departure_time_s" : 32100.0,
+          "arrival_time_s" : 32627.0,
+          "travel_time_min" : 8.783333333333333,
+          "distance_km" : 0.48569296588135297
+        } ]
+      }
+    } ],
+    "transit_isochrone" : [ ]
+  }


### PR DESCRIPTION
This PR let's users use the routing server infrastructure without actually starting a server on an HTTP port. Instead, one can put all the requests that one would send to the server into a JSON file, run the processing script, and obtain all responses in an output JSON file. The input requests and the output responses have the exact same structure as in the HTTP API:

```bash
java ... org.eqasim.server.RunProcessor \
  --config-path scenario_config.xml \
  --input-path requests.json \
  --output-path response.json 
```

Both the input and output files are structured by endpoint:

```json
{
  "road_router": [
    { "origin_x": 1234, "origin_y": 5122, ... }
  ],
  "transit_router": [
    { "origin_x": 1234, "origin_y": 5122, ... }
  ],
  "road_isochrone": [],
  "transit_isochrone": []
}
```

- Example for input.json in server/src/test/resources/processor/input.json
- Example for output.json server/src/test/resources/processor/output.json