### PR TITLE
chore: compatibility between release-please and dependabot

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: googleapis/release-please-action@v4
         id: release
         with:
-          token: ${{ secrets.RELEASE }}
+          token: ${{ secrets.RELEASE == '' && secrets.GITHUB_TOKEN || secrets.RELEASE }}
       - uses: actions/setup-java@v4
         if: ${{ steps.release.outputs.release_created }}
         with:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -2,9 +2,6 @@ on:
   push:
     branches:
       - develop
-  pull_request:
-    branches:
-      - develop
   
   workflow_dispatch:
 
@@ -22,7 +19,7 @@ jobs:
       - uses: googleapis/release-please-action@v4
         id: release
         with:
-          token: ${{ secrets.RELEASE == '' && secrets.GITHUB_TOKEN || secrets.RELEASE }}
+          token: ${{ secrets.RELEASE }}
       - uses: actions/setup-java@v4
         if: ${{ steps.release.outputs.release_created }}
         with:


### PR DESCRIPTION
Fixes compatibility between dependabot and release-please (hopefully), because dependabot PRs don't have access to our specific deployment token.