### PR TITLE
feat: add additional modes to termination modes

### DIFF
--- a/core/src/main/java/org/eqasim/core/simulation/modes/drt/utils/AdaptConfigForDrt.java
+++ b/core/src/main/java/org/eqasim/core/simulation/modes/drt/utils/AdaptConfigForDrt.java
@@ -20,6 +20,7 @@ import org.eqasim.core.simulation.mode_choice.EqasimModeChoiceModule;
 import org.eqasim.core.simulation.mode_choice.constraints.leg_time.LegTimeConstraintConfigGroup;
 import org.eqasim.core.simulation.mode_choice.constraints.leg_time.LegTimeConstraintModule;
 import org.eqasim.core.simulation.mode_choice.constraints.leg_time.LegTimeConstraintSingleLegConfigGroup;
+import org.eqasim.core.simulation.termination.EqasimTerminationConfigGroup;
 import org.matsim.contrib.common.zones.systems.grid.square.SquareGridZoneSystemParams;
 import org.matsim.contrib.drt.optimizer.constraints.DrtOptimizationConstraintsSetImpl;
 import org.matsim.contrib.drt.optimizer.insertion.DrtInsertionSearchParams;
@@ -69,6 +70,12 @@ public class AdaptConfigForDrt {
         Set<String> cachedModes = new HashSet<>(dmcConfig.getCachedModes());
         cachedModes.addAll(vehiclesPathByDrtMode.keySet());
         dmcConfig.setCachedModes(cachedModes);
+
+        // Add DRT to termination criteria
+        EqasimTerminationConfigGroup terminationConfig = EqasimTerminationConfigGroup.getOrCreate(config);
+        List<String> terminationModes = new ArrayList<>(terminationConfig.getModes());
+        terminationModes.addAll(vehiclesPathByDrtMode.keySet());
+        terminationConfig.setModes(terminationModes);
 
         boolean serviceAreaDrt = false;
 

--- a/core/src/main/java/org/eqasim/core/simulation/modes/feeder_drt/utils/AdaptConfigForFeederDrt.java
+++ b/core/src/main/java/org/eqasim/core/simulation/modes/feeder_drt/utils/AdaptConfigForFeederDrt.java
@@ -1,5 +1,6 @@
 package org.eqasim.core.simulation.modes.feeder_drt.utils;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -19,6 +20,7 @@ import org.eqasim.core.simulation.modes.feeder_drt.mode_choice.constraints.Feede
 import org.eqasim.core.simulation.modes.feeder_drt.router.access_egress_stop_search.CompositeAccessEgressStopSearchParameterSet;
 import org.eqasim.core.simulation.modes.feeder_drt.router.access_egress_stop_search.TransitStopByIdAccessEgressStopSearchParameterSet;
 import org.eqasim.core.simulation.modes.feeder_drt.router.access_egress_stop_search.TransitStopByModeAccessEgressStopSearchParameterSet;
+import org.eqasim.core.simulation.termination.EqasimTerminationConfigGroup;
 import org.matsim.contrib.drt.run.MultiModeDrtConfigGroup;
 import org.matsim.contribs.discrete_mode_choice.modules.config.DiscreteModeChoiceConfigGroup;
 import org.matsim.core.config.CommandLine;
@@ -51,12 +53,19 @@ public class AdaptConfigForFeederDrt {
             singleLegParameterSetByMainModeByLegMode = legTimeConstraintConfigGroup.getSingleLegParameterSetByMainModeByLegMode();
         }
 
-        // Add DRT to the available modes
+        // Add feeder to the available modes
         EqasimConfigGroup eqasimConfig = EqasimConfigGroup.get(config);
         Set<String> availableModes = new HashSet<>(eqasimConfig.getAdditionalAvailableModes());
         availableModes.addAll(baseDrtModes.keySet()); // add new modes
         availableModes.removeAll(baseDrtModes.values());
         eqasimConfig.setAdditionalAvailableModes(availableModes);
+
+        // Update termination modes
+        EqasimTerminationConfigGroup terminationConfig = EqasimTerminationConfigGroup.getOrCreate(config);
+        List<String> terminationModes = new ArrayList<>(terminationConfig.getModes());
+        terminationModes.removeAll(baseDrtModes.values());
+        terminationModes.addAll(baseDrtModes.keySet());
+        terminationConfig.setModes(terminationModes);
 
         //This constraint need to be added
         dmcConfig.getTripConstraints().add(FeederDrtConstraint.NAME);

--- a/core/src/main/java/org/eqasim/core/simulation/modes/transit_with_abstract_access/utils/AdaptConfigForTransitWithAbstractAccess.java
+++ b/core/src/main/java/org/eqasim/core/simulation/modes/transit_with_abstract_access/utils/AdaptConfigForTransitWithAbstractAccess.java
@@ -5,6 +5,7 @@ import org.eqasim.core.simulation.modes.transit_with_abstract_access.TransitWith
 import org.eqasim.core.simulation.modes.transit_with_abstract_access.mode_choice.TransitWithAbstractAccessModeChoiceModule;
 import org.eqasim.core.simulation.modes.transit_with_abstract_access.mode_choice.constraints.TransitWithAbstractAccessConstraint;
 import org.eqasim.core.simulation.modes.transit_with_abstract_access.routing.TransitWithAbstractAccessRoutingModule;
+import org.eqasim.core.simulation.termination.EqasimTerminationConfigGroup;
 import org.matsim.contribs.discrete_mode_choice.modules.config.DiscreteModeChoiceConfigGroup;
 import org.matsim.core.config.CommandLine;
 import org.matsim.core.config.Config;
@@ -14,7 +15,9 @@ import org.matsim.core.config.groups.ScoringConfigGroup;
 import com.google.common.collect.Sets;
 
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 public class AdaptConfigForTransitWithAbstractAccess {
@@ -54,6 +57,12 @@ public class AdaptConfigForTransitWithAbstractAccess {
 
         EqasimConfigGroup eqasimConfig = EqasimConfigGroup.get(config);
         eqasimConfig.setAdditionalAvailableModes(Sets.union(eqasimConfig.getAdditionalAvailableModes(), Set.of(mode)));
+
+        // Update termination modes
+        EqasimTerminationConfigGroup terminationConfig = EqasimTerminationConfigGroup.getOrCreate(config);
+        List<String> terminationModes = new ArrayList<>(terminationConfig.getModes());
+        terminationModes.add(mode);
+        terminationConfig.setModes(terminationModes);
 
         ConfigUtils.writeConfig(config, outputConfigPath);
     }


### PR DESCRIPTION
This PR makes the configuration scripts for DRT, feeder, and abstract transit also add the respective modes to the termination config group.