### PR TITLE
feat: compress eqasim-specific output

### DIFF
--- a/core/src/main/java/org/eqasim/core/analysis/activities/ActivityWriter.java
+++ b/core/src/main/java/org/eqasim/core/analysis/activities/ActivityWriter.java
@@ -6,6 +6,8 @@ import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.util.Collection;
 
+import org.matsim.core.utils.io.IOUtils;
+
 public class ActivityWriter {
 	final private Collection<ActivityItem> activities;
 	final private String delimiter;
@@ -20,7 +22,7 @@ public class ActivityWriter {
 	}
 
 	public void write(String outputPath) throws IOException {
-		BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(outputPath)));
+		BufferedWriter writer = IOUtils.getBufferedWriter(outputPath);
 
 		writer.write(formatHeader() + "\n");
 		writer.flush();

--- a/core/src/main/java/org/eqasim/core/analysis/legs/LegWriter.java
+++ b/core/src/main/java/org/eqasim/core/analysis/legs/LegWriter.java
@@ -1,12 +1,11 @@
 package org.eqasim.core.analysis.legs;
 
 import java.io.BufferedWriter;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.OutputStreamWriter;
 import java.util.Collection;
 
 import org.eqasim.core.analysis.DistanceUnit;
+import org.matsim.core.utils.io.IOUtils;
 
 public class LegWriter {
 	final private Collection<LegItem> legs;
@@ -27,7 +26,7 @@ public class LegWriter {
 	}
 
 	public void write(String outputPath) throws IOException {
-		BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(outputPath)));
+		BufferedWriter writer = IOUtils.getBufferedWriter(outputPath);
 
 		writer.write(formatHeader() + "\n");
 		writer.flush();

--- a/core/src/main/java/org/eqasim/core/analysis/pt/PublicTransportLegWriter.java
+++ b/core/src/main/java/org/eqasim/core/analysis/pt/PublicTransportLegWriter.java
@@ -6,6 +6,8 @@ import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.util.Collection;
 
+import org.matsim.core.utils.io.IOUtils;
+
 public class PublicTransportLegWriter {
 	final private Collection<PublicTransportLegItem> trips;
 	final private String delimiter;
@@ -20,7 +22,7 @@ public class PublicTransportLegWriter {
 	}
 
 	public void write(String outputPath) throws IOException {
-		BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(outputPath)));
+		BufferedWriter writer = IOUtils.getBufferedWriter(outputPath);
 
 		writer.write(formatHeader() + "\n");
 		writer.flush();

--- a/core/src/main/java/org/eqasim/core/analysis/trips/TripWriter.java
+++ b/core/src/main/java/org/eqasim/core/analysis/trips/TripWriter.java
@@ -7,6 +7,7 @@ import java.io.OutputStreamWriter;
 import java.util.Collection;
 
 import org.eqasim.core.analysis.DistanceUnit;
+import org.matsim.core.utils.io.IOUtils;
 
 public class TripWriter {
 	final private Collection<TripItem> trips;
@@ -27,7 +28,7 @@ public class TripWriter {
 	}
 
 	public void write(String outputPath) throws IOException {
-		BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(outputPath)));
+		BufferedWriter writer = IOUtils.getBufferedWriter(outputPath);
 
 		writer.write(formatHeader() + "\n");
 		writer.flush();

--- a/core/src/main/java/org/eqasim/core/simulation/analysis/AnalysisOutputListener.java
+++ b/core/src/main/java/org/eqasim/core/simulation/analysis/AnalysisOutputListener.java
@@ -29,11 +29,11 @@ import com.google.inject.Singleton;
 
 @Singleton
 public class AnalysisOutputListener implements IterationStartsListener, IterationEndsListener, ShutdownListener {
-	private static final String TRIPS_FILE_NAME = "eqasim_trips.csv";
-	private static final String LEGS_FILE_NAME = "eqasim_legs.csv";
-	private static final String PT_FILE_NAME = "eqasim_pt.csv";
-	private static final String ACTIVITIES_FILE_NAME = "eqasim_activities.csv";
-	private static final String TRAVEL_TIMES_FILE_NAME = "eqasim_travel_times.bin";
+	private static final String TRIPS_FILE_NAME = "eqasim_trips.csv.gz";
+	private static final String LEGS_FILE_NAME = "eqasim_legs.csv.gz";
+	private static final String PT_FILE_NAME = "eqasim_pt.csv.gz";
+	private static final String ACTIVITIES_FILE_NAME = "eqasim_activities.csv.gz";
+	private static final String TRAVEL_TIMES_FILE_NAME = "eqasim_travel_times.bin.gz";
 
 	private final OutputDirectoryHierarchy outputDirectory;
 

--- a/core/src/main/java/org/eqasim/core/simulation/analysis/stuck/StuckAnalysisListener.java
+++ b/core/src/main/java/org/eqasim/core/simulation/analysis/stuck/StuckAnalysisListener.java
@@ -18,7 +18,7 @@ import com.google.inject.Singleton;
 
 @Singleton
 public class StuckAnalysisListener implements StartupListener, IterationStartsListener, IterationEndsListener {
-	static public final String OUTPUT_NAME = "stuck_analysis.csv";
+	static public final String OUTPUT_NAME = "stuck_analysis.csv.gz";
 
 	private final EventsManager eventsManager;
 	private final OutputDirectoryHierarchy outputHierarchy;

--- a/core/src/main/java/org/eqasim/core/simulation/vdf/VDFUpdateListener.java
+++ b/core/src/main/java/org/eqasim/core/simulation/vdf/VDFUpdateListener.java
@@ -26,9 +26,9 @@ import com.google.common.io.Files;
 public class VDFUpdateListener implements IterationEndsListener, StartupListener, ShutdownListener {
 	private final static Logger logger = LogManager.getLogger(VDFUpdateListener.class);
 
-	private final String VDF_FILE = "vdf.bin";
-	private final String FLOW_FILE = "vdf_flow.csv";
-	private final String TRAVEL_TIMES_FILE = "vdf_travel_times.bin";
+	private final String VDF_FILE = "vdf.bin.gz";
+	private final String FLOW_FILE = "vdf_flow.csv.gz";
+	private final String TRAVEL_TIMES_FILE = "vdf_travel_times.bin.gz";
 
 	private final VDFScope scope;
 	private final VDFTrafficHandler handler;

--- a/core/src/main/java/org/eqasim/core/simulation/vdf/analysis/FlowWriter.java
+++ b/core/src/main/java/org/eqasim/core/simulation/vdf/analysis/FlowWriter.java
@@ -2,9 +2,7 @@ package org.eqasim.core.simulation.vdf.analysis;
 
 import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.OutputStreamWriter;
 import java.util.List;
 import java.util.Map;
 
@@ -13,6 +11,7 @@ import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.IdMap;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
+import org.matsim.core.utils.io.IOUtils;
 
 public class FlowWriter {
 	private final IdMap<Link, List<Double>> flows;
@@ -27,7 +26,7 @@ public class FlowWriter {
 
 	public void write(File path) {
 		try {
-			BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(path)));
+			BufferedWriter writer = IOUtils.getBufferedWriter(path.getPath());
 
 			writer.write(String.join(";", new String[] { "link_id", "interval", "start_time", "flow", "lanes", "osm" })
 					+ "\n");


### PR DESCRIPTION
Compress all the eqasim output at least with GZ. We could even put a config option to make use of stronger compression algorithms. This will avoid transferring endless volumes of CSV files, especially when we work with many runs during calibration.