### PR TITLE
fix(server): missing suffix in server output

### DIFF
--- a/server/src/main/java/org/eqasim/server/services/router/transit/TransitRouterResponse.java
+++ b/server/src/main/java/org/eqasim/server/services/router/transit/TransitRouterResponse.java
@@ -13,7 +13,7 @@ public class TransitRouterResponse {
 	@JsonProperty("request_index")
 	public int requestIndex = 0;
 
-	@JsonProperty("in_vehicle_travel_time")
+	@JsonProperty("in_vehicle_travel_time_min")
 	public double inVehicleTravelTime_min;
 
 	@JsonProperty("in_vehicle_travel_time_by_mode_min")


### PR DESCRIPTION
`in_vehicle_travel_time` -> `in_vehicle_travel_time_min`