### PR TITLE
feat(drt): remove standalone drt mode when defining feeder

### DIFF
--- a/core/src/main/java/org/eqasim/core/simulation/modes/feeder_drt/utils/AdaptConfigForFeederDrt.java
+++ b/core/src/main/java/org/eqasim/core/simulation/modes/feeder_drt/utils/AdaptConfigForFeederDrt.java
@@ -53,7 +53,10 @@ public class AdaptConfigForFeederDrt {
 
         // Add DRT to the available modes
         EqasimConfigGroup eqasimConfig = EqasimConfigGroup.get(config);
-        eqasimConfig.setAdditionalAvailableModes(Sets.union(eqasimConfig.getAdditionalAvailableModes(), basePtModes.keySet()));
+        Set<String> availableModes = new HashSet<>(eqasimConfig.getAdditionalAvailableModes());
+        availableModes.addAll(baseDrtModes.keySet()); // add new modes
+        availableModes.removeAll(baseDrtModes.values());
+        eqasimConfig.setAdditionalAvailableModes(availableModes);
 
         //This constraint need to be added
         dmcConfig.getTripConstraints().add(FeederDrtConstraint.NAME);


### PR DESCRIPTION
Makes sure that a DRT mode that is defined as the basis of a feeder mode is removed as a standalone choice. Might make sense to add a yes/no switch to the script at some point.