### PR TITLE
feat(server): optionally provide path to write the listening port

### DIFF
--- a/server/src/main/java/org/eqasim/server/RunServer.java
+++ b/server/src/main/java/org/eqasim/server/RunServer.java
@@ -1,5 +1,6 @@
 package org.eqasim.server;
 
+import java.io.BufferedWriter;
 import java.io.IOException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -12,6 +13,7 @@ import org.eqasim.server.api.TransitIsochroneEndpoint;
 import org.eqasim.server.api.TransitRouterEndpoint;
 import org.matsim.core.config.CommandLine;
 import org.matsim.core.config.CommandLine.ConfigurationException;
+import org.matsim.core.utils.io.IOUtils;
 
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonMappingException;
@@ -23,7 +25,7 @@ public class RunServer {
 			throws ConfigurationException, JsonParseException, JsonMappingException, IOException {
 		CommandLine cmd = new CommandLine.Builder(args) //
 				.requireOptions("config-path", "port") //
-				.allowOptions("threads", "configuration-path", "use-transit", "vdf-path",
+				.allowOptions("threads", "configuration-path", "use-transit", "vdf-path", "port-path",
 						EqasimConfigurator.CONFIGURATOR) //
 				.build();
 
@@ -63,5 +65,11 @@ public class RunServer {
 		// Run API
 		int port = Integer.parseInt(cmd.getOptionStrict("port"));
 		app.start(port);
+
+		if (cmd.hasOption("port-path")) {
+			BufferedWriter writer = IOUtils.getBufferedWriter(cmd.getOptionStrict("port-path"));
+			writer.write(String.valueOf(app.jettyServer().port()));
+			writer.close();
+		}
 	}
 }

--- a/server/src/main/java/org/eqasim/server/RunServer.java
+++ b/server/src/main/java/org/eqasim/server/RunServer.java
@@ -24,8 +24,8 @@ public class RunServer {
 	public static void main(String[] args)
 			throws ConfigurationException, JsonParseException, JsonMappingException, IOException {
 		CommandLine cmd = new CommandLine.Builder(args) //
-				.requireOptions("config-path", "port") //
-				.allowOptions("threads", "configuration-path", "use-transit", "vdf-path", "port-path",
+				.requireOptions("config-path") //
+				.allowOptions("port", "threads", "configuration-path", "use-transit", "vdf-path", "port-path",
 						EqasimConfigurator.CONFIGURATOR) //
 				.build();
 
@@ -63,7 +63,7 @@ public class RunServer {
 		}
 
 		// Run API
-		int port = Integer.parseInt(cmd.getOptionStrict("port"));
+		int port = cmd.getOption("port").map(Integer::parseInt).orElse(0);
 		app.start(port);
 
 		if (cmd.hasOption("port-path")) {


### PR DESCRIPTION
Adds the `--port-path` option to `RunServer` which makes the server write out the port on which it is listening. This is useful if you start the server without the `port` argument or with `--port 0`. This makes the system choose a random open port, which will then be written into your provided port path.