### PR TITLE
fix(RunDownsampling): allowing seed command line argument

### DIFF
--- a/core/src/main/java/org/eqasim/core/tools/sampling/RunDownsampling.java
+++ b/core/src/main/java/org/eqasim/core/tools/sampling/RunDownsampling.java
@@ -24,7 +24,7 @@ public class RunDownsampling {
     static public void main(String[] args) throws ConfigurationException {
         CommandLine cmd = new CommandLine.Builder(args) //
                 .requireOptions("config-path", "sampling-rate", "suffix") //
-                .allowOptions("update", EqasimConfigurator.CONFIGURATOR) //
+                .allowOptions("seed", "update", EqasimConfigurator.CONFIGURATOR) //
                 .build();
 
         Preconditions.checkArgument(cmd.getOptionStrict("suffix").length() > 0, "Suffix must be given.");


### PR DESCRIPTION
The code of RunDownsampling script  already is handles a seed, but it's actually not allowed by the CommandLine object. This PR fixes it. 