### PR TITLE
fix(core): Using EqasimConfigurator to avoid generating generic route in RunIsolateAgent

### DIFF
--- a/core/src/main/java/org/eqasim/core/tools/RunIsolateAgent.java
+++ b/core/src/main/java/org/eqasim/core/tools/RunIsolateAgent.java
@@ -4,6 +4,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 
+import org.eqasim.core.simulation.EqasimConfigurator;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.Scenario;
 import org.matsim.api.core.v01.population.Person;
@@ -22,7 +23,9 @@ public class RunIsolateAgent {
 				.build();
 
 		Config config = ConfigUtils.createConfig();
+		EqasimConfigurator configurator = EqasimConfigurator.getInstance(cmd);
 		Scenario scenario = ScenarioUtils.createScenario(config);
+		configurator.configureScenario(scenario);
 
 		// Load population
 		String inputPath = cmd.getOptionStrict("input-path");


### PR DESCRIPTION
The `RunIsolateAgent` converts special routes into `GenericRoute` instances in the written plans file. This can cause a crash if one runs a simulation later on with the resulting plans file (for example if there's a DRT leg). 

This PR just uses the `EqasimConfigurator` to properly set the route factories before reading the plans. This means that this script now needs to be executed in a setting where the configurator is defined in one of the usual ways (command line, eqasim.properties file, or environment variable).