### PR TITLE
chore: using a temporary location for controller.outputDirectory in relevant tools

### DIFF
--- a/core/src/main/java/org/eqasim/core/scenario/cutter/RunScenarioCutter.java
+++ b/core/src/main/java/org/eqasim/core/scenario/cutter/RunScenarioCutter.java
@@ -2,6 +2,8 @@ package org.eqasim.core.scenario.cutter;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.Set;
@@ -73,6 +75,14 @@ public class RunScenarioCutter {
 		configurator.updateConfig(config);
 		config.removeModule(EqasimTerminationConfigGroup.GROUP_NAME);
 		cmd.applyConfiguration(config);
+
+		// We make sure that the classical outputDirectory is written in a temporary location
+		try {
+			Path tempDirPath = Files.createTempDirectory("population_cutter_routing");
+			config.controller().setOutputDirectory(tempDirPath.resolve("outputs").toString());
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		}
 
 		VehiclesValidator.validate(config);
 
@@ -164,6 +174,14 @@ public class RunScenarioCutter {
 		cmd.applyConfiguration(config);
 		ConfigCutter configCutter = new ConfigCutter(prefix);
 		configCutter.run(config);
+
+		// We make sure that the classical outputDirectory is written in a temporary location
+		try {
+			Path tempDirPath = Files.createTempDirectory("population_cutter_routing");
+			config.controller().setOutputDirectory(tempDirPath.resolve("outputs").toString());
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		}
 
 		// Final routing
 		// TODO: Check if we can remove stuff

--- a/core/src/main/java/org/eqasim/core/scenario/routing/RunPopulationRouting.java
+++ b/core/src/main/java/org/eqasim/core/scenario/routing/RunPopulationRouting.java
@@ -1,8 +1,14 @@
 package org.eqasim.core.scenario.routing;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.apache.commons.io.FileUtils;
 import org.eqasim.core.misc.InjectorBuilder;
 import org.eqasim.core.scenario.validation.VehiclesValidator;
 import org.eqasim.core.simulation.EqasimConfigurator;
@@ -36,7 +42,16 @@ public class RunPopulationRouting {
 		config.replanning().clearStrategySettings();
 		VehiclesValidator.validate(config);
 
-		int batchSize = cmd.getOption("batch-size").map(Integer::parseInt).orElse(100);
+		Path tempDirPath;
+
+		try {
+			tempDirPath = Files.createTempDirectory("population_routing");
+			config.controller().setOutputDirectory(tempDirPath.resolve("outputs").toString());
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+
+        int batchSize = cmd.getOption("batch-size").map(Integer::parseInt).orElse(100);
 		int numberOfThreads = cmd.getOption("threads").map(Integer::parseInt)
 				.orElse(Runtime.getRuntime().availableProcessors());
 
@@ -67,5 +82,5 @@ public class RunPopulationRouting {
 		populationRouter.run(scenario.getPopulation());
 
 		new PopulationWriter(scenario.getPopulation()).write(cmd.getOptionStrict("output-path"));
-	}
+    }
 }


### PR DESCRIPTION
Following #294, we know have an OutputDirectoryHierarchy object created in cases where we don't need it such as in RunPopulationRouting or RunScenarioCutter and that writes a directory and some files on the hard drive. 
In contexts where these scripts are used in a parallelized pipeline, this can lead to conflicts where multiple jobs attempt to write the same directory or file. 

This PR make the two scripts mentioned above write in a temporary location. 

PS:  the current PR doesn't delete the temporary directory at the end of the process because some files within the directory are not properly closed (score and travel distance stats)