### PR TITLE
fix: release-please on main

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,7 +1,7 @@
 on:
   push:
     branches:
-      - develop
+      - main
   
   workflow_dispatch:
 


### PR DESCRIPTION
The `release-please` hook didn't work any more since the renaming to `main`. This should fix it.