### PR TITLE
feat(core): tool to split/merge populations

### DIFF
--- a/core/src/main/java/org/eqasim/core/simulation/CoreEqasimConfigurator.java
+++ b/core/src/main/java/org/eqasim/core/simulation/CoreEqasimConfigurator.java
@@ -1,0 +1,19 @@
+package org.eqasim.core.simulation;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.matsim.core.config.CommandLine;
+
+public class CoreEqasimConfigurator extends EqasimConfigurator {
+    private static final Logger logger = LogManager.getLogger(CoreEqasimConfigurator.class);
+
+    public CoreEqasimConfigurator(CommandLine cmd) {
+        super(cmd);
+
+        logger.warn(
+                "Your are using the CoreEqasimConfigurator.");
+        logger.warn("This should only happen if you intentionally set this up for testing or development purposes.");
+        logger.warn("The CoreEqasimConfigrator should never be used in production.");
+
+    }
+}

--- a/core/src/main/java/org/eqasim/core/tools/MergePopulation.java
+++ b/core/src/main/java/org/eqasim/core/tools/MergePopulation.java
@@ -1,0 +1,53 @@
+package org.eqasim.core.tools;
+
+import java.io.File;
+
+import org.eqasim.core.simulation.EqasimConfigurator;
+import org.matsim.api.core.v01.Scenario;
+import org.matsim.api.core.v01.population.Population;
+import org.matsim.core.config.CommandLine;
+import org.matsim.core.config.CommandLine.ConfigurationException;
+import org.matsim.core.config.Config;
+import org.matsim.core.config.ConfigUtils;
+import org.matsim.core.population.io.PopulationReader;
+import org.matsim.core.population.io.PopulationWriter;
+import org.matsim.core.scenario.ScenarioUtils;
+
+public class MergePopulation {
+    static public void main(String[] args) throws ConfigurationException {
+        CommandLine cmd = new CommandLine.Builder(args) //
+                .requireOptions("population-path") //
+                .allowOptions("output-path", "eqasim-configurator") //
+                .build();
+
+        String populationPath = cmd.getOptionStrict("population-path");
+
+        int chunks = 0;
+        while (new File(SplitPopulation.createChunkPath(populationPath, chunks)).exists()) {
+            chunks++;
+        }
+
+        EqasimConfigurator configurator = EqasimConfigurator.getInstance(cmd);
+
+        Config config = ConfigUtils.createConfig();
+        configurator.updateConfig(config);
+
+        Scenario scenario = ScenarioUtils.createScenario(config);
+        configurator.configureScenario(scenario);
+
+        Population population = scenario.getPopulation();
+
+        for (int k = 0; k < chunks; k++) {
+            String chunkPath = SplitPopulation.createChunkPath(populationPath, k);
+            new PopulationReader(scenario).readFile(chunkPath);
+        }
+
+        String outputPath = cmd.getOption("output-path").orElse(createMergePath(populationPath));
+        new PopulationWriter(population).write(outputPath);
+    }
+
+    static public String createMergePath(String path) {
+        String name = new File(path).getName().split("\\.")[0];
+        return path.replace(name, name + ".merged");
+    }
+}

--- a/core/src/main/java/org/eqasim/core/tools/SplitPopulation.java
+++ b/core/src/main/java/org/eqasim/core/tools/SplitPopulation.java
@@ -1,0 +1,85 @@
+package org.eqasim.core.tools;
+
+import java.io.File;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+
+import org.eqasim.core.simulation.EqasimConfigurator;
+import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.Scenario;
+import org.matsim.api.core.v01.population.Person;
+import org.matsim.api.core.v01.population.Population;
+import org.matsim.core.config.CommandLine;
+import org.matsim.core.config.CommandLine.ConfigurationException;
+import org.matsim.core.config.Config;
+import org.matsim.core.config.ConfigUtils;
+import org.matsim.core.population.io.PopulationReader;
+import org.matsim.core.population.io.PopulationWriter;
+import org.matsim.core.scenario.ScenarioUtils;
+
+import com.google.common.base.Preconditions;
+
+public class SplitPopulation {
+    static public void main(String[] args) throws ConfigurationException {
+        CommandLine cmd = new CommandLine.Builder(args) //
+                .requireOptions("population-path") //
+                .allowOptions("chunks", "chunk-size", EqasimConfigurator.CONFIGURATOR) //
+                .build();
+
+        String populationPath = cmd.getOptionStrict("population-path");
+
+        Preconditions.checkArgument(cmd.hasOption("chunks") ^ cmd.hasOption("chunk-size"),
+                "Either the number of chunks or the chunk size must be given.");
+
+        EqasimConfigurator configurator = EqasimConfigurator.getInstance(cmd);
+
+        Config config = ConfigUtils.createConfig();
+        configurator.updateConfig(config);
+
+        Scenario scenario = ScenarioUtils.createScenario(config);
+        configurator.configureScenario(scenario);
+
+        new PopulationReader(scenario).readFile(populationPath);
+        Population population = scenario.getPopulation();
+        int total = population.getPersons().size();
+
+        final int chunkSize;
+        final int chunks;
+
+        if (cmd.hasOption("chunk-size")) {
+            chunkSize = Integer.parseInt(cmd.getOptionStrict("chunk-size"));
+            chunks = total / chunkSize + 1;
+        } else {
+            chunks = Integer.parseInt(cmd.getOptionStrict("chunks"));
+            chunkSize = total / chunks + 1;
+        }
+
+        Preconditions.checkState(chunkSize * chunkSize >= total);
+
+        List<Person> persons = new LinkedList<>();
+        persons.addAll(population.getPersons().values());
+
+        for (int k = 0; k < chunks; k++) {
+            int startIndex = k * chunkSize;
+            int endIndex = Math.min((k + 1) * chunkSize, total);
+
+            // clear
+            Set<Id<Person>> remove = new HashSet<>(scenario.getPopulation().getPersons().keySet());
+            remove.forEach(scenario.getPopulation()::removePerson);
+
+            // fill up
+            persons.subList(startIndex, endIndex).forEach(scenario.getPopulation()::addPerson);
+
+            // write
+            String chunkPath = createChunkPath(populationPath, k);
+            new PopulationWriter(population).write(chunkPath);
+        }
+    }
+
+    static public String createChunkPath(String path, int chunk) {
+        String name = new File(path).getName().split("\\.")[0];
+        return path.replace(name, name + String.format(".%06d", chunk));
+    }
+}


### PR DESCRIPTION
This PR adds the two classes `SplitPopulation` and `MergePopulation` that allow to split a population into multiple chunks and then stitch them together again. This is useful for routing or performing standalone mode choice on a large population that can be distributed over multiple computing nodes.