### PR TITLE
fix: auto-delete output directory in standalone applications

### DIFF
--- a/core/src/main/java/org/eqasim/core/misc/InjectorBuilder.java
+++ b/core/src/main/java/org/eqasim/core/misc/InjectorBuilder.java
@@ -69,6 +69,8 @@ public class InjectorBuilder {
 		if (cleanOutputHierarchy) {
 			Runtime.getRuntime().addShutdownHook(new Thread(() -> {
 				try {
+					// need to close these file handles manually as they are opened by default by
+					// MATSim
 					injector.getInstance(TravelDistanceStats.class).close();
 					injector.getInstance(ScoreStatsControlerListener.class)
 							.notifyShutdown(new ShutdownEvent(null, false, 0, null));


### PR DESCRIPTION
Alternative to #430. Makes sure that there is no standard MATSim output directory generated for standalone applications like `RunPopulationRouting`.